### PR TITLE
fix: restrict skill loading to workspace paths only

### DIFF
--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -217,6 +217,7 @@ class AgentLoop:
                 skill_paths=[str(p) for p in self._skill_paths],
                 llm=self._chatbot,
                 auto_discover=True,
+                include_default_paths=False,
             )
 
             # Create SpoonReactSkill agent


### PR DESCRIPTION
## Summary
This PR prevents unrelated/global skills from being loaded into spoon-bot by default.

## Change
- In `spoon_bot/agent/loop.py`, pass `include_default_paths=False` when creating `SkillManager`.

## Why
Previously, `SkillLoader` would include default skill directories (`~/.spoon/skills` and cwd `skills`) in addition to workspace skill paths. This caused:
- unrelated skills to be discovered
- noisy startup logs
- potential off-topic auto-trigger behavior

Now spoon-bot only loads skills from explicit workspace paths.

## Validation
- Agent startup confirmed skills are loaded from workspace path set by `SPOON_BOT_WORKSPACE_PATH`
- Change is additive-safe and backward compatible for callers not passing this flag