### PR TITLE
fix(gateway): resolve Telegram/channel message processing crash

### DIFF
--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -917,6 +917,7 @@ class AgentLoop:
         self,
         message: str,
         media: list[str] | None = None,
+        session_key: str | None = None,
     ) -> str:
         """
         Process a user message and return the agent's response.
@@ -924,6 +925,8 @@ class AgentLoop:
         Args:
             message: The user's message.
             media: Optional list of media file paths.
+            session_key: Optional session key for multi-user/multi-channel isolation.
+                         When provided, switches to this session before processing.
 
         Returns:
             The agent's response text.
@@ -937,6 +940,12 @@ class AgentLoop:
         # Ensure initialized
         if not self._initialized:
             await self.initialize()
+
+        # Switch session if a different key is requested
+        if session_key and session_key != self.session_key:
+            self._session = self.sessions.get_or_create(session_key)
+            self.session_key = session_key
+            logger.debug(f"Switched to session: {session_key}")
 
         logger.info(f"Processing message: {message[:100]}...")
 
@@ -1779,6 +1788,7 @@ class AgentLoop:
         self,
         message: str,
         media: list[str] | None = None,
+        session_key: str | None = None,
     ) -> tuple[str, str | None]:
         """
         Process a user message and return the agent's response with thinking content.
@@ -1786,12 +1796,19 @@ class AgentLoop:
         Args:
             message: The user's message.
             media: Optional list of media file paths.
+            session_key: Optional session key for multi-user/multi-channel isolation.
 
         Returns:
             Tuple of (response_text, thinking_content). thinking_content may be None.
         """
         if not self._initialized:
             await self.initialize()
+
+        # Switch session if a different key is requested
+        if session_key and session_key != self.session_key:
+            self._session = self.sessions.get_or_create(session_key)
+            self.session_key = session_key
+            logger.debug(f"Switched to session: {session_key}")
 
         logger.info(f"Processing message (with thinking): {message[:100]}...")
 


### PR DESCRIPTION
## Summary

- **Root cause**: `ChannelManager._handle_message()` passes `session_key` to `AgentLoop.process()` and `process_with_thinking()` for per-user session isolation, but these methods did not accept the parameter — causing a `TypeError` that silently crashed every message attempt
- Adds `session_key: str | None = None` parameter to both `process()` and `process_with_thinking()` methods
- Implements automatic session switching when a different key is provided, enabling proper multi-user/multi-channel session isolation

## Impact

All channel messaging was broken (Telegram, Discord, Feishu, etc.) since the agent could never successfully process any inbound message. Every message resulted in:
```
TypeError: process() got an unexpected keyword argument 'session_key'
```
This was caught by the generic error handler in the bus, returning "Sorry, an unexpected error occurred" to all users.

## Test plan

- [ ] Start gateway with Telegram channel enabled: `spoon-bot gateway`
- [ ] Send a message from Telegram — verify bot responds
- [ ] Send messages from different Telegram users/chats — verify session isolation
- [ ] Test with think mode enabled to verify `process_with_thinking()` path


Made with [Cursor](https://cursor.com)