### PR TITLE
feat: add sub-agent orchestration system

### DIFF
--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -1131,6 +1131,7 @@ class AgentLoop:
         self,
         message: str,
         media: list[str] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
         session_key: str | None = None,
     ) -> str:
         """
@@ -1230,7 +1231,10 @@ class AgentLoop:
         try:
             for _attempt in range(_max_retries + 1):
                 try:
-                    result = await self._agent.run(message)
+                    run_kwargs: dict[str, Any] = {}
+                    if media:
+                        run_kwargs["media"] = media
+                    result = await self._agent.run(message, **run_kwargs)
 
                     logger.debug(f"Agent result type: {type(result)}")
                     if hasattr(result, 'content'):
@@ -1791,6 +1795,7 @@ class AgentLoop:
         self,
         message: str,
         media: list[str] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
         thinking: bool = False,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
@@ -2022,6 +2027,7 @@ class AgentLoop:
         self,
         message: str,
         media: list[str] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
         session_key: str | None = None,
     ) -> tuple[str, str | None]:
         """

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -8,7 +8,6 @@ ChatBot, SpoonReactMCP, and SkillManager with spoon-bot's native OS tools.
 from __future__ import annotations
 
 import asyncio
-import inspect
 import json
 import logging as stdlib_logging
 from collections import Counter
@@ -89,7 +88,10 @@ from spoon_bot.agent.tools.self_config import (
 from spoon_bot.agent.tools.web import WebSearchTool, WebFetchTool
 from spoon_bot.config import AgentLoopConfig, MemSearchConfig, validate_agent_loop_params, resolve_context_window
 from spoon_bot.services.hotreload import HotReloadService
-from spoon_bot.services.spawn import SpawnTool
+from spoon_bot.subagent.manager import SubagentManager
+from spoon_bot.subagent.tools import SubagentTool
+from spoon_bot.subagent.catalog import format_roles_for_prompt
+from spoon_bot.subagent.models import SubagentState
 from spoon_bot.session.manager import SessionManager
 from spoon_bot.session.store import create_session_store
 from spoon_bot.memory.store import MemoryStore
@@ -107,187 +109,6 @@ from spoon_bot.services.git import GitManager
 
 if TYPE_CHECKING:
     from spoon_bot.session.manager import Session
-
-
-_ATTACHMENT_CONTEXT_HEADER = "Attached workspace files (source of truth for this request):"
-_ATTACHMENT_ONLY_PLACEHOLDER = (
-    "The user attached files without extra text. Inspect the files and answer based on their contents."
-)
-_SANDBOX_WORKSPACE_ROOT = "/workspace"
-
-
-def _workspace_root_path(workspace: Path | str | None) -> Path:
-    """Resolve the workspace root used to validate persisted file references."""
-    return Path(workspace or Path.home() / ".spoon-bot" / "workspace").expanduser().resolve()
-
-
-def _resolve_workspace_file(path_str: str, workspace: Path | str | None) -> Path | None:
-    """Resolve a file path and ensure it stays within the configured workspace."""
-    candidate = str(path_str or "").strip()
-    if not candidate:
-        return None
-
-    workspace_root = _workspace_root_path(workspace)
-    sandbox_root = _SANDBOX_WORKSPACE_ROOT.rstrip("/")
-    try:
-        if candidate.startswith("/"):
-            normalized = Path(candidate).as_posix()
-            workspace_root_str = workspace_root.as_posix().rstrip("/")
-            if normalized == sandbox_root or normalized.startswith(sandbox_root + "/"):
-                relative = normalized[len(sandbox_root):].lstrip("/")
-                resolved = (workspace_root / relative).resolve(strict=True)
-            elif normalized == workspace_root_str or normalized.startswith(workspace_root_str + "/"):
-                relative = normalized[len(workspace_root_str):].lstrip("/")
-                resolved = (workspace_root / relative).resolve(strict=True)
-            else:
-                resolved = Path(candidate).expanduser().resolve(strict=True)
-        else:
-            resolved = (workspace_root / candidate).resolve(strict=True)
-    except (FileNotFoundError, OSError):
-        return None
-
-    if resolved != workspace_root and workspace_root not in resolved.parents:
-        return None
-    if not resolved.is_file():
-        return None
-    return resolved
-
-
-def _normalize_media_list(raw: Any) -> list[str]:
-    """Normalize stored media payloads to a list of non-empty file paths."""
-    if not isinstance(raw, list):
-        return []
-
-    items: list[str] = []
-    for item in raw:
-        if isinstance(item, str):
-            value = item.strip()
-        else:
-            value = str(item).strip() if item is not None else ""
-        if value:
-            items.append(value)
-    return items
-
-
-def _sanitize_media_list(raw: Any, workspace: Path | str | None) -> list[str]:
-    """Keep only workspace-backed media paths from persisted session metadata."""
-    return [
-        path
-        for path in _normalize_media_list(raw)
-        if _resolve_workspace_file(path, workspace) is not None
-    ]
-
-
-def _normalize_attachment_refs(raw: Any) -> list[dict[str, Any]]:
-    """Normalize stored attachment references from session metadata."""
-    if not isinstance(raw, list):
-        return []
-
-    normalized: list[dict[str, Any]] = []
-    for item in raw:
-        if not isinstance(item, dict):
-            continue
-        uri = str(item.get("workspace_path") or item.get("uri") or "").strip()
-        if not uri:
-            continue
-        attachment = dict(item)
-        attachment["uri"] = uri
-        attachment.setdefault("workspace_path", uri)
-        normalized.append(attachment)
-    return normalized
-
-
-def _sanitize_attachment_refs(raw: Any, workspace: Path | str | None) -> list[dict[str, Any]]:
-    """Keep only workspace-backed attachment references from persisted metadata."""
-    sanitized: list[dict[str, Any]] = []
-    for item in _normalize_attachment_refs(raw):
-        uri = str(item.get("workspace_path") or item.get("uri") or "").strip()
-        if _resolve_workspace_file(uri, workspace) is None:
-            continue
-        sanitized.append(item)
-    return sanitized
-
-
-def _attachment_context_entries(attachments: list[dict[str, Any]]) -> list[tuple[dict[str, Any], str]]:
-    """Return normalized attachment entries with resolved display paths."""
-    normalized_items: list[tuple[dict[str, Any], str]] = []
-    for item in attachments:
-        if not isinstance(item, dict):
-            continue
-        uri = str(item.get("workspace_path") or item.get("uri") or "").strip()
-        if uri:
-            normalized_items.append((item, uri))
-    return normalized_items
-
-
-def _build_attachment_context_lines(attachments: list[dict[str, Any]]) -> list[str]:
-    """Build the synthetic attachment context block appended to prompts."""
-    normalized_items = _attachment_context_entries(attachments)
-    if not normalized_items:
-        return []
-
-    lines = [_ATTACHMENT_CONTEXT_HEADER]
-    for item, uri in normalized_items:
-        name = str(item.get("name") or item.get("file_name") or "").strip()
-        mime_type = str(item.get("mime_type") or item.get("file_type") or "").strip()
-        size = item.get("size") if "size" in item else item.get("file_size")
-        suffix = []
-        if name:
-            suffix.append(f"name: {name}")
-        if mime_type:
-            suffix.append(f"mime: {mime_type}")
-        if isinstance(size, int) and size > 0:
-            suffix.append(f"size: {size} bytes")
-        line = f"- {uri}"
-        if suffix:
-            line += f" ({', '.join(suffix)})"
-        lines.append(line)
-    lines.append("Use these attached workspace files as the primary source of truth for this request.")
-    return lines
-
-
-def _ensure_attachment_context(content: str, attachments: list[dict[str, Any]]) -> str:
-    """Append attachment path context unless it is already present in content."""
-    if not attachments:
-        return content
-
-    text = content if isinstance(content, str) else str(content)
-    normalized_items = _attachment_context_entries(attachments)
-    uris = [uri for _, uri in normalized_items]
-    if not uris:
-        return text
-    if _ATTACHMENT_CONTEXT_HEADER in text and all(uri in text for uri in uris):
-        return text
-
-    lines = [text.strip()] if text.strip() else [_ATTACHMENT_ONLY_PLACEHOLDER]
-    lines.extend(["", *_build_attachment_context_lines(attachments)])
-    return "\n".join(lines)
-
-
-def _strip_attachment_context(content: str, attachments: list[dict[str, Any]]) -> str:
-    """Remove the exact synthetic attachment block so sessions keep user-authored text only."""
-    if not attachments:
-        return content
-
-    text = content if isinstance(content, str) else str(content)
-    if _ATTACHMENT_CONTEXT_HEADER not in text:
-        return text
-
-    context_lines = _build_attachment_context_lines(attachments)
-    if not context_lines:
-        return text
-
-    delimiter = f"\n\n{context_lines[0]}\n"
-    if delimiter not in text:
-        return text
-
-    prefix, suffix = text.split(delimiter, 1)
-    expected_suffix = "\n".join(context_lines[1:])
-    if suffix != expected_suffix:
-        return text
-    if prefix == _ATTACHMENT_ONLY_PLACEHOLDER:
-        return ""
-    return prefix
 
 
 class AgentLoop:
@@ -329,6 +150,8 @@ class AgentLoop:
         auto_commit: bool = True,
         enabled_tools: set[str] | None = None,
         tool_profile: str | None = None,
+        session_manager: SessionManager | None = None,
+        subagent_manager: SubagentManager | None = None,
         session_store_backend: str = "file",
         session_store_dsn: str | None = None,
         session_store_db_path: str | None = None,
@@ -358,6 +181,8 @@ class AgentLoop:
             auto_commit: Whether to auto-commit workspace changes after each message.
             enabled_tools: Explicit set of tool names to enable. None = all.
             tool_profile: Named profile ('coding', 'web3', 'research', 'full').
+            session_manager: Existing SessionManager to reuse for persistence.
+            subagent_manager: Existing SubagentManager to reuse for child agents.
             session_store_backend: Session storage backend ('file', 'sqlite', 'postgres').
             session_store_dsn: PostgreSQL DSN for 'postgres' backend.
             session_store_db_path: SQLite DB path for 'sqlite' backend.
@@ -409,22 +234,26 @@ class AgentLoop:
         self.tools = ToolRegistry()
 
         # Session persistence — configurable backend
-        _store_backend = session_store_backend or "file"
-        _store_db_path = session_store_db_path
-        if _store_backend == "sqlite" and not _store_db_path:
-            _store_db_path = str(self.workspace / "sessions.db")
-        try:
-            _session_store = create_session_store(
-                backend=_store_backend,
-                workspace=self.workspace,
-                db_path=_store_db_path,
-                dsn=session_store_dsn,
-            )
-            self.sessions = SessionManager(workspace=self.workspace, store=_session_store)
-            logger.info(f"Session store: {_store_backend}")
-        except Exception as exc:
-            logger.warning(f"Session store '{_store_backend}' init failed ({exc}), falling back to file")
-            self.sessions = SessionManager(self.workspace)
+        if session_manager is not None:
+            self.sessions = session_manager
+            logger.info("Session store: inherited from parent SessionManager")
+        else:
+            _store_backend = session_store_backend or "file"
+            _store_db_path = session_store_db_path
+            if _store_backend == "sqlite" and not _store_db_path:
+                _store_db_path = str(self.workspace / "sessions.db")
+            try:
+                _session_store = create_session_store(
+                    backend=_store_backend,
+                    workspace=self.workspace,
+                    db_path=_store_db_path,
+                    dsn=session_store_dsn,
+                )
+                self.sessions = SessionManager(workspace=self.workspace, store=_session_store)
+                logger.info(f"Session store: {_store_backend}")
+            except Exception as exc:
+                logger.warning(f"Session store '{_store_backend}' init failed ({exc}), falling back to file")
+                self.sessions = SessionManager(self.workspace)
 
         # Memory store — semantic (memsearch) or file-based
         self._memsearch_config: MemSearchConfig | None = None
@@ -454,6 +283,30 @@ class AgentLoop:
             self.memory = MemoryStore(self.workspace)
 
         self._git = GitManager(self.workspace) if auto_commit else None
+
+        # Sub-agent manager — shares this agent's SessionManager so sub-agents
+        # can reuse the same persistence backend with their own unique session keys.
+        if subagent_manager is not None:
+            self._subagent_manager = subagent_manager
+            self._owns_subagent_manager = False
+        else:
+            self._subagent_manager = SubagentManager(
+                session_manager=self.sessions,
+                workspace=self.workspace,
+                max_depth=self._config.subagent.max_depth,
+                max_children_per_agent=self._config.subagent.max_children_per_agent,
+                max_total_subagents=self._config.subagent.max_total_subagents,
+                parent_model=model,
+                parent_provider=provider,
+                parent_api_key=api_key,
+                parent_base_url=base_url,
+                persist_runs=self._config.subagent.persist_runs,
+                persist_file=self._config.subagent.persist_file,
+                archive_after_minutes=self._config.subagent.archive_after_minutes,
+                sweeper_interval_seconds=self._config.subagent.sweeper_interval_seconds,
+                max_persistent_agents=self._config.subagent.max_persistent_agents,
+            )
+            self._owns_subagent_manager = True
 
         # Skill paths: runtime workspace + bundled skills shipped with spoon-bot
         self._skill_paths = [self.workspace / "skills"]
@@ -578,6 +431,51 @@ class AgentLoop:
             except Exception:
                 pass
 
+        # ----------------------------------------------------------------
+        # Multi-Agent Orchestration section
+        # Injected when the SubagentTool (spawn) is available.
+        # Mirrors opencode task.txt's usage notes and openclaw's
+        # sessions-spawn-tool description pattern.
+        # ----------------------------------------------------------------
+        if "spawn" in self.tools.get_active_tools():
+            roles_block = format_roles_for_prompt()
+            system_prompt += (
+                "\n\n## Multi-Agent Orchestration\n\n"
+                "You are an **Orchestrator**. For complex tasks (e.g. 'build a user "
+                "management system', 'implement a REST API with frontend'), decompose "
+                "the work and delegate to specialised sub-agents using the `spawn` tool.\n\n"
+                "**You decide which agents to use and in what order** — there is no fixed "
+                "pipeline. Use your judgement based on the task requirements.\n\n"
+                "### Available specialised agent roles\n"
+                f"{roles_block}\n\n"
+                "### When to use sub-agents\n"
+                "- Complex tasks requiring multiple specialised skills\n"
+                "- Tasks that benefit from sequential specialisation "
+                "(e.g. plan → implement → review)\n"
+                "- Research + implementation tasks that can be parallelised\n\n"
+                "### When NOT to use sub-agents\n"
+                "- Simple, single-step tasks (file reads, quick questions, small edits)\n"
+                "- Tasks you can complete directly in a few tool calls\n\n"
+                "### Orchestration workflow (decide autonomously)\n"
+                "1. For complex tasks, start with `spawn(action='spawn', role='planner', "
+                "task='Analyse requirements for: <user request>')` to get a technical plan\n"
+                "2. Wait for the planner: `spawn(action='wait', timeout=120)`\n"
+                "3. Based on the plan, spawn implementation agents as needed:\n"
+                "   - `spawn(action='spawn', role='backend', task='...<plan context>...')`\n"
+                "   - `spawn(action='spawn', role='frontend', task='...<plan context>...')`\n"
+                "   - Launch independent agents in parallel (multiple tool calls at once)\n"
+                "4. Wait for results: `spawn(action='wait', timeout=180)`\n"
+                "5. Optionally spawn a `reviewer` to check the implementation\n"
+                "6. Summarise all results to the user\n\n"
+                "### Key rules (from opencode task.txt)\n"
+                "- Each sub-agent starts with a **fresh context** — provide all necessary "
+                "context in the `task` parameter\n"
+                "- The sub-agent's output is NOT visible to the user until you summarise it\n"
+                "- Use `task_id` from a result to resume the same sub-agent session later\n"
+                "- Use `spawn(action='list_roles')` to see all available roles at runtime\n"
+            )
+            logger.info("Injected Multi-Agent Orchestration section into system prompt")
+
         # NOTE: inactive-tools prompt is built later, after skill tools are
         # registered so that skill-provided tools are included in the list.
 
@@ -659,7 +557,6 @@ class AgentLoop:
         # and can cause the model to summarize instead of continue).
         self._agent.next_step_prompt = self.DEFAULT_NEXT_STEP_PROMPT
         self._agent._custom_next_step_prompt = True
-        self._agent._spoon_bot_base_think = self._agent.think
 
         # Build dynamic-tools prompt now that all tools (native + skill) are registered
         inactive_tools = self.tools.get_inactive_tools()
@@ -683,6 +580,9 @@ class AgentLoop:
             f"mcp_servers={len(self._mcp_tools)}, "
             f"skills_enabled={self._enable_skills}"
         )
+
+        # Start sub-agent archive sweeper (no-op if persistence is disabled)
+        await self._subagent_manager.start_sweeper()
 
         # Start background hot-reload service if enabled
         if self._auto_reload:
@@ -738,8 +638,9 @@ class AgentLoop:
             ],
         ))
 
-        # Background task tool
-        self.tools.register(SpawnTool())
+        # Sub-agent tool — replaces the old placeholder SpawnTool
+        spawn_tool = SubagentTool(manager=getattr(self, "_subagent_manager", None))
+        self.tools.register(spawn_tool)
 
         # Web tools
         self.tools.register(WebSearchTool())
@@ -975,7 +876,14 @@ class AgentLoop:
         return {"skills": skills_result, "mcp": mcp_result}
 
     async def cleanup(self) -> None:
-        """Shut down all managed resources (MCP tools, skills, etc.)."""
+        """Shut down all managed resources (MCP tools, skills, sub-agents, etc.)."""
+        # Cleanup sub-agents first so they can still access tools during their own cleanup
+        if hasattr(self, "_subagent_manager") and getattr(self, "_owns_subagent_manager", True):
+            try:
+                await self._subagent_manager.cleanup()
+            except Exception as exc:
+                logger.debug(f"Sub-agent manager cleanup: {exc}")
+
         # Cleanup MCP tools
         for mcp_tool in self._mcp_tools:
             for method in ("close", "cleanup", "shutdown"):
@@ -1060,12 +968,7 @@ class AgentLoop:
             return 0
 
         injected_count = 0
-        history_messages = (
-            self._session.get_messages()
-            if hasattr(self._session, "get_messages")
-            else self._session.get_history()
-        )
-        for msg in history_messages:
+        for msg in self._session.get_history():
             role = str(msg.get("role", "")).strip().lower()
             if role not in {"user", "assistant", "tool"}:
                 continue
@@ -1076,22 +979,6 @@ class AgentLoop:
                     content = json.dumps(content, ensure_ascii=False)
                 except Exception:
                     content = str(content)
-
-            raw_media = _normalize_media_list(msg.get("media"))
-            media = _sanitize_media_list(raw_media, self.workspace)
-            if raw_media and len(media) != len(raw_media):
-                logger.warning("Dropped invalid persisted media refs outside workspace during history sync")
-
-            raw_attachments = _normalize_attachment_refs(msg.get("attachments"))
-            attachments = _sanitize_attachment_refs(raw_attachments, self.workspace)
-            if raw_attachments and len(attachments) != len(raw_attachments):
-                logger.warning("Dropped invalid persisted attachment refs outside workspace during history sync")
-            content = self._build_runtime_message_content(
-                role,
-                content,
-                media=media,
-                attachments=attachments,
-            )
 
             try:
                 await self._agent.add_message(role, content)
@@ -1117,24 +1004,134 @@ class AgentLoop:
             f"trimmed_messages={trimmed_count}"
         )
 
-    def _build_runtime_message_content(
+    def set_subagent_context(
         self,
-        role: str,
-        content: str,
-        media: list[str] | None = None,
-        attachments: list[dict[str, Any]] | None = None,
-    ) -> Any:
-        """Build message content in the format expected by spoon-core runtime memory."""
-        text_content = _ensure_attachment_context(content, attachments or [])
-        if role == "user" and media:
-            return self.context._build_user_content(text_content, media)
-        return text_content
+        *,
+        session_key: str | None = None,
+        channel: str | None = None,
+    ) -> None:
+        """Bind the spawn tool to the current requester session/channel."""
+        spawn_tool = self.tools.get("spawn")
+        if spawn_tool and isinstance(spawn_tool, SubagentTool):
+            spawn_tool.set_spawner_context(
+                session_key=session_key or self.session_key,
+                channel=channel,
+            )
+
+    def _persist_turn(self, user_message: str, assistant_message: str) -> None:
+        """Save a completed user/assistant turn to session storage."""
+        try:
+            self._session.add_message("user", user_message)
+            self._session.add_message("assistant", assistant_message)
+            self.sessions.save(self._session)
+        except Exception as e:
+            logger.warning(f"Failed to save session: {e}")
+
+    def _should_skip_specialist_auto_route(self, message: str) -> bool:
+        """Return True when the current message should not be auto-routed."""
+        stripped = message.lstrip()
+        return (
+            self.session_key.startswith("subagent-")
+            or stripped.startswith("[Sub-agent Completed]")
+        )
+
+    def _maybe_create_persistent_subagent_from_request(
+        self,
+        message: str,
+    ) -> str | None:
+        """Create a persistent subagent from a natural-language user request."""
+        if self._should_skip_specialist_auto_route(message):
+            return None
+        parsed = self._subagent_manager.parse_persistent_subagent_request(message)
+        if parsed is None:
+            return None
+
+        profile = self._subagent_manager.create_persistent_subagent(
+            description=parsed["specialization"],
+        )
+        keywords = ", ".join(profile.match_keywords[:8]) or "(none)"
+        response = (
+            f"Persistent subagent `{profile.name}` created.\n"
+            f"Specialization: {profile.specialization}\n"
+            f"Auto-route: {'ON' if profile.auto_route else 'OFF'}\n"
+            f"Tool profile: {profile.tool_profile}\n"
+            f"Keywords: {keywords}\n\n"
+            "Future matching requests will be routed to this subagent automatically."
+        )
+        return response
+
+    async def _maybe_route_to_persistent_specialist(
+        self,
+        message: str,
+    ) -> tuple[str, str | None] | None:
+        """Attempt to route a matching top-level request to a persistent subagent."""
+        if self._should_skip_specialist_auto_route(message):
+            return None
+
+        matched = self._subagent_manager.find_best_auto_route_specialist(message)
+        if matched is None:
+            return None
+
+        agent_name = matched["agent_name"]
+        reason_text = ", ".join(matched["reasons"]) or "high-confidence subagent match"
+        logger.info(
+            f"Auto-routing request to persistent subagent {agent_name!r} "
+            f"(score={matched['score']}; {reason_text})"
+        )
+
+        current_channel = getattr(self._subagent_manager, "_current_spawner_channel", None)
+        current_metadata = getattr(self._subagent_manager, "_current_spawner_metadata", {})
+        current_reply_to = getattr(self._subagent_manager, "_current_spawner_reply_to", None)
+        record = await self._subagent_manager.dispatch_persistent_subagent(
+            agent_name=agent_name,
+            task=message,
+            spawner_session_key=self.session_key,
+            spawner_channel=current_channel,
+            spawner_metadata=current_metadata,
+            spawner_reply_to=current_reply_to,
+        )
+        wait_timeout = float(record.config.timeout_seconds or 300)
+        results = await self._subagent_manager.collect_results(
+            timeout=wait_timeout,
+            spawner_session_key=self.session_key,
+            agent_id=record.agent_id,
+        )
+        if not results:
+            response = (
+                f"Auto-routed to subagent `{agent_name}`, but it did not finish "
+                f"within {int(wait_timeout)}s."
+            )
+            note = (
+                f"Auto-routed to persistent subagent {agent_name} "
+                f"(score={matched['score']}; {reason_text})."
+            )
+            return response, note
+
+        result = results[-1]
+        if result.state == SubagentState.COMPLETED:
+            result_text = self._filter_execution_steps(result.result or "(no output)")
+            response = f"Subagent `{agent_name}` handled this request.\n\n{result_text}"
+        elif result.state == SubagentState.FAILED:
+            response = (
+                f"Subagent `{agent_name}` failed while handling this request.\n\n"
+                f"{result.error or '(no error message)'}"
+            )
+        elif result.state == SubagentState.CANCELLED:
+            response = f"Subagent `{agent_name}` was cancelled before finishing."
+        else:
+            response = result.result or result.error or f"Subagent `{agent_name}` returned no output."
+
+        note = (
+            f"Auto-routed to persistent subagent {agent_name} "
+            f"(score={matched['score']}; {reason_text})."
+        )
+        return response, note
 
     async def process(
         self,
         message: str,
         media: list[str] | None = None,
-        attachments: list[dict[str, Any]] | None = None,
+        session_key: str | None = None,
     ) -> str:
         """
         Process a user message and return the agent's response.
@@ -1142,10 +1139,18 @@ class AgentLoop:
         Args:
             message: The user's message.
             media: Optional list of media file paths.
+            session_key: Optional session key for multi-user/multi-channel isolation.
+                         When provided, switches to this session before processing.
 
         Returns:
             The agent's response text.
         """
+        # Switch session if requested
+        if session_key and session_key != self.session_key:
+            self.session_key = session_key
+            self._session = self.sessions.get_or_create(session_key)
+            logger.info(f"Switched to session: {session_key}")
+
         # Honour stop request from previous /stop command
         if self._stop_requested:
             self._stop_requested = False
@@ -1156,7 +1161,32 @@ class AgentLoop:
         if not self._initialized:
             await self.initialize()
 
+        # Switch session if a different key is requested
+        if session_key and session_key != self.session_key:
+            self._session = self.sessions.get_or_create(session_key)
+            self.session_key = session_key
+            logger.debug(f"Switched to session: {session_key}")
+
+        self.set_subagent_context(session_key=self.session_key)
+
         logger.info(f"Processing message: {message[:100]}...")
+
+        created = self._maybe_create_persistent_subagent_from_request(message)
+        if created is not None:
+            self._persist_turn(message, created)
+            return created
+
+        routed = await self._maybe_route_to_persistent_specialist(message)
+        if routed is not None:
+            routed_content, _route_note = routed
+            self._persist_turn(message, routed_content)
+            if self._auto_commit and self._git:
+                try:
+                    if self._git.has_changes():
+                        self._git.commit(message)
+                except Exception as e:
+                    logger.warning(f"Failed to auto-commit: {e}")
+            return routed_content
 
         # Refresh memory context
         try:
@@ -1185,14 +1215,6 @@ class AgentLoop:
 
         # Pre-inject matched skill content into the message
         message = self._pre_inject_matched_skill(message)
-        runtime_message = self._build_runtime_message_content(
-            "user",
-            message,
-            media=media,
-            attachments=attachments,
-        )
-        if isinstance(runtime_message, str):
-            message = runtime_message
 
         # Build a minimal per-step prompt with the user's request for context.
         # The anti-loop tracker will dynamically append progress info.
@@ -1201,22 +1223,14 @@ class AgentLoop:
 
         # Install anti-loop tracker to prevent repeated tool calls
         self._install_anti_loop_tracker(_base_prompt)
-        await self._agent.add_message("user", runtime_message)
 
         # Run agent — with recovery for LLM API errors (context overflow, etc.)
         # Retry up to 2 times on ANY error, with increasingly aggressive compression.
         _max_retries = 2
-        retry_requires_runtime_message_check = False
         try:
             for _attempt in range(_max_retries + 1):
                 try:
-                    if (
-                        retry_requires_runtime_message_check
-                        and not self._recent_runtime_has_user_message_content(runtime_message)
-                    ):
-                        await self._agent.add_message("user", runtime_message)
-                    retry_requires_runtime_message_check = False
-                    result = await self._agent.run()
+                    result = await self._agent.run(message)
 
                     logger.debug(f"Agent result type: {type(result)}")
                     if hasattr(result, 'content'):
@@ -1254,14 +1268,12 @@ class AgentLoop:
                     if _attempt < _max_retries:
                         logger.warning("Compressing context and retrying...")
                         # First retry: normal compression. Second: force-compress.
-                        compression_actions = 0
                         if _attempt == 0:
-                            compression_actions = self._compress_runtime_context()
-                            if compression_actions == 0:
-                                compression_actions += self._force_compress_runtime_context()
+                            compressed = self._compress_runtime_context()
+                            if compressed == 0:
+                                self._force_compress_runtime_context()
                         else:
-                            compression_actions = self._force_compress_runtime_context()
-                        retry_requires_runtime_message_check = True
+                            self._force_compress_runtime_context()
                         # Reset agent state so it can re-enter run()
                         if hasattr(self._agent, 'state'):
                             self._agent.state = AgentState.IDLE
@@ -1272,7 +1284,6 @@ class AgentLoop:
                     raise
         finally:
             # Always ensure agent is back in IDLE state after processing
-            self._restore_agent_think()
             if hasattr(self._agent, 'state') and self._agent.state != AgentState.IDLE:
                 logger.warning(
                     f"Post-run cleanup: resetting agent from {self._agent.state} to IDLE"
@@ -1281,21 +1292,7 @@ class AgentLoop:
                 self._agent.current_step = 0
 
         # Save to session
-        try:
-            save_kwargs: dict[str, Any] = {}
-            if media:
-                save_kwargs["media"] = list(media)
-            if attachments:
-                save_kwargs["attachments"] = [dict(item) for item in attachments if isinstance(item, dict)]
-            self._session.add_message(
-                "user",
-                _strip_attachment_context(message, attachments or []),
-                **save_kwargs,
-            )
-            self._session.add_message("assistant", final_content)
-            self.sessions.save(self._session)
-        except Exception as e:
-            logger.warning(f"Failed to save session: {e}")
+        self._persist_turn(message, final_content)
 
         # Auto-commit workspace changes
         if self._auto_commit and self._git:
@@ -1346,161 +1343,14 @@ class AgentLoop:
             logger.warning(f"Failed to extract content from agent memory: {exc}")
         return ""
 
-    @classmethod
-    def _serialize_message_content(cls, content: Any) -> Any:
-        """Convert message content into JSON-serializable Python objects."""
-        if content is None or isinstance(content, (str, int, float, bool)):
-            return content
-        if isinstance(content, list):
-            return [cls._serialize_message_content(item) for item in content]
-        if isinstance(content, dict):
-            return {
-                str(key): cls._serialize_message_content(value)
-                for key, value in content.items()
-            }
-        if hasattr(content, "model_dump"):
-            try:
-                dumped = content.model_dump(exclude_none=True)
-            except TypeError:
-                dumped = content.model_dump()
-            return cls._serialize_message_content(dumped)
-
-        extracted: dict[str, Any] = {}
-        for attr in (
-            "type",
-            "text",
-            "image_url",
-            "source",
-            "file_path",
-            "media_type",
-            "filename",
-            "name",
-            "url",
-            "detail",
-            "data",
-        ):
-            if hasattr(content, attr):
-                extracted[attr] = cls._serialize_message_content(getattr(content, attr))
-        if extracted:
-            return extracted
-        return str(content)
-
-    @classmethod
-    def _message_content_fingerprint(cls, content: Any) -> str:
-        """Create a stable string fingerprint for runtime content comparisons."""
-        serialized = cls._serialize_message_content(content)
-        if isinstance(serialized, str):
-            return f"str:{serialized}"
-        return json.dumps(serialized, sort_keys=True, ensure_ascii=True, default=str)
-
-    @classmethod
-    def _multimodal_content_summary(cls, content: list[Any], max_text_chars: int) -> str:
-        """Summarize multimodal content while dropping heavy binary payloads."""
-        serialized = cls._serialize_message_content(content)
-        if not isinstance(serialized, list):
-            text = str(serialized or "")
-            return text[:max_text_chars] if max_text_chars and len(text) > max_text_chars else text
-
-        text_parts: list[str] = []
-        image_count = 0
-        document_count = 0
-        file_refs: list[str] = []
-
-        for block in serialized:
-            if isinstance(block, dict):
-                block_type = str(block.get("type") or "")
-                if block_type == "text":
-                    text = str(block.get("text") or "")
-                    if text:
-                        text_parts.append(text)
-                    continue
-                if block_type in {"image", "image_url"}:
-                    image_count += 1
-                    continue
-                if block_type == "document":
-                    document_count += 1
-                    continue
-                if block_type == "file":
-                    file_path = str(block.get("file_path") or "")
-                    if file_path:
-                        file_refs.append(Path(file_path).name or file_path)
-                    continue
-            elif block:
-                text_parts.append(str(block))
-
-        text = "\n".join(part for part in text_parts if part).strip()
-        if max_text_chars and len(text) > max_text_chars:
-            text = text[:max_text_chars] + f"\n...[truncated {len(text) - max_text_chars} chars]"
-
-        summary_parts = [text] if text else []
-        if image_count:
-            summary_parts.append(f"[{image_count} image attachment(s) omitted during context compression]")
-        if document_count:
-            summary_parts.append(f"[{document_count} document attachment(s) omitted during context compression]")
-        if file_refs:
-            shown = ", ".join(file_refs[:3])
-            more = "" if len(file_refs) <= 3 else f" (+{len(file_refs) - 3} more)"
-            summary_parts.append(f"[File attachment reference(s): {shown}{more}]")
-        if not summary_parts:
-            summary_parts.append("[Multimodal content omitted during context compression]")
-        return "\n".join(summary_parts)
-
-    @classmethod
-    def _compress_message_content(cls, content: Any, max_chars: int) -> Any:
-        """Truncate text content and summarize multimodal content for recovery."""
-        if isinstance(content, str):
-            if len(content) <= max_chars:
-                return content
-            return content[:max_chars] + f"\n...[truncated {len(content) - max_chars} chars]"
-        if isinstance(content, list):
-            return cls._multimodal_content_summary(content, max_chars)
-        return content
-
-    @classmethod
-    def _message_content_char_count(cls, content: Any) -> int:
-        """Return an approximate character count for text and multimodal payloads."""
-        if content is None:
-            return 0
-        if isinstance(content, str):
-            return len(content)
-        if not isinstance(content, list):
-            return len(str(content))
-
-        total = 0
-        serialized = cls._serialize_message_content(content)
-        for block in serialized if isinstance(serialized, list) else [serialized]:
-            if isinstance(block, dict):
-                block_type = str(block.get("type") or "")
-                if block_type == "text":
-                    total += len(str(block.get("text") or ""))
-                    continue
-                if block_type == "image_url":
-                    total += len(str((block.get("image_url") or {}).get("url") or ""))
-                    continue
-                if block_type == "image":
-                    source = block.get("source") or {}
-                    total += len(str(source.get("media_type") or ""))
-                    total += len(str(source.get("data") or ""))
-                    continue
-                if block_type == "document":
-                    source = block.get("source") or {}
-                    total += len(str(source.get("media_type") or ""))
-                    total += len(str(source.get("data") or ""))
-                    total += len(str(block.get("filename") or ""))
-                    continue
-                if block_type == "file":
-                    total += len(str(block.get("file_path") or ""))
-                    total += len(str(block.get("media_type") or ""))
-                    continue
-                total += len(json.dumps(block, sort_keys=True, ensure_ascii=True, default=str))
-                continue
-            total += len(str(block))
-        return total
-
-    @classmethod
-    def _msg_char_count(cls, msg) -> int:
+    @staticmethod
+    def _msg_char_count(msg) -> int:
         """Return total character count of a message's content."""
-        return cls._message_content_char_count(getattr(msg, "content", None))
+        if isinstance(msg.content, str):
+            return len(msg.content)
+        if isinstance(msg.content, list):
+            return sum(len(getattr(b, 'text', '')) for b in msg.content)
+        return 0
 
     def _estimate_runtime_tokens(self) -> int:
         """Rough token estimate from the agent's runtime messages (~4 chars/token)."""
@@ -1517,52 +1367,6 @@ class AgentLoop:
             return False
         text = msg.content if isinstance(msg.content, str) else ''
         return text.startswith('[ORIGINAL USER REQUEST]') or text.startswith('Focus on the user')
-
-    def _recent_runtime_has_user_message_content(
-        self,
-        content: Any,
-        recent_messages: int = 10,
-    ) -> bool:
-        """Check whether recent runtime memory still contains the active user request."""
-        if not self._agent or not hasattr(self._agent, "memory"):
-            return False
-        messages = getattr(self._agent.memory, "messages", None)
-        if not isinstance(messages, list) or not messages:
-            return False
-
-        target = self._message_content_fingerprint(content)
-        for msg in reversed(messages[-recent_messages:]):
-            role = getattr(msg, "role", None)
-            role = role.value if hasattr(role, "value") else role
-            if role != "user":
-                continue
-            if self._is_next_step_user_msg(msg):
-                continue
-            if self._message_content_fingerprint(getattr(msg, "content", None)) == target:
-                return True
-        return False
-
-    @staticmethod
-    def _callable_accepts_kwarg(func: Any, kwarg: str) -> bool:
-        """Return True when *func* can accept *kwarg* as a keyword argument."""
-        try:
-            signature = inspect.signature(func)
-        except (TypeError, ValueError):
-            return False
-
-        if any(
-            param.kind == inspect.Parameter.VAR_KEYWORD
-            for param in signature.parameters.values()
-        ):
-            return True
-        param = signature.parameters.get(kwarg)
-        return bool(
-            param
-            and param.kind in (
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                inspect.Parameter.KEYWORD_ONLY,
-            )
-        )
 
     @staticmethod
     def _repair_tool_pairing(messages: list) -> int:
@@ -1672,10 +1476,9 @@ class AgentLoop:
         max_content = 300
         for i in range(1, max(1, len(messages) - keep_tail)):
             msg = messages[i]
-            original_content = getattr(msg, "content", None)
-            compressed_content = self._compress_message_content(original_content, max_content)
-            if compressed_content != original_content:
-                msg.content = compressed_content
+            if isinstance(msg.content, str) and len(msg.content) > max_content:
+                orig = len(msg.content)
+                msg.content = msg.content[:max_content] + f"\n...[truncated {orig - max_content} chars]"
                 compressed += 1
 
         # Phase 3: If still over budget, drop oldest rounds (keep first + last 8).
@@ -1718,10 +1521,8 @@ class AgentLoop:
 
         # Truncate ALL messages to 150 chars
         for msg in messages:
-            original_content = getattr(msg, "content", None)
-            compressed_content = self._compress_message_content(original_content, 150)
-            if compressed_content != original_content:
-                msg.content = compressed_content
+            if isinstance(msg.content, str) and len(msg.content) > 150:
+                msg.content = msg.content[:150] + "\n...[force-truncated]"
                 compressed += 1
 
         # Drop all but first + last 6 messages
@@ -1751,12 +1552,7 @@ class AgentLoop:
             return
 
         agent_loop = self
-        original_think = getattr(agent, "_spoon_bot_base_think", None)
-        if original_think is None:
-            original_think = agent.think
-            setattr(agent, "_spoon_bot_base_think", original_think)
-        else:
-            agent.think = original_think
+        original_think = agent.think
         call_tracker: Counter = Counter()
         detail_tracker: Counter = Counter()
         read_files: set = set()
@@ -1935,15 +1731,6 @@ class AgentLoop:
 
         agent.think = _tracked_think
 
-    def _restore_agent_think(self) -> None:
-        """Restore the agent's base think() implementation after a request."""
-        agent = self._agent
-        if agent is None:
-            return
-        original_think = getattr(agent, "_spoon_bot_base_think", None)
-        if original_think is not None:
-            agent.think = original_think
-
     def _filter_execution_steps(self, content: str) -> str:
         """
         Filter out technical execution steps from agent output.
@@ -2004,7 +1791,6 @@ class AgentLoop:
         self,
         message: str,
         media: list[str] | None = None,
-        attachments: list[dict[str, Any]] | None = None,
         thinking: bool = False,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
@@ -2035,20 +1821,9 @@ class AgentLoop:
             logger.warning(f"Failed to load memory context: {e}")
 
         full_content = ""
-        stream_completed = False
-        stream_cancelled = False
-        bg_task: asyncio.Task[None] | None = None
 
         # Trim and inject persisted history into runtime memory
         await self._prepare_request_context()
-        runtime_message = self._build_runtime_message_content(
-            "user",
-            message,
-            media=media,
-            attachments=attachments,
-        )
-        if isinstance(runtime_message, str):
-            message = runtime_message
 
         _base_prompt = self._build_step_prompt(message)
         self._agent.next_step_prompt = _base_prompt
@@ -2070,15 +1845,13 @@ class AgentLoop:
                 except (asyncio.TimeoutError, Exception):
                     break
 
-            await self._agent.add_message("user", runtime_message)
-
             # 2. Start run() in background
             run_result_text = ""
 
             async def _run_and_signal() -> None:
                 nonlocal run_result_text
                 try:
-                    result = await self._agent.run()
+                    result = await self._agent.run(request=message)
                     if hasattr(result, "content"):
                         run_result_text = result.content or ""
                     elif isinstance(result, str):
@@ -2128,9 +1901,8 @@ class AgentLoop:
                 except asyncio.TimeoutError:
                     continue
                 except asyncio.CancelledError:
-                    stream_cancelled = True
-                    logger.warning("Streaming cancelled while waiting for output")
-                    raise
+                    logger.warning("Streaming cancelled")
+                    break
                 except Exception as e:
                     logger.warning(f"Queue get error: {type(e).__name__}: {e}")
                     continue
@@ -2230,40 +2002,17 @@ class AgentLoop:
                 }
 
             # Emit done
-            stream_completed = True
             yield {"type": "done", "delta": "", "metadata": {"content": full_content}}
 
-        except asyncio.CancelledError:
-            stream_cancelled = True
-            logger.warning("Streaming cancelled")
-            raise
         except Exception as e:
             logger.error(f"Streaming error: {e}")
-            stream_completed = True
             yield {"type": "error", "delta": str(e), "metadata": {"error": str(e)}}
             yield {"type": "done", "delta": "", "metadata": {"error": str(e)}}
-        finally:
-            self._restore_agent_think()
-            if bg_task is not None and not bg_task.done():
-                bg_task.cancel()
-                try:
-                    await asyncio.wait_for(bg_task, timeout=5.0)
-                except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
-                    pass
 
         # Save to session only if we got actual content
-        if full_content and stream_completed and not stream_cancelled:
+        if full_content:
             try:
-                save_kwargs: dict[str, Any] = {}
-                if media:
-                    save_kwargs["media"] = list(media)
-                if attachments:
-                    save_kwargs["attachments"] = [dict(item) for item in attachments if isinstance(item, dict)]
-                self._session.add_message(
-                    "user",
-                    _strip_attachment_context(message, attachments or []),
-                    **save_kwargs,
-                )
+                self._session.add_message("user", message)
                 self._session.add_message("assistant", full_content)
                 self.sessions.save(self._session)
             except Exception as e:
@@ -2273,7 +2022,7 @@ class AgentLoop:
         self,
         message: str,
         media: list[str] | None = None,
-        attachments: list[dict[str, Any]] | None = None,
+        session_key: str | None = None,
     ) -> tuple[str, str | None]:
         """
         Process a user message and return the agent's response with thinking content.
@@ -2281,14 +2030,46 @@ class AgentLoop:
         Args:
             message: The user's message.
             media: Optional list of media file paths.
+            session_key: Optional session key for multi-user/multi-channel isolation.
 
         Returns:
             Tuple of (response_text, thinking_content). thinking_content may be None.
         """
+        # Switch session if requested
+        if session_key and session_key != self.session_key:
+            self.session_key = session_key
+            self._session = self.sessions.get_or_create(session_key)
+            logger.info(f"Switched to session: {session_key}")
+
         if not self._initialized:
             await self.initialize()
 
+        # Switch session if a different key is requested
+        if session_key and session_key != self.session_key:
+            self._session = self.sessions.get_or_create(session_key)
+            self.session_key = session_key
+            logger.debug(f"Switched to session: {session_key}")
+
+        self.set_subagent_context(session_key=self.session_key)
+
         logger.info(f"Processing message (with thinking): {message[:100]}...")
+
+        created = self._maybe_create_persistent_subagent_from_request(message)
+        if created is not None:
+            self._persist_turn(message, created)
+            return created, "Created persistent subagent from natural-language request."
+
+        routed = await self._maybe_route_to_persistent_specialist(message)
+        if routed is not None:
+            routed_content, route_note = routed
+            self._persist_turn(message, routed_content)
+            if self._auto_commit and self._git:
+                try:
+                    if self._git.has_changes():
+                        self._git.commit(message)
+                except Exception as e:
+                    logger.warning(f"Failed to auto-commit: {e}")
+            return routed_content, route_note
 
         # Refresh memory context
         try:
@@ -2300,26 +2081,17 @@ class AgentLoop:
 
         # Trim and inject persisted history into runtime memory
         await self._prepare_request_context()
-        runtime_message = self._build_runtime_message_content(
-            "user",
-            message,
-            media=media,
-            attachments=attachments,
-        )
-        if isinstance(runtime_message, str):
-            message = runtime_message
 
         _base_prompt = self._build_step_prompt(message)
         self._agent.next_step_prompt = _base_prompt
         self._install_anti_loop_tracker(_base_prompt)
-        await self._agent.add_message("user", runtime_message)
 
         # Run agent with thinking enabled
         try:
-            run_kwargs: dict[str, Any] = {}
-            if self._callable_accepts_kwarg(self._agent.run, "thinking"):
-                run_kwargs["thinking"] = True
-            result = await self._agent.run(**run_kwargs)
+            run_kwargs: dict[str, Any] = {"thinking": True}
+            if media:
+                run_kwargs["media"] = media
+            result = await self._agent.run(message, **run_kwargs)
 
             # Extract content and thinking
             if hasattr(result, "content"):
@@ -2338,25 +2110,9 @@ class AgentLoop:
         except Exception as e:
             logger.error(f"Agent processing error: {e}")
             raise
-        finally:
-            self._restore_agent_think()
 
         # Save to session
-        try:
-            save_kwargs: dict[str, Any] = {}
-            if media:
-                save_kwargs["media"] = list(media)
-            if attachments:
-                save_kwargs["attachments"] = [dict(item) for item in attachments if isinstance(item, dict)]
-            self._session.add_message(
-                "user",
-                _strip_attachment_context(message, attachments or []),
-                **save_kwargs,
-            )
-            self._session.add_message("assistant", final_content)
-            self.sessions.save(self._session)
-        except Exception as e:
-            logger.warning(f"Failed to save session: {e}")
+        self._persist_turn(message, final_content)
 
         # Auto-commit workspace changes
         if self._auto_commit and self._git:
@@ -2796,6 +2552,11 @@ class AgentLoop:
     def agent(self) -> SpoonReactMCP | SpoonReactSkill | None:
         """Access the underlying spoon-core agent."""
         return self._agent
+
+    @property
+    def subagent_manager(self) -> SubagentManager | None:
+        """Expose sub-agent manager for external access (e.g. slash commands)."""
+        return getattr(self, "_subagent_manager", None)
 
 
 async def create_agent(

--- a/spoon_bot/channels/discord/channel.py
+++ b/spoon_bot/channels/discord/channel.py
@@ -92,6 +92,44 @@ class DiscordChannel(BaseChannel):
         self._reaction_max_age: float = 600.0  # 10 minutes
 
     # ------------------------------------------------------------------
+    # Agent lifecycle integration
+    # ------------------------------------------------------------------
+
+    def set_agent(self, agent: Any) -> None:
+        """Override to register sub-agent lifecycle event listener."""
+        super().set_agent(agent)
+        _sm = getattr(agent, "subagent_manager", None)
+        if _sm is not None:
+            _sm.add_event_listener(self._on_subagent_event)
+            logger.debug(f"[{self.full_name}] Registered sub-agent event listener")
+
+    def _on_subagent_event(self, event: Any) -> None:
+        """Handle sub-agent lifecycle events for Discord notifications."""
+        event_type = getattr(event, "event_type", "")
+        agent_id = getattr(event, "agent_id", "?")
+        label = getattr(event, "label", "?")
+        model = getattr(event, "model_name", None)
+
+        if event_type == "spawning":
+            model_str = f" [{model}]" if model else ""
+            logger.info(
+                f"[{self.full_name}] Sub-agent spawned: {label!r} ({agent_id}){model_str}"
+            )
+        elif event_type == "completed":
+            elapsed = getattr(event, "elapsed_seconds", None)
+            elapsed_str = f" in {elapsed}s" if elapsed else ""
+            logger.info(
+                f"[{self.full_name}] Sub-agent completed: {label!r} ({agent_id}){elapsed_str}"
+            )
+        elif event_type in ("failed", "cancelled"):
+            error = getattr(event, "error", None)
+            error_str = f": {error}" if error else ""
+            logger.warning(
+                f"[{self.full_name}] Sub-agent {event_type}: "
+                f"{label!r} ({agent_id}){error_str}"
+            )
+
+    # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
 

--- a/spoon_bot/channels/manager.py
+++ b/spoon_bot/channels/manager.py
@@ -111,6 +111,12 @@ class ChannelManager:
         self._agent = agent
         self._bus.set_handler(self._handle_message)
 
+        # Give the sub-agent manager a reference to the bus so it can
+        # push wake-continuation messages when sub-agents complete.
+        _sm = getattr(agent, "subagent_manager", None)
+        if _sm is not None:
+            _sm.set_bus(self._bus)
+
         # Align bus concurrency with agent pool size so neither is wasted.
         pool_size = getattr(agent, "_pool_size", None)
         if pool_size is not None and pool_size != self._bus.max_concurrency:
@@ -609,6 +615,21 @@ class ChannelManager:
             media = message.media if message.has_media else None
             session_key = message.session_key or None
 
+            # Update sub-agent spawner context so any sub-agents spawned
+            # during this request know which channel/session to deliver
+            # their results to (push-based wake continuation).
+            _sm = getattr(self._agent, "subagent_manager", None)
+            if _sm is not None:
+                _sm.set_spawner_context(
+                    session_key=session_key,
+                    channel=message.channel,
+                    metadata=message.metadata.copy(),
+                    reply_to=message.message_id,
+                )
+            _set_sub_ctx = getattr(self._agent, "set_subagent_context", None)
+            if callable(_set_sub_ctx):
+                _set_sub_ctx(session_key=session_key, channel=message.channel)
+
             if think_level != "off":
                 response_text, thinking_content = await self._agent.process_with_thinking(
                     message=content,
@@ -645,7 +666,7 @@ class ChannelManager:
             return OutboundMessage(
                 content=response_text,
                 channel=message.channel,
-                reply_to=message.message_id,
+                reply_to=message.metadata.get("reply_to") or message.message_id,
                 metadata=message.metadata.copy(),
             )
 
@@ -655,14 +676,20 @@ class ChannelManager:
             # Use a generic user-facing message to avoid leaking internal
             # details (file paths, API keys, tracebacks).
             try:
+                from spoon_bot.exceptions import SpoonBotError as LegacySpoonBotError
                 from spoon_bot.exceptions import user_friendly_error
-                friendly = user_friendly_error(e)
+                from spoon_bot.utils.errors import format_user_error
+
+                if isinstance(e, LegacySpoonBotError):
+                    friendly = user_friendly_error(e)
+                else:
+                    friendly = format_user_error(e)
             except Exception:
                 friendly = "Sorry, an unexpected error occurred. Please try again."
             return OutboundMessage(
                 content=friendly,
                 channel=message.channel,
-                reply_to=message.message_id,
+                reply_to=message.metadata.get("reply_to") or message.message_id,
                 metadata=message.metadata.copy(),
             )
         finally:

--- a/spoon_bot/channels/telegram/commands.py
+++ b/spoon_bot/channels/telegram/commands.py
@@ -71,6 +71,8 @@ class CommandHandlers:
             "compact": self.handle_compact,
             "clear": self.handle_clear,
             "cancel": self.handle_cancel,
+            "subagents": self.handle_subagents,
+            "agents": self.handle_subagents,
         }
         for name, handler in commands.items():
             app.add_handler(CommandHandler(name, handler))
@@ -94,6 +96,23 @@ class CommandHandlers:
         except Exception:
             # Strip parse_mode and retry as plain text
             await update.message.reply_text(text, **kwargs)
+
+    def _subagent_request_context(
+        self,
+        update: Update,
+    ) -> tuple[str | None, str | None, dict[str, Any], str | None]:
+        """Return the session/channel context for sub-agent wake delivery."""
+        chat = getattr(update, "effective_chat", None)
+        message = getattr(update, "message", None)
+        metadata: dict[str, Any] = {}
+        if chat is not None and getattr(chat, "id", None) is not None:
+            metadata["chat_id"] = chat.id
+            metadata["chat_type"] = getattr(chat, "type", None)
+        if chat is None or chat.id is None:
+            return None, self._channel.full_name, metadata, None
+        session_key = f"telegram_{self._channel.account_id}_{chat.id}"
+        reply_to = str(message.message_id) if message and getattr(message, "message_id", None) else None
+        return session_key, self._channel.full_name, metadata, reply_to
 
     # ------------------------------------------------------------------
     # /start
@@ -432,6 +451,440 @@ class CommandHandlers:
             return
 
         await update.message.reply_text("Operation cancelled.")
+
+    # ------------------------------------------------------------------
+    # /subagents [list|spawn <task>|cancel [id|all]]
+    # /agents — alias for /subagents
+    # ------------------------------------------------------------------
+
+    async def handle_subagents(self, update: Update, context: Any) -> None:
+        if not self._check(update):
+            return
+
+        if not self._agent:
+            await self._reply(update, "Agent not available.")
+            return
+
+        manager = self._agent.subagent_manager
+        if manager is None:
+            await self._reply(update, "Sub-agent manager not available.")
+            return
+
+        args = context.args or []
+        subcommand = args[0].lower() if args else "list"
+
+        if subcommand in ("list", "ls"):
+            await self._subagents_list(update, manager)
+        elif subcommand == "spawn":
+            rest = args[1:]
+            await self._subagents_spawn(update, manager, rest)
+        elif subcommand == "resume":
+            agent_name = args[1] if len(args) > 1 else ""
+            task = " ".join(args[2:]).strip()
+            await self._subagents_resume(update, manager, agent_name, task)
+        elif subcommand in ("cancel", "kill"):
+            target = args[1] if len(args) > 1 else ""
+            await self._subagents_cancel(update, manager, target)
+        elif subcommand == "steer":
+            agent_id = args[1] if len(args) > 1 else ""
+            message = " ".join(args[2:]).strip()
+            await self._subagents_steer(update, manager, agent_id, message)
+        elif subcommand == "info":
+            agent_id = args[1] if len(args) > 1 else ""
+            await self._subagents_info(update, manager, agent_id)
+        elif subcommand == "help":
+            await self._reply(
+                update,
+                "*Sub-agent commands:*\n"
+                "`/subagents` — list all sub-agents\n"
+                "`/subagents spawn [--model M] [--thinking L] [--mode run|session] [--name N] <task>` — spawn\n"
+                "`/subagents resume <name> <new task>` — re-invoke a session agent\n"
+                "`/subagents cancel <id|all>` — cascade-cancel sub-agent(s)\n"
+                "`/subagents kill <id|all>` — alias for cancel\n"
+                "`/subagents steer <id> <new instructions>` — redirect running agent\n"
+                "`/subagents info <id>` — detailed metadata\n"
+                "`/agents` — alias for /subagents",
+            )
+        else:
+            await self._reply(
+                update,
+                "*Usage:*\n"
+                "`/subagents` — list all sub-agents\n"
+                "`/subagents spawn [--mode session --name N] <task>` — spawn\n"
+                "`/subagents resume <name> <new task>` — re-invoke a session agent\n"
+                "`/subagents cancel <id|all>` — cascade-cancel sub-agent(s)\n"
+                "`/subagents steer <id> <message>` — redirect running agent\n"
+                "`/subagents info <id>` — show details\n"
+                "`/subagents help` — full command reference",
+            )
+
+    async def _subagents_list(self, update: Update, manager: Any) -> None:
+        summary = manager.get_status_summary()
+        total = summary.get("total", 0)
+        if total == 0:
+            await self._reply(update, "No sub-agents spawned.")
+            return
+
+        lines = [f"*Sub-agents ({total} total):*"]
+
+        active = summary.get("active", [])
+        if active:
+            lines.append("\n*Active:*")
+            for e in active:
+                agent_id = e["agent_id"]
+                label = e["label"]
+                state = e["state"]
+                elapsed = e.get("elapsed_seconds")
+                model = e.get("model") or ""
+                pending_desc = e.get("pending_descendants", 0)
+                elapsed_str = f" — {elapsed}s" if elapsed is not None else ""
+                model_str = f" \\[{model}]" if model else ""
+                desc_str = (
+                    f" *(+{pending_desc} descendants)*"
+                    if pending_desc > 0 else ""
+                )
+                mode_str = (
+                    f" \\[session:{e['agent_name']}]"
+                    if e.get("spawn_mode") == "session" else ""
+                )
+                lines.append(
+                    f"`[{agent_id}]` {label}: *{state}*{elapsed_str}{model_str}{mode_str}{desc_str}"
+                )
+
+        recent = summary.get("recent", [])
+        if recent:
+            lines.append("\n*Recent:*")
+            for e in recent:
+                agent_id = e["agent_id"]
+                label = e["label"]
+                state = e["state"]
+                elapsed = e.get("elapsed_seconds")
+                model = e.get("model") or ""
+                elapsed_str = f" — {elapsed}s" if elapsed is not None else ""
+                model_str = f" \\[{model}]" if model else ""
+                mode_str = (
+                    f" \\[session:{e['agent_name']}]"
+                    if e.get("spawn_mode") == "session" else ""
+                )
+                lines.append(f"`[{agent_id}]` {label}: *{state}*{elapsed_str}{model_str}{mode_str}")
+
+        await self._reply(update, "\n".join(lines))
+
+    async def _subagents_spawn(
+        self, update: Update, manager: Any, args: list
+    ) -> None:
+        """Parse optional flags, then spawn."""
+        from spoon_bot.subagent.models import (
+            CleanupMode,
+            RoutingMode,
+            SpawnMode,
+            SubagentConfig,
+        )
+
+        model: str | None = None
+        thinking: str | None = None
+        mode: str | None = None
+        agent_name: str | None = None
+        cleanup: str | None = None
+        specialization: str | None = None
+        keywords_raw: str | None = None
+        auto_route = False
+        routing_mode: str | None = None
+        task_parts: list[str] = []
+
+        i = 0
+        while i < len(args):
+            token = args[i]
+            if token == "--model" and i + 1 < len(args):
+                model = args[i + 1]; i += 2
+            elif token == "--thinking" and i + 1 < len(args):
+                thinking = args[i + 1]; i += 2
+            elif token == "--mode" and i + 1 < len(args):
+                mode = args[i + 1]; i += 2
+            elif token == "--name" and i + 1 < len(args):
+                agent_name = args[i + 1]; i += 2
+            elif token == "--cleanup" and i + 1 < len(args):
+                cleanup = args[i + 1]; i += 2
+            elif token == "--auto-route":
+                auto_route = True; i += 1
+            elif token == "--specialization":
+                values: list[str] = []
+                j = i + 1
+                while j < len(args) and not args[j].startswith("--"):
+                    values.append(args[j])
+                    j += 1
+                specialization = " ".join(values).strip() or None
+                i = j
+            elif token == "--keywords":
+                values: list[str] = []
+                j = i + 1
+                while j < len(args) and not args[j].startswith("--"):
+                    values.append(args[j])
+                    j += 1
+                keywords_raw = " ".join(values).strip() or None
+                i = j
+            elif token == "--routing" and i + 1 < len(args):
+                routing_mode = args[i + 1]; i += 2
+            elif token.startswith("--model="):
+                model = token.split("=", 1)[1]; i += 1
+            elif token.startswith("--thinking="):
+                thinking = token.split("=", 1)[1]; i += 1
+            elif token.startswith("--mode="):
+                mode = token.split("=", 1)[1]; i += 1
+            elif token.startswith("--name="):
+                agent_name = token.split("=", 1)[1]; i += 1
+            elif token.startswith("--cleanup="):
+                cleanup = token.split("=", 1)[1]; i += 1
+            elif token.startswith("--specialization="):
+                specialization = token.split("=", 1)[1].strip() or None; i += 1
+            elif token.startswith("--keywords="):
+                keywords_raw = token.split("=", 1)[1].strip() or None; i += 1
+            elif token.startswith("--routing="):
+                routing_mode = token.split("=", 1)[1]; i += 1
+            else:
+                task_parts.append(token); i += 1
+
+        task = " ".join(task_parts).strip()
+        if not task:
+            await self._reply(
+                update,
+                "Usage: `/subagents spawn [--model M] [--thinking L] [--mode run|session] [--name N] "
+                "[--specialization TEXT] [--keywords a,b] [--auto-route] [--routing direct|orchestrated] <task>`",
+            )
+            return
+
+        config = SubagentConfig()
+        if model:
+            config.model = model
+        if thinking:
+            config.thinking_level = thinking
+        if mode:
+            try:
+                config.spawn_mode = SpawnMode(mode)
+            except ValueError:
+                await self._reply(update, f"Invalid --mode {mode!r}. Use 'run' or 'session'.")
+                return
+        if agent_name:
+            config.agent_name = agent_name
+        if cleanup:
+            try:
+                config.cleanup = CleanupMode(cleanup)
+            except ValueError:
+                await self._reply(update, f"Invalid --cleanup {cleanup!r}. Use 'keep' or 'delete'.")
+                return
+        if specialization:
+            config.specialization = specialization
+        if keywords_raw:
+            config.match_keywords = [
+                item.strip() for item in keywords_raw.split(",") if item.strip()
+            ]
+        config.auto_route = auto_route
+        if routing_mode:
+            try:
+                config.routing_mode = RoutingMode(routing_mode)
+            except ValueError:
+                await self._reply(update, f"Invalid --routing {routing_mode!r}. Use 'direct' or 'orchestrated'.")
+                return
+
+        try:
+            spawner_session_key, spawner_channel, spawner_metadata, spawner_reply_to = self._subagent_request_context(update)
+            record = await manager.spawn(
+                task=task,
+                label=task[:60],
+                config=config,
+                spawner_session_key=spawner_session_key,
+                spawner_channel=spawner_channel,
+                spawner_metadata=spawner_metadata,
+                spawner_reply_to=spawner_reply_to,
+            )
+            model_str = f"\nModel: `{record.model_name}`" if record.model_name else ""
+            thinking_str = f"\nThinking: {thinking}" if thinking else ""
+            mode_str = f"\nMode: {record.spawn_mode.value}"
+            name_str = f" `[{record.agent_name}]`" if record.agent_name else ""
+            route_str = "\nAuto-route: ON" if record.config.auto_route else ""
+            specialization_str = (
+                f"\nSpecialization: {record.config.specialization}"
+                if record.config.specialization else ""
+            )
+            keywords_str = (
+                f"\nKeywords: {', '.join(record.config.match_keywords)}"
+                if record.config.match_keywords else ""
+            )
+            await self._reply(
+                update,
+                f"*Sub-agent spawned!*\n"
+                f"ID: `{record.agent_id}`\n"
+                f"Label: {record.label}"
+                f"{model_str}{thinking_str}{mode_str}{name_str}"
+                f"{route_str}{specialization_str}{keywords_str}\n"
+                f"Use /subagents to monitor progress.",
+            )
+        except ValueError as exc:
+            await self._reply(update, f"Failed to spawn sub-agent: {exc}")
+        except Exception as exc:
+            logger.error(f"Unexpected error spawning sub-agent: {exc}")
+            await self._reply(update, f"Error spawning sub-agent: {exc}")
+
+    async def _subagents_resume(
+        self, update: Update, manager: Any, agent_name: str, task: str
+    ) -> None:
+        if not agent_name:
+            await self._reply(
+                update,
+                "Usage: `/subagents resume <agent_name> <new task>`",
+            )
+            return
+        if not task:
+            await self._reply(
+                update,
+                "Usage: `/subagents resume <agent_name> <new task>`\n"
+                "You must provide a new task for the agent.",
+            )
+            return
+
+        try:
+            spawner_session_key, spawner_channel, spawner_metadata, spawner_reply_to = self._subagent_request_context(update)
+            record = await manager.resume_agent(
+                agent_name=agent_name,
+                task=task,
+                spawner_session_key=spawner_session_key,
+                spawner_channel=spawner_channel,
+                spawner_metadata=spawner_metadata,
+                spawner_reply_to=spawner_reply_to,
+            )
+            model_str = f"\nModel: `{record.model_name}`" if record.model_name else ""
+            await self._reply(
+                update,
+                f"*Session agent resumed!*\n"
+                f"Name: `{agent_name}`\n"
+                f"ID: `{record.agent_id}`\n"
+                f"Task: {record.label}{model_str}\n"
+                f"Session history is preserved.\n"
+                f"Use /subagents to monitor progress.",
+            )
+        except ValueError as exc:
+            await self._reply(update, f"Failed to resume agent: {exc}")
+        except Exception as exc:
+            logger.error(f"Unexpected error resuming agent: {exc}")
+            await self._reply(update, f"Error resuming agent: {exc}")
+
+    async def _subagents_cancel(self, update: Update, manager: Any, target: str) -> None:
+        if not target:
+            await self._reply(
+                update,
+                "Usage: `/subagents cancel <agent_id>` or `/subagents cancel all`",
+            )
+            return
+
+        if target.lower() == "all":
+            count = await manager.cancel_all()
+            await self._reply(
+                update,
+                f"Cascade cancellation requested for {count} sub-agent(s).",
+            )
+        else:
+            # Count descendants for informative message
+            record = manager.registry.get(target)
+            descendants = (
+                manager.registry.get_descendants(target) if record else []
+            )
+            found = await manager.cancel(target, cascade=True)
+            if found:
+                desc_count = len(descendants)
+                desc_str = f" and {desc_count} descendants" if desc_count else ""
+                await self._reply(
+                    update,
+                    f"Cancellation requested for sub-agent `{target}`{desc_str}.",
+                )
+            else:
+                await self._reply(
+                    update,
+                    f"Sub-agent `{target}` not found or already finished.",
+                )
+
+    async def _subagents_steer(
+        self, update: Update, manager: Any, agent_id: str, message: str
+    ) -> None:
+        if not agent_id:
+            await self._reply(
+                update,
+                "Usage: `/subagents steer <agent_id> <new instructions>`",
+            )
+            return
+        if not message:
+            await self._reply(
+                update,
+                "Usage: `/subagents steer <agent_id> <new instructions>`\n"
+                "You must provide new instructions for the sub-agent.",
+            )
+            return
+
+        result = await manager.steer(agent_id, message)
+        status = result.get("status")
+        msg = result.get("message", "")
+
+        if status == "accepted":
+            await self._reply(
+                update,
+                f"*Steer accepted!*\n"
+                f"Sub-agent `{agent_id}` will be redirected.\n"
+                f"{msg}",
+            )
+        elif status == "rate_limited":
+            await self._reply(update, f"*Rate limited:* {msg}")
+        elif status == "done":
+            await self._reply(update, f"*Cannot steer:* {msg}")
+        else:
+            await self._reply(update, f"Sub-agent not found: `{agent_id}`.")
+
+    async def _subagents_info(
+        self, update: Update, manager: Any, agent_id: str
+    ) -> None:
+        if not agent_id:
+            await self._reply(update, "Usage: `/subagents info <agent_id>`")
+            return
+
+        info = await manager.get_info(agent_id)
+        if info is None:
+            await self._reply(update, f"Sub-agent `{agent_id}` not found.")
+            return
+
+        lines = [f"*Sub-agent `{agent_id}` info:*"]
+        lines.append(f"Label: {info['label']}")
+        lines.append(f"State: *{info['state']}*")
+        lines.append(f"Task: {info['task'][:120]}")
+        lines.append(f"Depth: {info['depth']}")
+        if info.get("model"):
+            lines.append(f"Model: `{info['model']}`")
+        lines.append(f"Tool profile: {info['tool_profile']}")
+        if info.get("specialization"):
+            lines.append(f"Specialization: {info['specialization']}")
+        if info.get("auto_route"):
+            lines.append("Auto-route: ON")
+        if info.get("routing_mode"):
+            lines.append(f"Routing mode: {info['routing_mode']}")
+        if info.get("match_keywords"):
+            lines.append(f"Keywords: {', '.join(info['match_keywords'])}")
+        if info.get("thinking_level"):
+            lines.append(f"Thinking: {info['thinking_level']}")
+        if info.get("elapsed_seconds") is not None:
+            lines.append(f"Elapsed: {info['elapsed_seconds']}s")
+        if info.get("pending_descendants", 0) > 0:
+            lines.append(f"Pending descendants: {info['pending_descendants']}")
+        if info.get("children"):
+            lines.append(f"Children: {', '.join(f'`{c}`' for c in info['children'])}")
+        if info.get("token_usage"):
+            tu = info["token_usage"]
+            lines.append(
+                f"Tokens: {tu.get('total_tokens', 0)} "
+                f"(in {tu.get('input_tokens', 0)} / out {tu.get('output_tokens', 0)})"
+            )
+        if info.get("result_preview"):
+            lines.append(f"Result preview:\n_{info['result_preview']}_")
+        if info.get("error"):
+            lines.append(f"Error: {info['error']}")
+
+        await self._reply(update, "\n".join(lines))
 
     # ------------------------------------------------------------------
     # /whoami  — user info (no agent needed)

--- a/spoon_bot/channels/telegram/constants.py
+++ b/spoon_bot/channels/telegram/constants.py
@@ -115,6 +115,8 @@ BOT_COMMANDS: list[tuple[str, str]] = [
     ("compact", "Compact conversation context"),
     ("clear", "Clear conversation history"),
     ("cancel", "Cancel current operation"),
+    ("subagents", "Manage sub-agents (list/spawn/cancel)"),
+    ("agents", "Alias for /subagents"),
 ]
 
 # ---------------------------------------------------------------------------

--- a/spoon_bot/config.py
+++ b/spoon_bot/config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 from pydantic import (
     BaseModel,
@@ -353,6 +353,77 @@ class MemSearchConfig(BaseModel):
         return self.embedding_model or os.environ.get("OPENAI_EMBEDDING_MODEL")
 
 
+class SubagentLimitsConfig(BaseModel):
+    """Limits and defaults for the sub-agent system."""
+
+    max_depth: int = Field(
+        default=2,
+        ge=1,
+        le=8,
+        description=(
+            "Maximum spawn depth "
+            "(1 = direct children only, 2 = children + grandchildren, max 8)"
+        ),
+    )
+    max_children_per_agent: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description="Maximum concurrent children per agent (1-20)",
+    )
+    max_total_subagents: int = Field(
+        default=20,
+        ge=1,
+        le=50,
+        description="Maximum total active sub-agents across all depths (1-50)",
+    )
+    default_model: Optional[str] = Field(
+        default=None,
+        description="Default model for sub-agents (inherits from parent if None)",
+    )
+    default_tool_profile: str = Field(
+        default="core",
+        description="Default tool profile for sub-agents (core, coding, research, full)",
+    )
+    # --- Persistence settings ---
+    persist_runs: bool = Field(
+        default=True,
+        description=(
+            "Persist sub-agent records to disk as JSON so they survive process restarts"
+        ),
+    )
+    persist_file: str = Field(
+        default="subagents/runs.json",
+        description=(
+            "Path to the persistence file. Relative paths are resolved against workspace. "
+            "Absolute paths are used as-is."
+        ),
+    )
+    archive_after_minutes: int = Field(
+        default=60,
+        ge=1,
+        le=10080,
+        description=(
+            "Minutes after which terminal sub-agent records (completed/failed/cancelled) "
+            "are removed from the persistence file (1-10080, i.e. up to 7 days)"
+        ),
+    )
+    sweeper_interval_seconds: int = Field(
+        default=60,
+        ge=10,
+        le=3600,
+        description="Interval in seconds for the background archive sweeper (10-3600)",
+    )
+    max_persistent_agents: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description=(
+            "Maximum number of persistent (session-mode) named agents that can be created (1-50)"
+        ),
+    )
+
+
 class AgentLoopConfig(BaseModel):
     """Configuration for AgentLoop with validation."""
 
@@ -448,6 +519,12 @@ class AgentLoopConfig(BaseModel):
         ge=1.0,
         le=300.0,
         description="Polling interval in seconds for auto-reload file watcher (1-300)"
+    )
+
+    # Sub-agent system
+    subagent: SubagentLimitsConfig = Field(
+        default_factory=SubagentLimitsConfig,
+        description="Sub-agent system limits and defaults",
     )
 
     @field_validator("workspace", mode="before")

--- a/spoon_bot/subagent/__init__.py
+++ b/spoon_bot/subagent/__init__.py
@@ -1,0 +1,77 @@
+"""Sub-agent system for spoon-bot.
+
+Provides the ability for agents to spawn child agents that run concurrently
+and report results back to the parent via a push-based announcement.
+
+The system supports LLM-driven orchestration: the main agent autonomously
+decides which specialised sub-agents to spawn and in what order, using the
+AgentCatalog to discover available roles (planner, backend, frontend, etc.).
+
+Public API
+----------
+SubagentManager        — Orchestration engine (one per root AgentLoop).
+SubagentConfig         — Per-agent config overrides (includes ``role`` field).
+SubagentRecord         — Lifecycle record for a single sub-agent.
+SubagentResult         — Result delivered to the parent agent.
+SubagentState          — State enum (PENDING, RUNNING, COMPLETED, FAILED, CANCELLED).
+SpawnMode              — Spawn mode enum (RUN, SESSION).
+CleanupMode            — Cleanup mode enum (KEEP, DELETE).
+SubagentTool           — LLM-facing Tool with role-based spawning and list_roles action.
+TokenUsage             — Token usage statistics for a sub-agent run.
+SubagentRunsFile       — JSON file I/O for persistence.
+SubagentSweeper        — Background task that archives stale records.
+AgentDirectory         — Directory manager for persistent session-mode agents.
+AgentRole              — Dataclass describing a specialised sub-agent role.
+AGENT_CATALOG          — Built-in role registry (planner, backend, frontend, …).
+get_role               — Look up an AgentRole by name.
+list_roles             — Return all registered AgentRole objects.
+format_roles_for_prompt — Format roles for injection into LLM prompts.
+"""
+
+from spoon_bot.subagent.models import (
+    CleanupMode,
+    PersistentSubagentProfile,
+    RoutingMode,
+    SpawnMode,
+    SubagentConfig,
+    SubagentRecord,
+    SubagentResult,
+    SubagentState,
+    TokenUsage,
+)
+from spoon_bot.subagent.manager import SubagentManager
+from spoon_bot.subagent.registry import SubagentRegistry
+from spoon_bot.subagent.tools import SubagentTool
+from spoon_bot.subagent.persistence import AgentDirectory, SubagentRunsFile, SubagentSweeper
+from spoon_bot.subagent.catalog import (
+    AgentRole,
+    AGENT_CATALOG,
+    get_role,
+    list_roles,
+    format_roles_for_prompt,
+)
+
+__all__ = [
+    # Core sub-agent system
+    "AgentDirectory",
+    "CleanupMode",
+    "PersistentSubagentProfile",
+    "RoutingMode",
+    "SpawnMode",
+    "SubagentConfig",
+    "SubagentManager",
+    "SubagentRecord",
+    "SubagentRegistry",
+    "SubagentResult",
+    "SubagentState",
+    "SubagentTool",
+    "TokenUsage",
+    "SubagentRunsFile",
+    "SubagentSweeper",
+    # Agent role catalog (LLM orchestration)
+    "AgentRole",
+    "AGENT_CATALOG",
+    "get_role",
+    "list_roles",
+    "format_roles_for_prompt",
+]

--- a/spoon_bot/subagent/catalog.py
+++ b/spoon_bot/subagent/catalog.py
@@ -1,0 +1,257 @@
+"""Agent role catalog for the sub-agent system.
+
+Defines a registry of specialized SubAgent roles that the LLM Orchestrator
+can choose from when decomposing complex tasks. Inspired by:
+  - opencode's Agent.Info (packages/opencode/src/agent/agent.ts)
+  - openclaw's sessions_spawn tool (src/agents/tools/sessions-spawn-tool.ts)
+
+Each AgentRole carries:
+  - name:           Unique identifier used as the `role` parameter in spawn()
+  - description:    Human/LLM-readable description injected into the tool's
+                    description string (mirrors opencode task.txt's {agents} block)
+  - system_prompt:  Specialized system prompt for this role's AgentLoop instance
+  - tool_profile:   Tool set to activate ('core', 'coding', 'research', 'full')
+  - max_iterations: Maximum tool-call iterations for this role
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class AgentRole:
+    """Describes a specialized SubAgent role.
+
+    Attributes:
+        name:           Unique role identifier (e.g. "planner", "backend").
+        description:    Short description shown to the LLM Orchestrator so it
+                        can decide which role to use for a given subtask.
+        system_prompt:  Full system prompt injected into the child AgentLoop.
+        tool_profile:   Tool profile for the child AgentLoop
+                        ('core', 'coding', 'research', 'full').
+        max_iterations: Hard cap on tool-call iterations for this role.
+        thinking_level: Optional extended-thinking level for LLM models
+                        ('basic', 'extended', or None).
+    """
+
+    name: str
+    description: str
+    system_prompt: str
+    tool_profile: str = "core"
+    max_iterations: int = 15
+    thinking_level: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Built-in role definitions
+# ---------------------------------------------------------------------------
+
+_PLANNER_PROMPT = """\
+You are a senior technical architect and project planner.
+
+Your sole responsibility is to analyse the user's requirement and produce a
+clear, actionable technical plan. You do NOT write code — you plan.
+
+## Output format
+Return a structured plan that includes:
+1. **Requirement summary** — restate the goal in your own words.
+2. **Architecture overview** — key components, data models, API contracts.
+3. **Task breakdown** — ordered list of implementation tasks with:
+   - Task name
+   - Responsible role (backend / frontend / researcher / reviewer)
+   - Acceptance criteria
+4. **Technology choices** — recommended stack with brief justification.
+5. **Open questions** — anything that needs clarification before implementation.
+
+Be concise. Avoid boilerplate. Focus on decisions that unblock implementation.
+"""
+
+_BACKEND_PROMPT = """\
+You are an expert backend engineer.
+
+You receive a technical plan (or a direct task description) and implement the
+server-side code: APIs, business logic, database schemas, authentication, etc.
+
+## Guidelines
+- Follow the architecture described in the plan.
+- Write clean, well-structured code with appropriate error handling.
+- Create or update files directly using the write_file / edit_file tools.
+- Run tests or linting commands via the shell tool to verify your work.
+- At the end, summarise: files created/modified, API endpoints exposed,
+  and any environment variables or dependencies added.
+"""
+
+_FRONTEND_PROMPT = """\
+You are an expert frontend engineer.
+
+You receive a technical plan and/or backend API specification and implement the
+user-facing interface: components, pages, state management, API integration.
+
+## Guidelines
+- Follow the architecture and API contracts from the plan.
+- Write clean, accessible, responsive UI code.
+- Create or update files directly using the write_file / edit_file tools.
+- Run build or lint commands via the shell tool to verify your work.
+- At the end, summarise: files created/modified, pages/components added,
+  and any new dependencies introduced.
+"""
+
+_RESEARCHER_PROMPT = """\
+You are a technical researcher and documentation specialist.
+
+Your job is to investigate a topic, technology, or codebase and return a
+concise, well-structured research report. You do NOT write production code.
+
+## Guidelines
+- Use web_search and web_fetch to gather up-to-date information.
+- Use read_file, grep, and shell to explore the local codebase when relevant.
+- Cite sources (URLs) for external information.
+- Return a structured report: summary, key findings, recommendations,
+  and relevant code snippets or links.
+"""
+
+_REVIEWER_PROMPT = """\
+You are a senior code reviewer and quality engineer.
+
+You receive code (file paths or inline snippets) and produce a thorough review
+covering correctness, security, performance, maintainability, and test coverage.
+
+## Guidelines
+- Use read_file and grep to inspect the code under review.
+- Run tests or static analysis via the shell tool when possible.
+- Return a structured review: overall assessment, critical issues (must fix),
+  suggestions (nice to have), and a brief summary.
+- Be specific: reference file names and line numbers where relevant.
+"""
+
+_DEVOPS_PROMPT = """\
+You are a DevOps and infrastructure engineer.
+
+You handle deployment configuration, CI/CD pipelines, containerisation,
+environment setup, and operational concerns.
+
+## Guidelines
+- Use the shell tool to run infrastructure commands (docker, kubectl, etc.).
+- Create or update configuration files (Dockerfile, docker-compose, CI YAML).
+- Verify changes by running the relevant commands and checking output.
+- Return a summary: what was configured, how to deploy, and any secrets or
+  environment variables that need to be set.
+"""
+
+_TESTER_PROMPT = """\
+You are a QA engineer and test automation specialist.
+
+You write and run tests for a given codebase or feature.
+
+## Guidelines
+- Use read_file and grep to understand the code under test.
+- Write unit tests, integration tests, or end-to-end tests as appropriate.
+- Run the test suite via the shell tool and report results.
+- Return a summary: tests written, coverage achieved, failures found.
+"""
+
+
+# ---------------------------------------------------------------------------
+# The catalog — maps role name → AgentRole
+# ---------------------------------------------------------------------------
+
+AGENT_CATALOG: dict[str, AgentRole] = {
+    "planner": AgentRole(
+        name="planner",
+        description=(
+            "Technical architect: analyses requirements and produces a structured "
+            "implementation plan (architecture, task breakdown, tech choices). "
+            "Use this FIRST for any complex multi-component task."
+        ),
+        system_prompt=_PLANNER_PROMPT,
+        tool_profile="research",
+        max_iterations=12,
+    ),
+    "backend": AgentRole(
+        name="backend",
+        description=(
+            "Backend engineer: implements server-side code — REST/GraphQL APIs, "
+            "business logic, database schemas, authentication. "
+            "Provide the plan output as context."
+        ),
+        system_prompt=_BACKEND_PROMPT,
+        tool_profile="coding",
+        max_iterations=25,
+    ),
+    "frontend": AgentRole(
+        name="frontend",
+        description=(
+            "Frontend engineer: implements user interfaces — components, pages, "
+            "state management, API integration. "
+            "Provide the plan and backend API spec as context."
+        ),
+        system_prompt=_FRONTEND_PROMPT,
+        tool_profile="coding",
+        max_iterations=25,
+    ),
+    "researcher": AgentRole(
+        name="researcher",
+        description=(
+            "Technical researcher: investigates technologies, APIs, or codebases "
+            "and returns a structured research report with sources. "
+            "Use when you need information before deciding how to implement."
+        ),
+        system_prompt=_RESEARCHER_PROMPT,
+        tool_profile="research",
+        max_iterations=15,
+    ),
+    "reviewer": AgentRole(
+        name="reviewer",
+        description=(
+            "Code reviewer: performs a thorough review of code for correctness, "
+            "security, performance, and maintainability. "
+            "Use after implementation to catch issues before delivery."
+        ),
+        system_prompt=_REVIEWER_PROMPT,
+        tool_profile="coding",
+        max_iterations=12,
+    ),
+    "devops": AgentRole(
+        name="devops",
+        description=(
+            "DevOps engineer: handles deployment configuration, CI/CD pipelines, "
+            "containerisation (Docker/Kubernetes), and environment setup."
+        ),
+        system_prompt=_DEVOPS_PROMPT,
+        tool_profile="coding",
+        max_iterations=20,
+    ),
+    "tester": AgentRole(
+        name="tester",
+        description=(
+            "QA engineer: writes and runs tests (unit, integration, e2e) for a "
+            "given feature or codebase, and reports coverage and failures."
+        ),
+        system_prompt=_TESTER_PROMPT,
+        tool_profile="coding",
+        max_iterations=20,
+    ),
+}
+
+
+def get_role(name: str) -> AgentRole | None:
+    """Return the AgentRole for *name*, or None if not found."""
+    return AGENT_CATALOG.get(name)
+
+
+def list_roles() -> list[AgentRole]:
+    """Return all registered AgentRole objects in definition order."""
+    return list(AGENT_CATALOG.values())
+
+
+def format_roles_for_prompt() -> str:
+    """Return a formatted string listing all roles for injection into prompts.
+
+    Mirrors opencode task.txt's ``{agents}`` block pattern.
+    """
+    lines = []
+    for role in AGENT_CATALOG.values():
+        lines.append(f"  - {role.name}: {role.description}")
+    return "\n".join(lines)

--- a/spoon_bot/subagent/manager.py
+++ b/spoon_bot/subagent/manager.py
@@ -763,7 +763,7 @@ class SubagentManager:
                     f"Persistent agent {agent_name!r} already exists. "
                     "Use resume_agent / spawn(action='resume') to reuse it."
                 )
-            if len(existing_names) >= self.max_persistent_agents:
+            if agent_name not in existing_names and len(existing_names) >= self.max_persistent_agents:
                 raise ValueError(
                     f"Max persistent agents ({self.max_persistent_agents}) reached."
                 )

--- a/spoon_bot/subagent/manager.py
+++ b/spoon_bot/subagent/manager.py
@@ -1,0 +1,1903 @@
+"""Sub-agent manager — spawn, run, collect results, cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from pathlib import Path
+from typing import Any, Callable, Awaitable, Optional, TYPE_CHECKING
+
+from loguru import logger
+
+from spoon_bot.subagent.models import (
+    CleanupMode,
+    PersistentSubagentProfile,
+    SpawnMode,
+    SubagentConfig,
+    SubagentRecord,
+    SubagentResult,
+    SubagentState,
+    TokenUsage,
+)
+from spoon_bot.subagent.registry import SubagentRegistry
+from spoon_bot.subagent.persistence import AgentDirectory, SubagentRunsFile, SubagentSweeper
+from spoon_bot.bus.events import SubagentEvent
+
+if TYPE_CHECKING:
+    from spoon_bot.session.manager import SessionManager
+    from spoon_bot.bus.queue import MessageBus
+
+# Announce retry settings
+_ANNOUNCE_MAX_RETRIES = 3
+_ANNOUNCE_BASE_DELAY = 1.0  # seconds
+# Steer rate limit
+_STEER_MIN_INTERVAL = 2.0  # seconds between steers to the same agent
+# Result truncation for wake messages
+_WAKE_RESULT_TRUNCATE = 2000
+
+
+class SubagentManager:
+    """Manages sub-agent lifecycle.
+
+    One SubagentManager instance is created per root AgentLoop. It:
+    - Maintains a SubagentRegistry for lifecycle tracking
+    - Runs each sub-agent as an independent asyncio.Task
+    - Delivers results via asyncio.Queue (pull) AND bus injection (push/wake)
+    - Shares the parent's SessionManager (sub-agents get unique session keys)
+    - Enforces depth, children-per-agent, and total concurrency limits
+    - Emits SubagentEvents for channel integrations (Discord, Telegram)
+    """
+
+    def __init__(
+        self,
+        *,
+        session_manager: SessionManager,
+        workspace: Path,
+        max_depth: int = 2,
+        max_children_per_agent: int = 5,
+        max_total_subagents: int = 20,
+        # Parent agent config for inheritance
+        parent_model: str | None = None,
+        parent_provider: str | None = None,
+        parent_api_key: str | None = None,
+        parent_base_url: str | None = None,
+        # Persistence settings
+        persist_runs: bool = True,
+        persist_file: str = "subagents/runs.json",
+        archive_after_minutes: int = 60,
+        sweeper_interval_seconds: int = 60,
+        max_persistent_agents: int = 10,
+    ) -> None:
+        # Build persistence layer
+        runs_file: SubagentRunsFile | None = None
+        if persist_runs:
+            persist_path = Path(persist_file)
+            if not persist_path.is_absolute():
+                persist_path = workspace / persist_path
+            runs_file = SubagentRunsFile(persist_path)
+
+        self.registry = SubagentRegistry(runs_file=runs_file)
+        self._persistent_profiles: dict[str, PersistentSubagentProfile] = {
+            profile.name: profile
+            for profile in AgentDirectory.list_profiles(workspace)
+        }
+
+        # Background sweeper (started lazily in start_sweeper())
+        self._sweeper: SubagentSweeper | None = (
+            SubagentSweeper(
+                registry=self.registry,
+                session_manager=session_manager,
+                archive_after_minutes=archive_after_minutes,
+                interval_seconds=sweeper_interval_seconds,
+            )
+            if persist_runs
+            else None
+        )
+        self.session_manager = session_manager
+        self.workspace = workspace
+        self.max_depth = max_depth
+        self.max_children_per_agent = max_children_per_agent
+        self.max_total_subagents = max_total_subagents
+        self.max_persistent_agents = max_persistent_agents
+
+        # Parent config used for inheritance
+        self._parent_model = parent_model
+        self._parent_provider = parent_provider
+        self._parent_api_key = parent_api_key
+        self._parent_base_url = parent_base_url
+
+        # Pull-based result delivery
+        self._results: asyncio.Queue[SubagentResult] = asyncio.Queue()
+        self._buffered_results: list[SubagentResult] = []
+        self._results_lock = asyncio.Lock()
+
+        # Push-based delivery — reference to the message bus
+        self._bus: MessageBus | None = None
+
+        # Current spawner context (updated per-process call from AgentLoop)
+        self._current_spawner_session: str | None = None
+        self._current_spawner_channel: str | None = None
+        self._current_spawner_metadata: dict[str, Any] = {}
+        self._current_spawner_reply_to: str | None = None
+
+        # Live asyncio.Task handles — agent_id → Task
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+
+        # Steer support — pending steer messages and timestamps
+        self._steer_requests: dict[str, str] = {}
+        self._steer_timestamps: dict[str, float] = {}
+
+        # Lifecycle event listeners
+        self._event_listeners: list[Callable[[SubagentEvent], Awaitable[None] | None]] = []
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    def set_bus(self, bus: MessageBus) -> None:
+        """Attach the MessageBus for push-based wake delivery."""
+        self._bus = bus
+
+    def set_spawner_context(
+        self,
+        *,
+        session_key: str | None,
+        channel: str | None,
+        metadata: dict[str, Any] | None = None,
+        reply_to: str | None = None,
+    ) -> None:
+        """Update the current spawner context.
+
+        Called by AgentLoop at the start of each process() / process_with_thinking()
+        so that any sub-agents spawned during that call know who to deliver results to.
+        """
+        self._current_spawner_session = session_key
+        self._current_spawner_channel = channel
+        self._current_spawner_metadata = dict(metadata or {})
+        self._current_spawner_reply_to = reply_to
+
+    def add_event_listener(
+        self,
+        listener: Callable[[SubagentEvent], Awaitable[None] | None],
+    ) -> None:
+        """Register a lifecycle event listener (e.g. for Discord notifications)."""
+        self._event_listeners.append(listener)
+
+    def _resolve_spawner_context(
+        self,
+        *,
+        spawner_session_key: str | None = None,
+        spawner_channel: str | None = None,
+        spawner_metadata: dict[str, Any] | None = None,
+        spawner_reply_to: str | None = None,
+    ) -> tuple[str | None, str | None, dict[str, Any], str | None]:
+        """Resolve explicit spawner context over manager-level defaults."""
+        return (
+            spawner_session_key
+            if spawner_session_key is not None
+            else self._current_spawner_session,
+            spawner_channel
+            if spawner_channel is not None
+            else self._current_spawner_channel,
+            dict(spawner_metadata)
+            if spawner_metadata is not None
+            else dict(self._current_spawner_metadata),
+            spawner_reply_to
+            if spawner_reply_to is not None
+            else self._current_spawner_reply_to,
+        )
+
+    @staticmethod
+    def _result_matches_scope(
+        result: SubagentResult,
+        *,
+        spawner_session_key: str | None = None,
+        agent_id: str | None = None,
+    ) -> bool:
+        """Return True when *result* belongs to the requested requester scope."""
+        if agent_id is not None and result.agent_id != agent_id:
+            return False
+        if (
+            spawner_session_key is not None
+            and result.spawner_session_key != spawner_session_key
+        ):
+            return False
+        return True
+
+    def _start_background_run(
+        self,
+        record: SubagentRecord,
+        *,
+        task_override: str | None = None,
+        is_restart: bool = False,
+    ) -> None:
+        """Launch a tracked asyncio task for the given sub-agent record."""
+        bg_task = asyncio.create_task(
+            self._run_subagent(
+                record,
+                task_override=task_override,
+                is_restart=is_restart,
+            ),
+            name=f"subagent-{record.agent_id}",
+        )
+        self._tasks[record.agent_id] = bg_task
+
+    def _persistent_agent_names(self) -> set[str]:
+        """Return all known persistent agent names from disk and registry."""
+        names = set(self._persistent_profiles.keys())
+        names.update(
+            self._record_agent_name(record)
+            for record in self.registry.list_all()
+            if self._record_spawn_mode(record) == SpawnMode.SESSION and self._record_agent_name(record)
+        )
+        return names
+
+    def _get_persistent_profile(self, name: str) -> PersistentSubagentProfile | None:
+        """Return a persistent subagent profile by name."""
+        return self._persistent_profiles.get(name)
+
+    def _save_persistent_profile(self, profile: PersistentSubagentProfile) -> None:
+        """Persist and cache a persistent subagent profile."""
+        agent_dir = AgentDirectory(self.workspace, profile.name)
+        agent_dir.ensure()
+        agent_dir.save_profile_json(profile)
+        self._persistent_profiles[profile.name] = profile
+
+    @staticmethod
+    def _record_agent_name(record: SubagentRecord) -> str | None:
+        """Return the effective persistent agent name for a record."""
+        return record.agent_name or record.config.agent_name
+
+    @staticmethod
+    def _record_spawn_mode(record: SubagentRecord) -> SpawnMode:
+        """Return the effective spawn mode for a record."""
+        return record.config.spawn_mode or record.spawn_mode
+
+    def _allocate_persistent_agent_name(self, preferred_name: str) -> str:
+        """Return a unique persistent agent name derived from *preferred_name*."""
+        base = re.sub(r"[^a-z0-9_-]+", "-", preferred_name.lower()).strip("-_")
+        if not base:
+            base = "subagent"
+        existing = self._persistent_agent_names()
+        if base not in existing:
+            return base
+        suffix = 2
+        while f"{base}-{suffix}" in existing:
+            suffix += 1
+        return f"{base}-{suffix}"
+
+    @classmethod
+    def _infer_persistent_subagent_profile(cls, description: str) -> dict[str, Any]:
+        """Infer a persistent subagent profile from a natural-language description."""
+        raw = description.strip().strip("。.!? ")
+        normalized = cls._normalize_text(raw)
+        keywords = [raw]
+        match_examples = [raw]
+        tool_profile = "coding"
+        suggested_name = "subagent"
+
+        if any(token in normalized for token in ["新闻", "news", "headline", "热点"]):
+            suggested_name = "news-subagent"
+            tool_profile = "research"
+            keywords.extend([
+                "今天的新闻",
+                "今日新闻",
+                "新闻摘要",
+                "科技热点",
+                "国际热点",
+                "daily news",
+                "news summary",
+            ])
+            system_prompt = (
+                "You are a persistent news sub-agent. Your responsibility is to "
+                "summarize current news and produce concise, structured digests. "
+                "Prioritize fresh information, especially technology and international topics "
+                "when the request asks for them."
+            )
+        elif any(token in normalized for token in ["认证", "登录", "password", "authentication", "login"]):
+            suggested_name = "auth-subagent"
+            tool_profile = "coding"
+            keywords.extend([
+                "登录失败",
+                "密码重置",
+                "authentication",
+                "login issue",
+                "password reset",
+            ])
+            system_prompt = (
+                "You are a persistent authentication sub-agent. Handle login, "
+                "password reset, and account recovery work directly."
+            )
+        elif any(token in normalized for token in ["docker", "部署", "deploy", "kubernetes", "ci/cd"]):
+            suggested_name = "deploy-subagent"
+            tool_profile = "coding"
+            keywords.extend([
+                "部署",
+                "Docker",
+                "CI/CD",
+                "deployment",
+            ])
+            system_prompt = (
+                "You are a persistent deployment sub-agent. Handle Docker, CI/CD, "
+                "and deployment configuration requests."
+            )
+        else:
+            ascii_tokens = re.findall(r"[a-z0-9_]{3,}", normalized)
+            if ascii_tokens:
+                suggested_name = "-".join(ascii_tokens[:2]) + "-subagent"
+            system_prompt = (
+                "You are a persistent sub-agent dedicated to a specific class of tasks. "
+                f"Your specialization is: {raw}. Handle future matching requests directly."
+            )
+
+        deduped_keywords: list[str] = []
+        seen: set[str] = set()
+        for keyword in keywords:
+            stripped = keyword.strip()
+            if not stripped:
+                continue
+            marker = stripped.lower()
+            if marker in seen:
+                continue
+            seen.add(marker)
+            deduped_keywords.append(stripped)
+
+        return {
+            "suggested_name": suggested_name,
+            "specialization": raw,
+            "tool_profile": tool_profile,
+            "system_prompt": system_prompt,
+            "match_keywords": deduped_keywords,
+            "match_examples": match_examples,
+        }
+
+    @classmethod
+    def _infer_persistent_subagent_profile(cls, description: str) -> dict[str, Any]:
+        """Infer a persistent subagent profile from natural-language intent.
+
+        This duplicate definition intentionally overrides the older heuristic
+        above. It uses ASCII-safe unicode escapes for Chinese trigger words so
+        the matching logic remains stable regardless of console encoding.
+        """
+        raw = description.strip().strip("。.!? ")
+        normalized = cls._normalize_text(raw)
+        keywords = [raw]
+        match_examples = [raw]
+        tool_profile = "coding"
+        suggested_name = "subagent"
+
+        news_terms = [
+            "news",
+            "headline",
+            "daily news",
+            "news summary",
+            "today's news",
+            "today news",
+            "\u65b0\u95fb",
+            "\u70ed\u70b9",
+        ]
+        auth_terms = [
+            "authentication",
+            "login",
+            "password",
+            "\u8ba4\u8bc1",
+            "\u767b\u5f55",
+            "\u5bc6\u7801",
+        ]
+        literature_terms = [
+            "literature",
+            "paper",
+            "papers",
+            "research paper",
+            "academic research",
+            "scholar",
+            "\u6587\u732e",
+            "\u8bba\u6587",
+            "\u5b66\u672f",
+            "\u7814\u7a76\u8d44\u6599",
+        ]
+        deploy_terms = [
+            "docker",
+            "deploy",
+            "deployment",
+            "kubernetes",
+            "ci/cd",
+            "\u90e8\u7f72",
+        ]
+
+        if any(term in normalized for term in news_terms):
+            suggested_name = "news-subagent"
+            tool_profile = "research"
+            keywords.extend([
+                "\u4eca\u5929\u7684\u65b0\u95fb",
+                "\u4eca\u65e5\u65b0\u95fb",
+                "\u65b0\u95fb\u6458\u8981",
+                "\u79d1\u6280\u70ed\u70b9",
+                "\u56fd\u9645\u70ed\u70b9",
+                "daily news",
+                "news summary",
+            ])
+            system_prompt = (
+                "You are a persistent news sub-agent. Your responsibility is to "
+                "summarize current news and produce concise, structured digests. "
+                "Prioritize fresh information, especially technology and "
+                "international topics when the request asks for them."
+            )
+        elif any(term in normalized for term in auth_terms):
+            suggested_name = "auth-subagent"
+            tool_profile = "coding"
+            keywords.extend([
+                "\u767b\u5f55\u5931\u8d25",
+                "\u5bc6\u7801\u91cd\u7f6e",
+                "authentication",
+                "login issue",
+                "password reset",
+            ])
+            system_prompt = (
+                "You are a persistent authentication sub-agent. Handle login, "
+                "password reset, and account recovery work directly."
+            )
+        elif any(term in normalized for term in literature_terms):
+            suggested_name = "academic-research-subagent"
+            tool_profile = "research"
+            keywords.extend([
+                "\u6587\u732e\u67e5\u8be2",
+                "\u8bba\u6587\u68c0\u7d22",
+                "\u8bba\u6587\u6458\u8981",
+                "\u7814\u7a76\u8d44\u6599",
+                "\u5b66\u672f\u7814\u7a76",
+                "\u6587\u732e\u7efc\u8ff0",
+                "\u671f\u520a\u8bba\u6587",
+                "\u5b66\u672f\u6570\u636e\u5e93",
+                "\u8bba\u6587\u603b\u7ed3",
+                "paper",
+                "papers",
+                "research",
+                "literature",
+                "summary",
+                "literature search",
+                "paper search",
+                "paper summary",
+            ])
+            system_prompt = (
+                "You are a persistent academic research sub-agent. Handle "
+                "literature search, paper discovery, paper summaries, "
+                "research background synthesis, and reference collection."
+            )
+        elif any(term in normalized for term in deploy_terms):
+            suggested_name = "deploy-subagent"
+            tool_profile = "coding"
+            keywords.extend([
+                "\u90e8\u7f72",
+                "Docker",
+                "CI/CD",
+                "deployment",
+            ])
+            system_prompt = (
+                "You are a persistent deployment sub-agent. Handle Docker, "
+                "CI/CD, and deployment configuration requests."
+            )
+        else:
+            ascii_tokens = re.findall(r"[a-z0-9_]{3,}", normalized)
+            if ascii_tokens:
+                suggested_name = "-".join(ascii_tokens[:2]) + "-subagent"
+            system_prompt = (
+                "You are a persistent sub-agent dedicated to a specific class "
+                f"of tasks. Your specialization is: {raw}. Handle future "
+                "matching requests directly."
+            )
+
+        deduped_keywords: list[str] = []
+        seen: set[str] = set()
+        for keyword in keywords:
+            stripped = keyword.strip()
+            if not stripped:
+                continue
+            marker = stripped.lower()
+            if marker in seen:
+                continue
+            seen.add(marker)
+            deduped_keywords.append(stripped)
+
+        return {
+            "suggested_name": suggested_name,
+            "specialization": raw,
+            "tool_profile": tool_profile,
+            "system_prompt": system_prompt,
+            "match_keywords": deduped_keywords,
+            "match_examples": match_examples,
+        }
+
+    @classmethod
+    def parse_persistent_subagent_request(cls, message: str) -> dict[str, Any] | None:
+        """Parse a natural-language request to create a persistent subagent."""
+        text = cls._strip_sender_prefix(message)
+        patterns = [
+            re.compile(
+                r"^(?:请|帮我|麻烦你|请你)?创建(?:一个|个)?(?:专门的|持久的)?\s*(?:subagent|sub agent|子代理)\s*(?:来|用于|负责|专门处理|专门做)?(?P<body>.+)$",
+                re.IGNORECASE,
+            ),
+            re.compile(
+                r"^(?:please\s+)?create\s+(?:me\s+)?(?:a\s+)?(?:persistent\s+)?(?:subagent|sub agent)\s+(?:to|for)\s+(?P<body>.+)$",
+                re.IGNORECASE,
+            ),
+        ]
+        for pattern in patterns:
+            match = pattern.match(text)
+            if not match:
+                continue
+            body = match.group("body").strip().strip("。.!? ")
+            if not body:
+                return None
+            profile = cls._infer_persistent_subagent_profile(body)
+            profile["source_message"] = text
+            return profile
+        return None
+
+    @staticmethod
+    def _strip_sender_prefix(text: str) -> str:
+        """Remove leading chat-style sender prefixes like ``[Name]:``."""
+        return re.sub(r"^\s*\[[^\]]+\]:\s*", "", text, count=1).strip()
+
+    @staticmethod
+    def _normalize_text(text: str) -> str:
+        return re.sub(r"\s+", " ", SubagentManager._strip_sender_prefix(text).lower()).strip()
+
+    @classmethod
+    def _tokenize_text(cls, text: str) -> set[str]:
+        normalized = cls._normalize_text(text)
+        tokens = {
+            token
+            for token in re.findall(r"[a-z0-9_]{3,}", normalized)
+        }
+        for segment in re.findall(r"[\u4e00-\u9fff]+", normalized):
+            if len(segment) <= 4:
+                tokens.add(segment)
+            for n in (2, 3, 4):
+                if len(segment) < n:
+                    continue
+                for idx in range(len(segment) - n + 1):
+                    tokens.add(segment[idx:idx + n])
+        return tokens
+
+    @classmethod
+    def _score_specialist_match(
+        cls,
+        *,
+        message: str,
+        profile: PersistentSubagentProfile,
+    ) -> tuple[int, bool, list[str]]:
+        """Score how strongly a user message matches a persistent subagent profile."""
+        normalized = cls._normalize_text(message)
+        message_tokens = cls._tokenize_text(message)
+        score = 0
+        strong_signal = False
+        reasons: list[str] = []
+
+        agent_name = profile.name.strip().lower()
+        if agent_name and agent_name in normalized:
+            score += 12
+            strong_signal = True
+            reasons.append(f"name:{agent_name}")
+
+        for keyword in profile.match_keywords:
+            kw = keyword.strip().lower()
+            if not kw:
+                continue
+            if kw in normalized:
+                score += 6
+                strong_signal = True
+                reasons.append(f"keyword:{kw}")
+                continue
+
+            kw_tokens = cls._tokenize_text(kw)
+            if not kw_tokens:
+                continue
+            overlap = kw_tokens & message_tokens
+            contains_cjk = bool(re.search(r"[\u4e00-\u9fff]", kw))
+            required_overlap = 1 if contains_cjk else (2 if len(kw_tokens) > 1 else 1)
+            if len(overlap) >= required_overlap:
+                score += 5 if contains_cjk else 4
+                strong_signal = True
+                reasons.append(f"keyword_tokens:{kw}")
+
+        specialization = (profile.specialization or "").strip()
+        if specialization:
+            spec_tokens = cls._tokenize_text(specialization)
+            overlap = sorted(spec_tokens & message_tokens)
+            if overlap:
+                score += min(5, len(overlap))
+                reasons.append(f"specialization:{','.join(overlap[:4])}")
+
+        for example in profile.match_examples:
+            overlap = cls._tokenize_text(example) & message_tokens
+            contains_cjk = bool(re.search(r"[\u4e00-\u9fff]", example))
+            if len(overlap) >= (1 if contains_cjk else 2):
+                score += 3 if contains_cjk else 2
+                reasons.append("example")
+                break
+
+        return score, strong_signal, reasons
+
+    def _persist_session_agent_state(self, agent_id: str) -> None:
+        """Persist agent.json metadata for a session-mode agent if present."""
+        record = self.registry.get(agent_id)
+        agent_name = self._record_agent_name(record) if record else None
+        if not record or self._record_spawn_mode(record) != SpawnMode.SESSION or not agent_name:
+            return
+        try:
+            base_profile = self._get_persistent_profile(agent_name)
+            if base_profile is None:
+                profile = PersistentSubagentProfile.from_subagent_config(
+                    name=agent_name,
+                    config=record.config,
+                    created_at=record.created_at,
+                )
+            else:
+                profile = base_profile.model_copy(deep=True)
+                updated_cfg = record.config
+                profile.role = updated_cfg.role
+                profile.model = record.model_name or updated_cfg.model or profile.model
+                profile.provider = updated_cfg.provider or profile.provider
+                profile.api_key = updated_cfg.api_key or profile.api_key
+                profile.base_url = updated_cfg.base_url or profile.base_url
+                profile.max_iterations = updated_cfg.max_iterations
+                profile.system_prompt = updated_cfg.system_prompt or profile.system_prompt
+                profile.tool_profile = updated_cfg.tool_profile
+                profile.enabled_tools = updated_cfg.enabled_tools
+                profile.enable_skills = updated_cfg.enable_skills
+                profile.context_window = updated_cfg.context_window
+                profile.thinking_level = updated_cfg.thinking_level
+                profile.timeout_seconds = updated_cfg.timeout_seconds
+                profile.cleanup = updated_cfg.cleanup
+                profile.specialization = updated_cfg.specialization or profile.specialization
+                profile.auto_route = updated_cfg.auto_route
+                profile.match_keywords = list(updated_cfg.match_keywords)
+                profile.match_examples = list(updated_cfg.match_examples)
+                profile.routing_mode = updated_cfg.routing_mode
+            profile.last_active_at = record.completed_at or record.started_at or record.created_at
+            profile.last_run_agent_id = record.agent_id
+            profile.last_run_state = record.state.value
+            self._save_persistent_profile(profile)
+        except Exception as exc:
+            logger.debug(f"Failed to update agent.json for {agent_name!r}: {exc}")
+
+    @staticmethod
+    def _merge_resume_config(
+        base: SubagentConfig,
+        override: SubagentConfig | None,
+    ) -> SubagentConfig:
+        """Merge explicit override fields onto an existing sub-agent config."""
+        effective = base.model_copy(deep=True)
+        if override is None:
+            return effective
+        for key, value in override.model_dump(exclude_unset=True).items():
+            setattr(effective, key, value)
+        return effective
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def spawn(
+        self,
+        task: str,
+        *,
+        label: str = "",
+        parent_id: str | None = None,
+        config: SubagentConfig | None = None,
+        spawner_session_key: str | None = None,
+        spawner_channel: str | None = None,
+        spawner_metadata: dict[str, Any] | None = None,
+        spawner_reply_to: str | None = None,
+        allow_existing_profile_name: bool = False,
+    ) -> SubagentRecord:
+        """Spawn a new sub-agent to work on *task*.
+
+        Validates all limits, registers the sub-agent, then starts it as
+        a background asyncio.Task.
+
+        Args:
+            task:      The message/instruction for the sub-agent.
+            label:     Short human-readable label (truncated from task if empty).
+            parent_id: ID of the parent sub-agent (None = spawned by root).
+            config:    Optional config overrides.
+
+        Returns:
+            The newly created SubagentRecord.
+
+        Raises:
+            ValueError: If any limit is exceeded or config is invalid.
+        """
+        cfg = config or SubagentConfig()
+
+        # --- Depth check ---
+        parent_depth = 0
+        if parent_id:
+            parent_record = self.registry.get(parent_id)
+            if parent_record:
+                parent_depth = parent_record.depth
+        child_depth = parent_depth + 1
+
+        if child_depth > self.max_depth:
+            raise ValueError(
+                f"Max spawn depth ({self.max_depth}) exceeded. "
+                f"Parent depth={parent_depth}, requested child depth={child_depth}."
+            )
+
+        # --- Children-per-agent limit ---
+        if parent_id:
+            active_children = self.registry.count_active_children(parent_id)
+            if active_children >= self.max_children_per_agent:
+                raise ValueError(
+                    f"Max children per agent ({self.max_children_per_agent}) "
+                    f"already reached for parent {parent_id}."
+                )
+
+        # --- Total sub-agent limit ---
+        total_active = self.registry.count_active_total()
+        if total_active >= self.max_total_subagents:
+            raise ValueError(
+                f"Max total active sub-agents ({self.max_total_subagents}) reached."
+            )
+
+        # --- Session-mode validations ---
+        agent_dir_path: str | None = None
+        if cfg.spawn_mode == SpawnMode.SESSION:
+            if not cfg.agent_name:
+                raise ValueError(
+                    "agent_name is required when spawn_mode='session'."
+                )
+            agent_name = cfg.agent_name
+            # Validate name: alphanumeric, hyphens, underscores only
+            import re
+            if not re.match(r"^[a-zA-Z0-9_-]+$", agent_name):
+                raise ValueError(
+                    f"agent_name {agent_name!r} is invalid. "
+                    "Use only letters, digits, hyphens, and underscores."
+                )
+            existing_names = set(self._persistent_profiles.keys())
+            if agent_name in existing_names and not allow_existing_profile_name:
+                raise ValueError(
+                    f"Persistent agent {agent_name!r} already exists. "
+                    "Use resume_agent / spawn(action='resume') to reuse it."
+                )
+            if len(existing_names) >= self.max_persistent_agents:
+                raise ValueError(
+                    f"Max persistent agents ({self.max_persistent_agents}) reached."
+                )
+            # Set up agent directory
+            agent_dir = AgentDirectory(self.workspace, agent_name)
+            agent_dir.ensure()
+            agent_dir_path = str(agent_dir.root)
+
+        # --- Resolve effective model name ---
+        effective_model = cfg.model or self._parent_model
+        (
+            resolved_spawner_session,
+            resolved_spawner_channel,
+            resolved_spawner_metadata,
+            resolved_spawner_reply_to,
+        ) = self._resolve_spawner_context(
+            spawner_session_key=spawner_session_key,
+            spawner_channel=spawner_channel,
+            spawner_metadata=spawner_metadata,
+            spawner_reply_to=spawner_reply_to,
+        )
+
+        # --- Create and register record ---
+        record = SubagentRecord(
+            parent_id=parent_id,
+            depth=child_depth,
+            label=label or task[:60],
+            task=task,
+            config=cfg,
+            model_name=effective_model,
+            spawner_session_key=resolved_spawner_session,
+            spawner_channel=resolved_spawner_channel,
+            spawner_metadata=resolved_spawner_metadata,
+            spawner_reply_to=resolved_spawner_reply_to,
+            spawn_mode=cfg.spawn_mode,
+            cleanup=cfg.cleanup,
+            agent_name=cfg.agent_name,
+            agent_dir=agent_dir_path,
+        )
+
+        self.registry.register(record)
+        self._persist_session_agent_state(record.agent_id)
+        logger.info(
+            f"Sub-agent {record.agent_id!r} registered: "
+            f"depth={record.depth}, label={record.label!r}, model={effective_model!r}"
+        )
+
+        # Emit lifecycle event
+        await self._emit_event(SubagentEvent(
+            event_type="spawning",
+            agent_id=record.agent_id,
+            label=record.label,
+            parent_id=record.parent_id,
+            depth=record.depth,
+            model_name=effective_model,
+            spawner_session_key=record.spawner_session_key,
+            spawner_channel=record.spawner_channel,
+        ))
+
+        # --- Start background execution ---
+        self._start_background_run(record)
+
+        return record
+
+    async def collect_results(
+        self,
+        timeout: float = 0.0,
+        *,
+        spawner_session_key: str | None = None,
+        agent_id: str | None = None,
+    ) -> list[SubagentResult]:
+        """Collect scoped results without draining unrelated sub-agent outputs.
+
+        Args:
+            timeout: If > 0, wait up to this many seconds for at least one
+                     result before returning. If 0, return immediately.
+
+        Returns:
+            List of SubagentResult (may be empty).
+        """
+        results: list[SubagentResult] = []
+        deadline = time.monotonic() + timeout if timeout > 0 else None
+
+        while True:
+            async with self._results_lock:
+                retained: list[SubagentResult] = []
+                for buffered in self._buffered_results:
+                    if self._result_matches_scope(
+                        buffered,
+                        spawner_session_key=spawner_session_key,
+                        agent_id=agent_id,
+                    ):
+                        results.append(buffered)
+                    else:
+                        retained.append(buffered)
+                self._buffered_results = retained
+
+            try:
+                if results:
+                    result = self._results.get_nowait()
+                elif deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return results
+                    result = await asyncio.wait_for(self._results.get(), timeout=remaining)
+                else:
+                    result = self._results.get_nowait()
+            except asyncio.QueueEmpty:
+                return results
+            except asyncio.TimeoutError:
+                return results
+
+            if self._result_matches_scope(
+                result,
+                spawner_session_key=spawner_session_key,
+                agent_id=agent_id,
+            ):
+                results.append(result)
+            else:
+                async with self._results_lock:
+                    self._buffered_results.append(result)
+
+    async def cancel(self, agent_id: str, *, cascade: bool = True) -> bool:
+        """Cancel a running or pending sub-agent.
+
+        Args:
+            agent_id: The agent to cancel.
+            cascade:  If True (default), also cancel all descendants.
+
+        Returns:
+            True if the task was found and cancellation was requested.
+        """
+        found = False
+        if cascade:
+            # Cancel descendants first (deepest first)
+            descendants = self.registry.get_descendants(agent_id)
+            for desc in reversed(descendants):
+                task = self._tasks.get(desc.agent_id)
+                if task and not task.done():
+                    task.cancel()
+                    logger.info(f"Cascade cancel: sub-agent {desc.agent_id!r}")
+                    found = True
+
+        task = self._tasks.get(agent_id)
+        if task and not task.done():
+            task.cancel()
+            logger.info(f"Cancellation requested for sub-agent {agent_id}")
+            found = True
+        return found
+
+    async def cancel_all(self, parent_id: str | None = None) -> int:
+        """Cancel all active sub-agents, optionally filtered by parent.
+
+        Always uses cascade kill.
+
+        Returns:
+            Number of top-level sub-agents whose cancellation was requested.
+        """
+        count = 0
+        for record in self.registry.list_all():
+            if parent_id and record.parent_id != parent_id:
+                continue
+            if record.state in (SubagentState.PENDING, SubagentState.RUNNING):
+                if await self.cancel(record.agent_id, cascade=True):
+                    count += 1
+        return count
+
+    async def steer(
+        self,
+        agent_id: str,
+        new_message: str,
+    ) -> dict[str, Any]:
+        """Redirect a running sub-agent with a new message.
+
+        The current run is aborted and the sub-agent is restarted with
+        *new_message* appended to the existing session history.
+
+        Rate limited: at most one steer per _STEER_MIN_INTERVAL seconds.
+
+        Returns:
+            Dict with keys: status, agent_id, label, message.
+        """
+        record = self.registry.get(agent_id)
+        if record is None:
+            return {"status": "not_found", "agent_id": agent_id, "message": "Agent not found."}
+
+        if record.state not in (SubagentState.PENDING, SubagentState.RUNNING):
+            return {
+                "status": "done",
+                "agent_id": agent_id,
+                "label": record.label,
+                "message": f"Agent is already in terminal state: {record.state.value}",
+            }
+
+        # Rate limiting
+        last_steer = self._steer_timestamps.get(agent_id, 0.0)
+        elapsed_since = time.time() - last_steer
+        if elapsed_since < _STEER_MIN_INTERVAL:
+            wait = round(_STEER_MIN_INTERVAL - elapsed_since, 1)
+            return {
+                "status": "rate_limited",
+                "agent_id": agent_id,
+                "label": record.label,
+                "message": f"Rate limited. Try again in {wait}s.",
+            }
+
+        # Queue the steer request (processed in _run_subagent's CancelledError handler)
+        self._steer_requests[agent_id] = new_message
+        self._steer_timestamps[agent_id] = time.time()
+
+        # Cancel current task (triggers the steer restart)
+        task = self._tasks.get(agent_id)
+        if task and not task.done():
+            task.cancel()
+            logger.info(
+                f"Steer requested for sub-agent {agent_id!r}: "
+                f"{new_message[:60]!r}"
+            )
+            return {
+                "status": "accepted",
+                "agent_id": agent_id,
+                "label": record.label,
+                "message": f"Steer accepted. Sub-agent {agent_id} will be redirected.",
+            }
+        else:
+            # Task is done — start a fresh run
+            self._steer_requests.pop(agent_id, None)
+            return {
+                "status": "done",
+                "agent_id": agent_id,
+                "label": record.label,
+                "message": "Agent already finished. Use spawn to create a new one.",
+            }
+
+    async def get_info(self, agent_id: str) -> dict[str, Any] | None:
+        """Return detailed metadata for a sub-agent.
+
+        Returns None if the agent is not found.
+        """
+        record = self.registry.get(agent_id)
+        if record is None:
+            return None
+
+        now = time.time()
+        elapsed: float | None = None
+        if record.started_at:
+            end = record.completed_at or now
+            elapsed = round(end - record.started_at, 2)
+
+        pending_desc = self.registry.count_pending_descendants(agent_id)
+
+        return {
+            "agent_id": record.agent_id,
+            "label": record.label,
+            "state": record.state.value,
+            "task": record.task,
+            "depth": record.depth,
+            "parent_id": record.parent_id,
+            "session_key": record.session_key,
+            "model": record.model_name,
+            "tool_profile": record.config.tool_profile,
+            "specialization": record.config.specialization,
+            "auto_route": record.config.auto_route,
+            "match_keywords": list(record.config.match_keywords),
+            "match_examples": list(record.config.match_examples),
+            "routing_mode": record.config.routing_mode.value,
+            "max_iterations": record.config.max_iterations,
+            "thinking_level": record.config.thinking_level,
+            "timeout_seconds": record.config.timeout_seconds,
+            "children": record.children,
+            "pending_descendants": pending_desc,
+            "created_at": record.created_at,
+            "started_at": record.started_at,
+            "completed_at": record.completed_at,
+            "elapsed_seconds": elapsed,
+            "result_preview": (record.result or "")[:300] if record.result else None,
+            "error": record.error,
+            "token_usage": (
+                record.token_usage.model_dump() if record.token_usage else None
+            ),
+        }
+
+    async def resume_agent(
+        self,
+        agent_name: str,
+        task: str,
+        *,
+        config: SubagentConfig | None = None,
+        parent_id: str | None = None,
+        spawner_session_key: str | None = None,
+        spawner_channel: str | None = None,
+        spawner_metadata: dict[str, Any] | None = None,
+        spawner_reply_to: str | None = None,
+    ) -> SubagentRecord:
+        """Re-invoke a persistent session-mode agent with a new task.
+
+        Finds the most recent record for *agent_name*, verifies it is a
+        session-mode agent in a terminal state, then restarts it using
+        the existing session_key (preserving conversation context).
+
+        Args:
+            agent_name: The name of the persistent agent to resume.
+            task:       New task/instruction to send to the agent.
+            config:     Optional config overrides (defaults to original config).
+
+        Returns:
+            The updated SubagentRecord.
+
+        Raises:
+            ValueError: If the agent is not found, not a session-mode agent,
+                        or is currently running.
+        """
+        # Find record by agent_name
+        matching = [
+            r for r in self.registry.list_all()
+            if self._record_agent_name(r) == agent_name and self._record_spawn_mode(r) == SpawnMode.SESSION
+        ]
+        if not matching:
+            profile = self._get_persistent_profile(agent_name)
+            if profile is not None:
+                return await self.spawn(
+                    task=task,
+                    label=task[:60],
+                    config=profile.to_subagent_config(),
+                    spawner_session_key=spawner_session_key,
+                    spawner_channel=spawner_channel,
+                    spawner_metadata=spawner_metadata,
+                    spawner_reply_to=spawner_reply_to,
+                    allow_existing_profile_name=True,
+                )
+            raise ValueError(
+                f"No session-mode agent named {agent_name!r} found. "
+                "Create it first before resuming it."
+            )
+        # Take the most recently created
+        record = max(matching, key=lambda r: r.created_at)
+
+        if record.state in (SubagentState.PENDING, SubagentState.RUNNING):
+            raise ValueError(
+                f"Agent {agent_name!r} ({record.agent_id}) is currently "
+                f"{record.state.value}. Wait for it to complete first."
+            )
+
+        effective_config = self._merge_resume_config(record.config, config)
+        effective_config.spawn_mode = SpawnMode.SESSION
+        effective_config.agent_name = agent_name
+        effective_model = effective_config.model or self._parent_model
+        (
+            resolved_spawner_session,
+            resolved_spawner_channel,
+            resolved_spawner_metadata,
+            resolved_spawner_reply_to,
+        ) = self._resolve_spawner_context(
+            spawner_session_key=spawner_session_key,
+            spawner_channel=spawner_channel,
+            spawner_metadata=spawner_metadata,
+            spawner_reply_to=spawner_reply_to,
+        )
+        label = task[:60]
+        self.registry.prepare_for_resume(
+            record.agent_id,
+            task=task,
+            label=label,
+            parent_id=parent_id,
+            spawner_session_key=resolved_spawner_session,
+            spawner_channel=resolved_spawner_channel,
+            spawner_metadata=resolved_spawner_metadata,
+            spawner_reply_to=resolved_spawner_reply_to,
+            model_name=effective_model,
+            config=effective_config,
+        )
+        self._persist_session_agent_state(record.agent_id)
+
+        logger.info(
+            f"Resuming session agent {agent_name!r} ({record.agent_id}): "
+            f"{task[:60]!r}"
+        )
+
+        # Launch background task (reuses existing session_key = preserved context)
+        # is_restart=False so the PENDING→RUNNING transition fires properly
+        await self._emit_event(SubagentEvent(
+            event_type="spawning",
+            agent_id=record.agent_id,
+            label=record.label,
+            parent_id=record.parent_id,
+            depth=record.depth,
+            model_name=record.model_name,
+            spawner_session_key=record.spawner_session_key,
+            spawner_channel=record.spawner_channel,
+        ))
+        self._start_background_run(record)
+
+        return record
+
+    def find_best_auto_route_specialist(self, task: str) -> dict[str, Any] | None:
+        """Return the best persistent subagent profile for *task*, or None."""
+        candidates: list[dict[str, Any]] = []
+        profiles: dict[str, PersistentSubagentProfile] = dict(self._persistent_profiles)
+        for record in self.registry.list_all():
+            agent_name = self._record_agent_name(record)
+            if (
+                agent_name
+                and agent_name not in profiles
+                and self._record_spawn_mode(record) == SpawnMode.SESSION
+                and record.config.auto_route
+            ):
+                profiles[agent_name] = PersistentSubagentProfile.from_subagent_config(
+                    name=agent_name,
+                    config=record.config,
+                    created_at=record.created_at,
+                    last_active_at=record.completed_at or record.started_at or record.created_at,
+                    last_run_agent_id=record.agent_id,
+                    last_run_state=record.state.value,
+                )
+
+        for profile in profiles.values():
+            if not profile.auto_route:
+                continue
+            if profile.routing_mode.value != "direct":
+                continue
+
+            score, strong_signal, reasons = self._score_specialist_match(
+                message=task,
+                profile=profile,
+            )
+            if score <= 0:
+                continue
+            candidates.append({
+                "profile": profile,
+                "agent_name": profile.name,
+                "score": score,
+                "strong_signal": strong_signal,
+                "reasons": reasons,
+            })
+
+        if not candidates:
+            return None
+
+        candidates.sort(
+            key=lambda item: (
+                item["score"],
+                len(item["reasons"]),
+                item["profile"].created_at,
+            ),
+            reverse=True,
+        )
+        best = candidates[0]
+        if not best["strong_signal"] or best["score"] < 7:
+            return None
+        if len(candidates) > 1 and candidates[1]["score"] >= best["score"] - 2:
+            logger.info(
+                "Persistent specialist routing skipped due to ambiguous match: "
+                f"{best['agent_name']} score={best['score']} vs "
+                f"{candidates[1]['agent_name']} score={candidates[1]['score']}"
+            )
+            return None
+
+        return {
+            "agent_name": best["agent_name"],
+            "score": best["score"],
+            "reasons": best["reasons"],
+            "specialization": best["profile"].specialization,
+            "profile": best["profile"],
+        }
+
+    def create_persistent_subagent(
+        self,
+        *,
+        description: str,
+        agent_name: str | None = None,
+        config: SubagentConfig | None = None,
+        label: str | None = None,
+    ) -> PersistentSubagentProfile:
+        """Create a persistent subagent profile without immediately running it."""
+        profile = self._infer_persistent_subagent_profile(description)
+        cfg = (config.model_copy(deep=True) if config else SubagentConfig())
+        cfg.spawn_mode = SpawnMode.SESSION
+        cfg.auto_route = True if config is None else cfg.auto_route
+        cfg.specialization = cfg.specialization or profile["specialization"]
+        if config is None or cfg.tool_profile == "core":
+            cfg.tool_profile = profile["tool_profile"]
+        cfg.system_prompt = cfg.system_prompt or profile["system_prompt"]
+        if not cfg.match_keywords:
+            cfg.match_keywords = list(profile["match_keywords"])
+        if not cfg.match_examples:
+            cfg.match_examples = list(profile["match_examples"])
+
+        chosen_name = self._allocate_persistent_agent_name(
+            agent_name or profile["suggested_name"]
+        )
+        cfg.agent_name = chosen_name
+
+        persistent_profile = PersistentSubagentProfile.from_subagent_config(
+            name=chosen_name,
+            config=cfg,
+        )
+        self._save_persistent_profile(persistent_profile)
+        logger.info(
+            f"Persistent subagent created: {chosen_name!r} "
+            f"(tool_profile={cfg.tool_profile}, auto_route={cfg.auto_route})"
+        )
+        return persistent_profile
+
+    async def dispatch_persistent_subagent(
+        self,
+        *,
+        agent_name: str,
+        task: str,
+        spawner_session_key: str | None = None,
+        spawner_channel: str | None = None,
+        spawner_metadata: dict[str, Any] | None = None,
+        spawner_reply_to: str | None = None,
+    ) -> SubagentRecord:
+        """Start or resume a persistent subagent session from its profile."""
+        profile = self._get_persistent_profile(agent_name)
+        if profile is None:
+            raise ValueError(f"No persistent subagent profile named {agent_name!r} found.")
+
+        matching = [
+            r for r in self.registry.list_all()
+            if self._record_agent_name(r) == agent_name and self._record_spawn_mode(r) == SpawnMode.SESSION
+        ]
+        if matching:
+            latest = max(matching, key=lambda r: r.created_at)
+            if latest.state in (SubagentState.PENDING, SubagentState.RUNNING):
+                raise ValueError(
+                    f"Persistent subagent {agent_name!r} is already running. "
+                    "Wait for it to finish before dispatching another task."
+                )
+            return await self.resume_agent(
+                agent_name=agent_name,
+                task=task,
+                spawner_session_key=spawner_session_key,
+                spawner_channel=spawner_channel,
+                spawner_metadata=spawner_metadata,
+                spawner_reply_to=spawner_reply_to,
+            )
+
+        return await self.spawn(
+            task=task,
+            label=task[:60],
+            config=profile.to_subagent_config(),
+            spawner_session_key=spawner_session_key,
+            spawner_channel=spawner_channel,
+            spawner_metadata=spawner_metadata,
+            spawner_reply_to=spawner_reply_to,
+            allow_existing_profile_name=True,
+        )
+
+    async def resume_task(
+        self,
+        task_id: str,
+        task: str,
+        *,
+        config: SubagentConfig | None = None,
+        parent_id: str | None = None,
+        spawner_session_key: str | None = None,
+        spawner_channel: str | None = None,
+        spawner_metadata: dict[str, Any] | None = None,
+        spawner_reply_to: str | None = None,
+    ) -> SubagentRecord:
+        """Resume an existing sub-agent session by task_id / agent_id."""
+        record = self.registry.get(task_id)
+        if record is None:
+            raise ValueError(f"Sub-agent task_id {task_id!r} was not found.")
+
+        if record.state in (SubagentState.PENDING, SubagentState.RUNNING):
+            raise ValueError(
+                f"Sub-agent {task_id!r} is currently {record.state.value}. "
+                "Wait for it to complete before resuming it."
+            )
+
+        effective_config = self._merge_resume_config(record.config, config)
+        effective_config.spawn_mode = self._record_spawn_mode(record)
+        if record.agent_name and not effective_config.agent_name:
+            effective_config.agent_name = record.agent_name
+        effective_model = effective_config.model or self._parent_model
+        (
+            resolved_spawner_session,
+            resolved_spawner_channel,
+            resolved_spawner_metadata,
+            resolved_spawner_reply_to,
+        ) = self._resolve_spawner_context(
+            spawner_session_key=spawner_session_key,
+            spawner_channel=spawner_channel,
+            spawner_metadata=spawner_metadata,
+            spawner_reply_to=spawner_reply_to,
+        )
+        label = task[:60]
+        self.registry.prepare_for_resume(
+            record.agent_id,
+            task=task,
+            label=label,
+            parent_id=parent_id,
+            spawner_session_key=resolved_spawner_session,
+            spawner_channel=resolved_spawner_channel,
+            spawner_metadata=resolved_spawner_metadata,
+            spawner_reply_to=resolved_spawner_reply_to,
+            model_name=effective_model,
+            config=effective_config,
+        )
+        self._persist_session_agent_state(record.agent_id)
+
+        logger.info(f"Resuming sub-agent task {task_id!r}: {task[:60]!r}")
+
+        await self._emit_event(SubagentEvent(
+            event_type="spawning",
+            agent_id=record.agent_id,
+            label=record.label,
+            parent_id=record.parent_id,
+            depth=record.depth,
+            model_name=record.model_name,
+            spawner_session_key=record.spawner_session_key,
+            spawner_channel=record.spawner_channel,
+        ))
+        self._start_background_run(record)
+
+        return record
+
+    def list_persistent_agents(self) -> list[dict[str, Any]]:
+        """Return metadata for all session-mode agents (active and past)."""
+        result: list[dict[str, Any]] = []
+        runtime_by_name: dict[str, SubagentRecord] = {}
+        for record in self.registry.list_all():
+            if self._record_spawn_mode(record) != SpawnMode.SESSION or not self._record_agent_name(record):
+                continue
+            name = self._record_agent_name(record)
+            existing = runtime_by_name.get(name)
+            if existing is None or record.created_at > existing.created_at:
+                runtime_by_name[name] = record
+
+        for name, profile in sorted(self._persistent_profiles.items()):
+            runtime_record = runtime_by_name.get(name)
+            result.append({
+                "agent_id": runtime_record.agent_id if runtime_record else profile.last_run_agent_id,
+                "agent_name": name,
+                "label": runtime_record.label if runtime_record else f"persistent:{name}",
+                "state": runtime_record.state.value if runtime_record else (profile.last_run_state or "idle"),
+                "model": runtime_record.model_name if runtime_record else profile.model,
+                "agent_dir": str(AgentDirectory(self.workspace, name).root),
+                "specialization": profile.specialization,
+                "auto_route": profile.auto_route,
+                "match_keywords": list(profile.match_keywords),
+                "match_examples": list(profile.match_examples),
+                "routing_mode": profile.routing_mode.value,
+                "created_at": profile.created_at,
+                "last_active_at": runtime_record.completed_at if runtime_record and runtime_record.completed_at else profile.last_active_at or profile.created_at,
+            })
+        return result
+
+    async def start_sweeper(self) -> None:
+        """Start the background archive sweeper (call after the event loop is running)."""
+        if self._sweeper is not None:
+            await self._sweeper.start()
+
+    async def stop_sweeper(self) -> None:
+        """Stop the background archive sweeper."""
+        if self._sweeper is not None:
+            await self._sweeper.stop()
+
+    async def cleanup(self) -> None:
+        """Shut down all sub-agents, stop the sweeper, and clean up sessions."""
+        # Stop sweeper first so it doesn't race with cleanup
+        await self.stop_sweeper()
+
+        cancelled = await self.cancel_all()
+        if cancelled:
+            logger.info(f"Cancelled {cancelled} sub-agent(s) during cleanup")
+
+        if self._tasks:
+            await asyncio.gather(*self._tasks.values(), return_exceptions=True)
+
+        for record in self.registry.list_all():
+            # Preserve session data for persistent (session-mode) agents
+            if self._record_spawn_mode(record) == SpawnMode.SESSION:
+                continue
+            try:
+                self.session_manager.delete(record.session_key)
+            except Exception:
+                pass
+
+        self._tasks.clear()
+        logger.info("SubagentManager cleanup complete")
+
+    def get_status_summary(
+        self,
+        parent_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Return a rich summary dict of sub-agent statuses.
+
+        Separates active (pending/running) from recent (terminal) records.
+        Includes model name and pending descendant counts.
+        """
+        records = (
+            self.registry.list_by_parent(parent_id)
+            if parent_id
+            else self.registry.list_all()
+        )
+
+        active: list[dict[str, Any]] = []
+        recent: list[dict[str, Any]] = []
+
+        now = time.time()
+        for r in records:
+            elapsed: float | None = None
+            if r.started_at:
+                end = r.completed_at or now
+                elapsed = round(end - r.started_at, 1)
+
+            pending_desc = self.registry.count_pending_descendants(r.agent_id)
+
+            entry = {
+                "agent_id": r.agent_id,
+                "label": r.label,
+                "state": r.state.value,
+                "depth": r.depth,
+                "model": r.model_name,
+                "elapsed_seconds": elapsed,
+                "pending_descendants": pending_desc,
+                "spawn_mode": r.spawn_mode.value,
+                "agent_name": r.agent_name,
+            }
+
+            if r.state in (SubagentState.PENDING, SubagentState.RUNNING):
+                active.append(entry)
+            else:
+                recent.append(entry)
+
+        return {
+            "total": len(records),
+            "active": active,
+            "recent": recent,
+            # Legacy field for backward compat with existing status handler
+            "by_state": {
+                e["state"]: [e2 for e2 in records
+                              if e2.state.value == e["state"]]
+                for e in (active + recent)
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # Internal: background execution
+    # ------------------------------------------------------------------
+
+    async def _run_subagent(
+        self,
+        record: SubagentRecord,
+        task_override: str | None = None,
+        is_restart: bool = False,
+    ) -> None:
+        """Background coroutine: create AgentLoop → run task → deliver result."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        task_text = task_override or record.task
+
+        if not is_restart:
+            self.registry.transition(
+                record.agent_id,
+                SubagentState.RUNNING,
+                started_at=time.time(),
+            )
+            self._persist_session_agent_state(record.agent_id)
+            await self._emit_event(SubagentEvent(
+                event_type="started",
+                agent_id=record.agent_id,
+                label=record.label,
+                parent_id=record.parent_id,
+                depth=record.depth,
+                model_name=record.model_name,
+                spawner_session_key=record.spawner_session_key,
+                spawner_channel=record.spawner_channel,
+            ))
+
+        logger.info(f"Sub-agent {record.agent_id!r} starting task: {task_text[:80]!r}")
+
+        child_agent: AgentLoop | None = None
+        _steered = False
+
+        try:
+            cfg = record.config
+            effective_model = cfg.model or self._parent_model
+
+            child_agent = AgentLoop(
+                workspace=self.workspace,
+                model=effective_model,
+                provider=cfg.provider or self._parent_provider,
+                api_key=cfg.api_key or self._parent_api_key,
+                base_url=cfg.base_url or self._parent_base_url,
+                max_iterations=cfg.max_iterations,
+                session_key=record.session_key,
+                system_prompt=cfg.system_prompt or self._build_system_prompt(record),
+                enable_skills=cfg.enable_skills,
+                enabled_tools=cfg.enabled_tools,
+                tool_profile=cfg.tool_profile,
+                context_window=cfg.context_window,
+                auto_commit=False,
+                session_manager=self.session_manager,
+                subagent_manager=self,
+            )
+
+            await child_agent.initialize()
+
+            # Inject SubagentTool with reference back to this manager
+            from spoon_bot.subagent.tools import SubagentTool
+            spawn_tool = child_agent.tools.get("spawn")
+            if spawn_tool and isinstance(spawn_tool, SubagentTool):
+                spawn_tool.set_manager(self)
+                spawn_tool._parent_agent_id = record.agent_id
+                spawn_tool.set_spawner_context(
+                    session_key=record.session_key,
+                    channel=record.spawner_channel,
+                )
+
+            # Run the task — with optional timeout and thinking
+            if cfg.timeout_seconds:
+                run_coro = self._run_process(child_agent, task_text, cfg)
+                result_text = await asyncio.wait_for(
+                    run_coro, timeout=float(cfg.timeout_seconds)
+                )
+            else:
+                result_text = await self._run_process(child_agent, task_text, cfg)
+
+            # Extract token usage if available
+            token_usage = self._extract_token_usage(child_agent)
+
+            await child_agent.cleanup()
+
+            now = time.time()
+            elapsed = round(now - (record.started_at or record.created_at), 2)
+
+            self.registry.transition(
+                record.agent_id,
+                SubagentState.COMPLETED,
+                result=result_text,
+                completed_at=now,
+                frozen_result_text=result_text,
+                token_usage=token_usage,
+            )
+            self._persist_session_agent_state(record.agent_id)
+
+            result_obj = SubagentResult(
+                agent_id=record.agent_id,
+                label=record.label,
+                state=SubagentState.COMPLETED,
+                result=result_text,
+                elapsed_seconds=elapsed,
+                spawner_session_key=record.spawner_session_key,
+                spawner_channel=record.spawner_channel,
+                spawner_metadata=dict(record.spawner_metadata),
+                spawner_reply_to=record.spawner_reply_to,
+                model_name=record.model_name,
+            )
+            await self._results.put(result_obj)
+
+            logger.info(f"Sub-agent {record.agent_id!r} completed in {elapsed}s")
+
+            # Emit lifecycle event
+            await self._emit_event(SubagentEvent(
+                event_type="completed",
+                agent_id=record.agent_id,
+                label=record.label,
+                parent_id=record.parent_id,
+                depth=record.depth,
+                model_name=record.model_name,
+                result=result_text,
+                elapsed_seconds=elapsed,
+                spawner_session_key=record.spawner_session_key,
+                spawner_channel=record.spawner_channel,
+            ))
+
+            # Push-based delivery: announce result to spawner via bus
+            await self._announce_result(result_obj)
+
+        except asyncio.TimeoutError:
+            if child_agent:
+                try:
+                    await child_agent.cleanup()
+                except Exception:
+                    pass
+            error_msg = f"Sub-agent timed out after {cfg.timeout_seconds}s"
+            logger.warning(f"Sub-agent {record.agent_id!r}: {error_msg}")
+            self.registry.transition(
+                record.agent_id,
+                SubagentState.FAILED,
+                error=error_msg,
+                completed_at=time.time(),
+            )
+            self._persist_session_agent_state(record.agent_id)
+            result_obj = SubagentResult(
+                agent_id=record.agent_id,
+                label=record.label,
+                state=SubagentState.FAILED,
+                error=error_msg,
+                spawner_session_key=record.spawner_session_key,
+                spawner_channel=record.spawner_channel,
+                spawner_metadata=dict(record.spawner_metadata),
+                spawner_reply_to=record.spawner_reply_to,
+            )
+            await self._results.put(result_obj)
+            await self._announce_result(result_obj)
+            await self._emit_event(SubagentEvent(
+                event_type="failed",
+                agent_id=record.agent_id,
+                label=record.label,
+                parent_id=record.parent_id,
+                depth=record.depth,
+                error=error_msg,
+                spawner_session_key=record.spawner_session_key,
+                spawner_channel=record.spawner_channel,
+            ))
+
+        except asyncio.CancelledError:
+            if child_agent:
+                try:
+                    await child_agent.cleanup()
+                except Exception:
+                    pass
+
+            # Check if this is a steer request (not a user cancellation)
+            steer_message = self._steer_requests.pop(record.agent_id, None)
+            if steer_message is not None:
+                # Steer: restart with the new message, preserve session history
+                _steered = True
+                logger.info(f"Sub-agent {record.agent_id!r} steered with new message")
+                self._start_background_run(
+                    record,
+                    task_override=steer_message,
+                    is_restart=True,
+                )
+            else:
+                # Regular cancellation
+                self.registry.transition(
+                    record.agent_id,
+                    SubagentState.CANCELLED,
+                    completed_at=time.time(),
+                )
+                self._persist_session_agent_state(record.agent_id)
+                result_obj = SubagentResult(
+                    agent_id=record.agent_id,
+                    label=record.label,
+                    state=SubagentState.CANCELLED,
+                    spawner_session_key=record.spawner_session_key,
+                    spawner_channel=record.spawner_channel,
+                    spawner_metadata=dict(record.spawner_metadata),
+                    spawner_reply_to=record.spawner_reply_to,
+                )
+                await self._results.put(result_obj)
+                logger.info(f"Sub-agent {record.agent_id!r} was cancelled")
+                await self._emit_event(SubagentEvent(
+                    event_type="cancelled",
+                    agent_id=record.agent_id,
+                    label=record.label,
+                    parent_id=record.parent_id,
+                    depth=record.depth,
+                    spawner_session_key=record.spawner_session_key,
+                    spawner_channel=record.spawner_channel,
+                ))
+
+        except Exception as exc:
+            if child_agent:
+                try:
+                    await child_agent.cleanup()
+                except Exception:
+                    pass
+            error_msg = f"{type(exc).__name__}: {exc}"
+            logger.error(f"Sub-agent {record.agent_id!r} failed: {error_msg}")
+            self.registry.transition(
+                record.agent_id,
+                SubagentState.FAILED,
+                error=error_msg,
+                completed_at=time.time(),
+            )
+            self._persist_session_agent_state(record.agent_id)
+            result_obj = SubagentResult(
+                agent_id=record.agent_id,
+                label=record.label,
+                state=SubagentState.FAILED,
+                error=error_msg,
+                spawner_session_key=record.spawner_session_key,
+                spawner_channel=record.spawner_channel,
+                spawner_metadata=dict(record.spawner_metadata),
+                spawner_reply_to=record.spawner_reply_to,
+            )
+            await self._results.put(result_obj)
+            await self._announce_result(result_obj)
+            await self._emit_event(SubagentEvent(
+                event_type="failed",
+                agent_id=record.agent_id,
+                label=record.label,
+                parent_id=record.parent_id,
+                depth=record.depth,
+                error=error_msg,
+                spawner_session_key=record.spawner_session_key,
+                spawner_channel=record.spawner_channel,
+            ))
+
+        finally:
+            if not _steered:
+                self._tasks.pop(record.agent_id, None)
+
+    @staticmethod
+    async def _run_process(
+        child_agent: Any,
+        task_text: str,
+        cfg: SubagentConfig,
+    ) -> str:
+        """Run the child agent process with optional extended thinking."""
+        if cfg.thinking_level and cfg.thinking_level != "off":
+            result_text, _ = await child_agent.process_with_thinking(task_text)
+        else:
+            result_text = await child_agent.process(task_text)
+        return result_text or ""
+
+    @staticmethod
+    def _extract_token_usage(child_agent: Any) -> Optional[TokenUsage]:
+        """Extract token usage from a child AgentLoop if available."""
+        try:
+            usage = child_agent.get_usage()
+            if not usage:
+                return None
+            return TokenUsage(
+                input_tokens=usage.get("input_tokens", 0),
+                output_tokens=usage.get("output_tokens", 0),
+                total_tokens=usage.get("total_tokens", 0),
+                cache_read_tokens=usage.get("cache_read_tokens", 0),
+                cache_write_tokens=usage.get("cache_write_tokens", 0),
+            )
+        except Exception:
+            return None
+
+    async def _announce_result(self, result: SubagentResult) -> None:
+        """Push result to spawner channel via bus injection (with retry/backoff).
+
+        Falls back silently if no bus is set or channel cannot be reached.
+        """
+        if not self._bus:
+            return
+        if not result.spawner_session_key or not result.spawner_channel:
+            return
+
+        # Build wake message
+        state = result.state.value
+        content_raw = result.result or result.error or "(no output)"
+        content = content_raw[:_WAKE_RESULT_TRUNCATE]
+        if len(content_raw) > _WAKE_RESULT_TRUNCATE:
+            content += f"\n... [{len(content_raw) - _WAKE_RESULT_TRUNCATE} chars omitted]"
+
+        elapsed_str = (
+            f" in {result.elapsed_seconds}s" if result.elapsed_seconds else ""
+        )
+        wake_content = (
+            f"[Sub-agent Completed] '{result.label}' ({result.agent_id}) "
+            f"has {state}{elapsed_str}.\n"
+            f"task_id: {result.agent_id}\n\n"
+            f"{content}"
+        )
+
+        from spoon_bot.bus.events import InboundMessage
+        wake_metadata = dict(result.spawner_metadata)
+        wake_metadata.update({
+            "is_subagent_wake": True,
+            "subagent_id": result.agent_id,
+        })
+        if result.spawner_reply_to is not None:
+            wake_metadata.setdefault("reply_to", result.spawner_reply_to)
+        wake_msg = InboundMessage(
+            content=wake_content,
+            channel=result.spawner_channel,
+            session_key=result.spawner_session_key,
+            sender_id="subagent_system",
+            metadata=wake_metadata,
+        )
+
+        for attempt in range(_ANNOUNCE_MAX_RETRIES):
+            try:
+                published = await self._bus.publish(wake_msg)
+                if published:
+                    logger.info(
+                        f"Wake announced for sub-agent {result.agent_id!r} "
+                        f"→ {result.spawner_channel} / {result.spawner_session_key}"
+                    )
+                    # Clear frozen result after announce if cleanup mode is DELETE
+                    record = self.registry.get(result.agent_id)
+                    if record and record.cleanup == CleanupMode.DELETE:
+                        self.registry.update_fields(
+                            result.agent_id,
+                            frozen_result_text=None,
+                        )
+                    return
+                # Queue full — retry after backoff
+                delay = _ANNOUNCE_BASE_DELAY * (2 ** attempt)
+                logger.warning(
+                    f"Bus queue full, retrying announce for {result.agent_id!r} "
+                    f"in {delay}s (attempt {attempt + 1}/{_ANNOUNCE_MAX_RETRIES})"
+                )
+                await asyncio.sleep(delay)
+            except Exception as exc:
+                logger.error(
+                    f"Announce failed for {result.agent_id!r} "
+                    f"(attempt {attempt + 1}): {exc}"
+                )
+                if attempt < _ANNOUNCE_MAX_RETRIES - 1:
+                    await asyncio.sleep(_ANNOUNCE_BASE_DELAY * (2 ** attempt))
+
+        logger.error(
+            f"Failed to announce sub-agent {result.agent_id!r} result "
+            f"after {_ANNOUNCE_MAX_RETRIES} attempts."
+        )
+
+    async def _emit_event(self, event: SubagentEvent) -> None:
+        """Notify all registered lifecycle event listeners."""
+        for listener in self._event_listeners:
+            try:
+                result = listener(event)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as exc:
+                logger.debug(f"Subagent event listener error: {exc}")
+
+    def _build_system_prompt(self, record: SubagentRecord) -> str:
+        """Build a focused system prompt for the sub-agent."""
+        specialization_line = ""
+        if record.config.specialization:
+            specialization_line = (
+                f"Specialization: {record.config.specialization}\n"
+                "Treat requests that fall in this specialization as your primary responsibility.\n"
+            )
+        return (
+            f"You are a sub-agent (ID: {record.agent_id}) working on a specific subtask.\n"
+            f"{specialization_line}"
+            f"Your task: {record.task}\n\n"
+            f"Guidelines:\n"
+            f"- Focus exclusively on this task.\n"
+            f"- Be concise and deliver concrete, actionable results.\n"
+            f"- Do not spawn further sub-agents unless strictly necessary.\n"
+            f"- When done, provide a clear summary of results."
+        )

--- a/spoon_bot/subagent/models.py
+++ b/spoon_bot/subagent/models.py
@@ -1,0 +1,448 @@
+"""Data models for the sub-agent system.
+
+Uses Optional[T] throughout for Python 3.9 compatibility —
+Pydantic evaluates field annotations at runtime, so str | None
+syntax (Python 3.10+) is not safe even with from __future__ import annotations.
+"""
+
+from __future__ import annotations
+
+import time
+from enum import Enum
+from typing import Any, List, Optional, Set
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+
+class SubagentState(str, Enum):
+    """Lifecycle states for a sub-agent."""
+
+    PENDING = "pending"       # Created, not yet started
+    RUNNING = "running"       # AgentLoop.process() in progress
+    COMPLETED = "completed"   # Finished successfully
+    FAILED = "failed"         # Finished with error
+    CANCELLED = "cancelled"   # Cancelled by parent or kill command
+
+
+class SpawnMode(str, Enum):
+    """Sub-agent spawn mode."""
+
+    RUN = "run"          # Ephemeral (default) — archived after archive_after_minutes
+    SESSION = "session"  # Persistent — own directory, never auto-archived
+
+
+class CleanupMode(str, Enum):
+    """How frozen_result_text is handled after result is announced to spawner."""
+
+    KEEP = "keep"      # Retain frozen_result_text after announce (default)
+    DELETE = "delete"  # Clear frozen_result_text after announce to free memory
+
+
+class RoutingMode(str, Enum):
+    """How a persistent specialist should be used when auto-routed."""
+
+    DIRECT = "direct"
+    ORCHESTRATED = "orchestrated"
+
+
+class TokenUsage(BaseModel):
+    """Token usage statistics for a sub-agent run."""
+
+    input_tokens: int = Field(default=0, description="Input/prompt tokens consumed")
+    output_tokens: int = Field(default=0, description="Output/completion tokens produced")
+    total_tokens: int = Field(default=0, description="Total tokens (input + output)")
+    cache_read_tokens: int = Field(default=0, description="Tokens read from cache")
+    cache_write_tokens: int = Field(default=0, description="Tokens written to cache")
+
+
+class SubagentConfig(BaseModel):
+    """Configuration for a spawned sub-agent.
+
+    All fields are optional — unset fields inherit from the parent agent.
+
+    When ``role`` is set, the SubagentTool will look up the matching
+    AgentRole in the catalog and automatically apply its ``system_prompt``,
+    ``tool_profile``, and ``max_iterations`` — mirroring opencode's
+    ``subagent_type`` parameter in task.ts.
+    """
+
+    role: Optional[str] = Field(
+        default=None,
+        description=(
+            "Specialized agent role from the catalog "
+            "(e.g. 'planner', 'backend', 'frontend', 'researcher', 'reviewer'). "
+            "When set, system_prompt, tool_profile, and max_iterations are "
+            "automatically loaded from the role definition unless explicitly overridden."
+        ),
+    )
+    model: Optional[str] = Field(
+        default=None,
+        description="LLM model to use (inherits from parent if None)",
+    )
+    provider: Optional[str] = Field(
+        default=None,
+        description="LLM provider (inherits from parent if None)",
+    )
+    api_key: Optional[str] = Field(
+        default=None,
+        description="API key (inherits from parent if None)",
+    )
+    base_url: Optional[str] = Field(
+        default=None,
+        description="Custom base URL (inherits from parent if None)",
+    )
+    max_iterations: int = Field(
+        default=15,
+        ge=1,
+        le=50,
+        description="Maximum tool call iterations",
+    )
+    system_prompt: Optional[str] = Field(
+        default=None,
+        description="Custom system prompt (auto-generated if None)",
+    )
+    tool_profile: str = Field(
+        default="core",
+        description="Tool profile: core, coding, research, or full",
+    )
+    enabled_tools: Optional[Set[str]] = Field(
+        default=None,
+        description="Explicit set of tool names to enable (None = profile default)",
+    )
+    enable_skills: bool = Field(
+        default=False,
+        description="Whether to enable the skill system (off by default for speed)",
+    )
+    context_window: Optional[int] = Field(
+        default=None,
+        description="Override context window in tokens",
+    )
+    thinking_level: Optional[str] = Field(
+        default=None,
+        description=(
+            "Extended thinking level for LLM models: "
+            "'basic' or 'extended'. None = disabled."
+        ),
+    )
+    timeout_seconds: Optional[int] = Field(
+        default=None,
+        ge=10,
+        le=3600,
+        description=(
+            "Hard wall-clock timeout in seconds for the sub-agent run. "
+            "None = no timeout (bounded only by max_iterations)."
+        ),
+    )
+    spawn_mode: SpawnMode = Field(
+        default=SpawnMode.RUN,
+        description=(
+            "Spawn mode: 'run' (ephemeral, archived after archive_after_minutes) "
+            "or 'session' (persistent named agent, never auto-archived)."
+        ),
+    )
+    cleanup: CleanupMode = Field(
+        default=CleanupMode.KEEP,
+        description=(
+            "Cleanup mode for frozen_result_text after announce: "
+            "'keep' (retain) or 'delete' (clear to free memory)."
+        ),
+    )
+    agent_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Name for a persistent session-mode agent. "
+            "Required when spawn_mode='session'. Used as directory name under agents/."
+        ),
+    )
+    specialization: Optional[str] = Field(
+        default=None,
+        description=(
+            "Short description of the specialist sub-agent's responsibility "
+            "(e.g. 'handle authentication and account recovery tasks')."
+        ),
+    )
+    auto_route: bool = Field(
+        default=False,
+        description=(
+            "Whether top-level user requests that strongly match this specialist "
+            "should be routed to it automatically."
+        ),
+    )
+    match_keywords: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Explicit keywords or phrases that should strongly match this "
+            "specialist for auto-routing."
+        ),
+    )
+    match_examples: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional example tasks that describe the kind of work this "
+            "specialist should receive."
+        ),
+    )
+    routing_mode: RoutingMode = Field(
+        default=RoutingMode.DIRECT,
+        description=(
+            "Routing strategy for auto-routed specialist work. "
+            "'direct' means route the whole request to this specialist."
+        ),
+    )
+
+
+class PersistentSubagentProfile(BaseModel):
+    """Persistent definition of a user-created subagent.
+
+    This is the durable routing object. Session/runs are ephemeral executions
+    of this profile, not the source of truth for its existence.
+    """
+
+    name: str = Field(description="Unique persistent subagent name")
+    role: Optional[str] = Field(default=None, description="Optional built-in role hint")
+    model: Optional[str] = Field(default=None, description="Preferred model override")
+    provider: Optional[str] = Field(default=None, description="Preferred provider override")
+    api_key: Optional[str] = Field(default=None, description="Optional API key override")
+    base_url: Optional[str] = Field(default=None, description="Optional base URL override")
+    max_iterations: int = Field(default=15, ge=1, le=50)
+    system_prompt: Optional[str] = Field(default=None)
+    tool_profile: str = Field(default="core")
+    enabled_tools: Optional[Set[str]] = Field(default=None)
+    enable_skills: bool = Field(default=False)
+    context_window: Optional[int] = Field(default=None)
+    thinking_level: Optional[str] = Field(default=None)
+    timeout_seconds: Optional[int] = Field(default=None, ge=10, le=3600)
+    cleanup: CleanupMode = Field(default=CleanupMode.KEEP)
+    specialization: Optional[str] = Field(default=None)
+    auto_route: bool = Field(default=False)
+    match_keywords: List[str] = Field(default_factory=list)
+    match_examples: List[str] = Field(default_factory=list)
+    routing_mode: RoutingMode = Field(default=RoutingMode.DIRECT)
+    created_at: float = Field(default_factory=time.time)
+    last_active_at: Optional[float] = Field(default=None)
+    last_run_agent_id: Optional[str] = Field(default=None)
+    last_run_state: Optional[str] = Field(default=None)
+
+    def to_subagent_config(self) -> "SubagentConfig":
+        """Convert this profile into a session-mode SubagentConfig."""
+        return SubagentConfig(
+            role=self.role,
+            model=self.model,
+            provider=self.provider,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            max_iterations=self.max_iterations,
+            system_prompt=self.system_prompt,
+            tool_profile=self.tool_profile,
+            enabled_tools=self.enabled_tools,
+            enable_skills=self.enable_skills,
+            context_window=self.context_window,
+            thinking_level=self.thinking_level,
+            timeout_seconds=self.timeout_seconds,
+            spawn_mode=SpawnMode.SESSION,
+            cleanup=self.cleanup,
+            agent_name=self.name,
+            specialization=self.specialization,
+            auto_route=self.auto_route,
+            match_keywords=list(self.match_keywords),
+            match_examples=list(self.match_examples),
+            routing_mode=self.routing_mode,
+        )
+
+    @classmethod
+    def from_subagent_config(
+        cls,
+        *,
+        name: str,
+        config: "SubagentConfig",
+        created_at: float | None = None,
+        last_active_at: float | None = None,
+        last_run_agent_id: str | None = None,
+        last_run_state: str | None = None,
+    ) -> "PersistentSubagentProfile":
+        """Create a persistent profile from a session-mode config."""
+        return cls(
+            name=name,
+            role=config.role,
+            model=config.model,
+            provider=config.provider,
+            api_key=config.api_key,
+            base_url=config.base_url,
+            max_iterations=config.max_iterations,
+            system_prompt=config.system_prompt,
+            tool_profile=config.tool_profile,
+            enabled_tools=config.enabled_tools,
+            enable_skills=config.enable_skills,
+            context_window=config.context_window,
+            thinking_level=config.thinking_level,
+            timeout_seconds=config.timeout_seconds,
+            cleanup=config.cleanup,
+            specialization=config.specialization,
+            auto_route=config.auto_route,
+            match_keywords=list(config.match_keywords),
+            match_examples=list(config.match_examples),
+            routing_mode=config.routing_mode,
+            created_at=created_at or time.time(),
+            last_active_at=last_active_at,
+            last_run_agent_id=last_run_agent_id,
+            last_run_state=last_run_state,
+        )
+
+
+class SubagentRecord(BaseModel):
+    """Tracks a single sub-agent's lifecycle."""
+
+    agent_id: str = Field(
+        default_factory=lambda: f"sub_{uuid4().hex[:10]}",
+        description="Unique identifier for this sub-agent",
+    )
+    parent_id: Optional[str] = Field(
+        default=None,
+        description="Parent agent_id (None = spawned by root agent)",
+    )
+    depth: int = Field(
+        default=0,
+        description="Spawn depth (0 = root, 1 = first generation, etc.)",
+    )
+    label: str = Field(
+        default="",
+        description="Short human-readable label for this sub-agent",
+    )
+    task: str = Field(
+        default="",
+        description="The task/message sent to this sub-agent",
+    )
+    state: SubagentState = Field(
+        default=SubagentState.PENDING,
+        description="Current lifecycle state",
+    )
+    result: Optional[str] = Field(
+        default=None,
+        description="Result text when state is COMPLETED",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Error message when state is FAILED",
+    )
+    config: SubagentConfig = Field(
+        default_factory=SubagentConfig,
+        description="Sub-agent configuration",
+    )
+    session_key: str = Field(
+        default="",
+        description="Session key for this sub-agent (auto-generated)",
+    )
+    # Spawner context — used for push-based wake continuation delivery
+    spawner_session_key: Optional[str] = Field(
+        default=None,
+        description=(
+            "Session key of the entity that spawned this sub-agent "
+            "(used for push-based result delivery)"
+        ),
+    )
+    spawner_channel: Optional[str] = Field(
+        default=None,
+        description=(
+            "Channel name (e.g. 'telegram:spoon_bot') of the spawner "
+            "(used for push-based result delivery)"
+        ),
+    )
+    spawner_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Original inbound metadata of the spawner, when available.",
+    )
+    spawner_reply_to: Optional[str] = Field(
+        default=None,
+        description="Original inbound message id that replies should target.",
+    )
+    # Effective model name (resolved at spawn time for display)
+    model_name: Optional[str] = Field(
+        default=None,
+        description="Effective model name used by this sub-agent (for display)",
+    )
+    # Token usage
+    token_usage: Optional[TokenUsage] = Field(
+        default=None,
+        description="Token usage statistics for this run",
+    )
+    # Wake continuation — latest frozen output for re-invocation
+    frozen_result_text: Optional[str] = Field(
+        default=None,
+        description=(
+            "Latest frozen completion text. Updated each time the sub-agent "
+            "completes (even if woken multiple times)."
+        ),
+    )
+    created_at: float = Field(
+        default_factory=time.time,
+        description="Unix timestamp when this record was created",
+    )
+    started_at: Optional[float] = Field(
+        default=None,
+        description="Unix timestamp when execution started",
+    )
+    completed_at: Optional[float] = Field(
+        default=None,
+        description="Unix timestamp when execution completed",
+    )
+    children: List[str] = Field(
+        default_factory=list,
+        description="List of child agent_ids spawned by this sub-agent",
+    )
+    # Spawn mode and cleanup (mirrored from config at spawn time for querying)
+    spawn_mode: SpawnMode = Field(
+        default=SpawnMode.RUN,
+        description="Spawn mode ('run' or 'session') — mirrored from config at spawn time",
+    )
+    cleanup: CleanupMode = Field(
+        default=CleanupMode.KEEP,
+        description="Cleanup mode ('keep' or 'delete') — mirrored from config at spawn time",
+    )
+    agent_name: Optional[str] = Field(
+        default=None,
+        description="Named agent name for session-mode agents",
+    )
+    agent_dir: Optional[str] = Field(
+        default=None,
+        description="Absolute path to the persistent agent directory (session mode only)",
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        """Auto-generate session_key from agent_id if not set."""
+        if not self.session_key:
+            self.session_key = f"subagent-{self.agent_id}"
+
+
+class SubagentResult(BaseModel):
+    """Result delivered back to the parent agent via the results queue."""
+
+    agent_id: str = Field(description="Sub-agent identifier")
+    label: str = Field(description="Sub-agent label")
+    state: SubagentState = Field(description="Final state")
+    result: Optional[str] = Field(default=None, description="Output text if completed")
+    error: Optional[str] = Field(default=None, description="Error message if failed")
+    elapsed_seconds: Optional[float] = Field(
+        default=None,
+        description="Wall-clock seconds from start to completion",
+    )
+    spawner_session_key: Optional[str] = Field(
+        default=None,
+        description="Session key of the spawner (for push-based routing)",
+    )
+    spawner_channel: Optional[str] = Field(
+        default=None,
+        description="Channel name of the spawner (for push-based routing)",
+    )
+    spawner_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Original inbound metadata of the spawner, when available.",
+    )
+    spawner_reply_to: Optional[str] = Field(
+        default=None,
+        description="Original inbound message id that replies should target.",
+    )
+    model_name: Optional[str] = Field(
+        default=None,
+        description="Effective model used by this sub-agent",
+    )

--- a/spoon_bot/subagent/persistence.py
+++ b/spoon_bot/subagent/persistence.py
@@ -1,0 +1,443 @@
+"""File-based JSON persistence for sub-agent records.
+
+Single-file approach following the OpenClaw pattern:
+  {workspace}/subagents/runs.json
+
+On-disk format:
+  {"version": 1, "runs": {"<agent_id>": {...SubagentRecord dump...}, ...}}
+
+Three components:
+  SubagentRunsFile  — Synchronous JSON file I/O (atomic writes, corrupt-file recovery)
+  restore_subagent_runs — Orphan reconciliation on startup
+  SubagentSweeper   — Async background task that archives old terminal records
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+from loguru import logger
+
+from spoon_bot.subagent.models import (
+    PersistentSubagentProfile,
+    SubagentRecord,
+    SubagentState,
+    SpawnMode,
+)
+
+if TYPE_CHECKING:
+    from spoon_bot.subagent.registry import SubagentRegistry
+    from spoon_bot.session.manager import SessionManager
+
+# Increment this when the on-disk schema changes in a backwards-incompatible way.
+_SCHEMA_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# SubagentRunsFile
+# ---------------------------------------------------------------------------
+
+
+class SubagentRunsFile:
+    """Read / write the runs.json persistence file.
+
+    All I/O is synchronous — callers (SubagentRegistry) already hold the
+    threading.RLock when calling these methods, so no additional locking
+    is required here.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def load(self) -> dict[str, SubagentRecord]:
+        """Load sub-agent records from disk.
+
+        Returns an empty dict if the file does not exist or is corrupt.
+        Silently handles forward-compatible schema versions (with a warning).
+        """
+        if not self._path.exists():
+            return {}
+
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+            data: dict[str, Any] = json.loads(raw)
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
+            logger.error(f"SubagentRunsFile: failed to read {self._path}: {exc}")
+            self._quarantine_corrupt_file()
+            return {}
+
+        version = data.get("version", 0)
+        if not isinstance(version, int) or version < 1:
+            logger.warning(
+                f"SubagentRunsFile: unknown version {version!r}; "
+                "treating file as corrupt"
+            )
+            self._quarantine_corrupt_file()
+            return {}
+
+        if version > _SCHEMA_VERSION:
+            logger.warning(
+                f"SubagentRunsFile: file version {version} is newer than "
+                f"code version {_SCHEMA_VERSION}; will attempt to load anyway"
+            )
+
+        # Future migration hook:
+        # if version < _SCHEMA_VERSION:
+        #     data = self._migrate(data, from_version=version)
+
+        runs_raw: dict[str, Any] = data.get("runs", {})
+        records: dict[str, SubagentRecord] = {}
+        skipped = 0
+        for agent_id, record_data in runs_raw.items():
+            try:
+                records[agent_id] = SubagentRecord.model_validate(record_data)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    f"SubagentRunsFile: skipping malformed record {agent_id!r}: {exc}"
+                )
+                skipped += 1
+
+        if skipped:
+            logger.warning(f"SubagentRunsFile: skipped {skipped} malformed record(s)")
+
+        logger.debug(
+            f"SubagentRunsFile: loaded {len(records)} record(s) from {self._path}"
+        )
+        return records
+
+    def save(self, records: dict[str, SubagentRecord]) -> None:
+        """Persist all records to disk atomically.
+
+        Uses write-to-temp + rename so that a crash during write never
+        leaves a half-written runs.json.
+
+        Errors are logged but never raised — persistence failures must
+        not break sub-agent logic.
+        """
+        payload: dict[str, Any] = {
+            "version": _SCHEMA_VERSION,
+            "runs": {
+                agent_id: record.model_dump(mode="json")
+                for agent_id, record in records.items()
+            },
+        }
+
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = self._path.with_suffix(".tmp")
+            tmp_path.write_text(
+                json.dumps(payload, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            # Atomic replace (POSIX-atomic; on Windows best-effort)
+            tmp_path.replace(self._path)
+            logger.debug(
+                f"SubagentRunsFile: persisted {len(records)} record(s) "
+                f"to {self._path}"
+            )
+        except OSError as exc:
+            logger.error(
+                f"SubagentRunsFile: failed to persist to {self._path}: {exc}"
+            )
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _quarantine_corrupt_file(self) -> None:
+        """Rename the corrupt file so it is not lost but won't block startup."""
+        backup = self._path.with_suffix(".corrupt.json")
+        try:
+            self._path.rename(backup)
+            logger.warning(
+                f"SubagentRunsFile: corrupt file moved to {backup} "
+                "(will start with empty registry)"
+            )
+        except OSError as exc:
+            logger.warning(
+                f"SubagentRunsFile: could not quarantine corrupt file: {exc}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Persistent agent directory manager
+# ---------------------------------------------------------------------------
+
+
+class AgentDirectory:
+    """Manages the on-disk directory for a persistent (session-mode) agent.
+
+    Directory layout:
+        {workspace}/agents/{name}/
+        ├── agent.json       Agent metadata (config, stats, timestamps)
+        └── sessions/        Session transcript files for this agent
+    """
+
+    def __init__(self, workspace: Path, agent_name: str) -> None:
+        self.root = Path(workspace) / "agents" / agent_name
+        self.agent_name = agent_name
+
+    def ensure(self) -> Path:
+        """Create the directory structure and return the root path."""
+        self.root.mkdir(parents=True, exist_ok=True)
+        (self.root / "sessions").mkdir(exist_ok=True)
+        return self.root
+
+    def save_agent_json(self, record: SubagentRecord) -> None:
+        """Persist agent metadata to agent.json."""
+        profile = PersistentSubagentProfile.from_subagent_config(
+            name=self.agent_name,
+            config=record.config,
+            created_at=record.created_at,
+            last_active_at=record.completed_at or record.started_at or record.created_at,
+            last_run_agent_id=record.agent_id,
+            last_run_state=record.state.value,
+        )
+        self.save_profile_json(profile)
+
+    def save_profile_json(self, profile: PersistentSubagentProfile) -> None:
+        """Persist a persistent subagent profile to agent.json."""
+        agent_json_path = self.root / "agent.json"
+        try:
+            agent_json_path.write_text(
+                json.dumps(profile.model_dump(mode="json"), indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            logger.debug(f"AgentDirectory: saved agent.json for {profile.name!r}")
+        except OSError as exc:
+            logger.error(f"AgentDirectory: failed to save agent.json for {profile.name!r}: {exc}")
+
+    def load_agent_json(self) -> Optional[dict[str, Any]]:
+        """Load raw agent.json, returning None if not found or corrupt."""
+        agent_json_path = self.root / "agent.json"
+        if not agent_json_path.exists():
+            return None
+        try:
+            return json.loads(agent_json_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.error(f"AgentDirectory: failed to load agent.json for {self.agent_name!r}: {exc}")
+            return None
+
+    def load_profile_json(self) -> Optional[PersistentSubagentProfile]:
+        """Load agent.json as a PersistentSubagentProfile."""
+        data = self.load_agent_json()
+        if data is None:
+            return None
+        try:
+            # Backward-compat: old files used agent_id/model/state fields only.
+            profile_data = dict(data)
+            profile_data.pop("agent_id", None)
+            profile_data.pop("spawn_mode", None)
+            profile_data.pop("state", None)
+            profile_data.pop("total_tokens", None)
+            if "name" not in profile_data:
+                profile_data["name"] = self.agent_name
+            return PersistentSubagentProfile.model_validate(profile_data)
+        except Exception as exc:
+            logger.error(f"AgentDirectory: failed to parse profile for {self.agent_name!r}: {exc}")
+            return None
+
+    def exists(self) -> bool:
+        """Return True if the agent directory exists."""
+        return self.root.exists()
+
+    @staticmethod
+    def list_agents(workspace: Path) -> list[str]:
+        """List all persistent agent directories under {workspace}/agents/."""
+        agents_dir = Path(workspace) / "agents"
+        if not agents_dir.exists():
+            return []
+        return sorted(d.name for d in agents_dir.iterdir() if d.is_dir())
+
+    @staticmethod
+    def list_profiles(workspace: Path) -> list[PersistentSubagentProfile]:
+        """Load all persistent subagent profiles from disk."""
+        profiles: list[PersistentSubagentProfile] = []
+        for name in AgentDirectory.list_agents(workspace):
+            profile = AgentDirectory(workspace, name).load_profile_json()
+            if profile is not None:
+                profiles.append(profile)
+        return profiles
+
+
+# ---------------------------------------------------------------------------
+# Startup restoration
+# ---------------------------------------------------------------------------
+
+
+def restore_subagent_runs(
+    records: dict[str, SubagentRecord],
+) -> dict[str, SubagentRecord]:
+    """Reconcile loaded records after a process restart.
+
+    Any record still in PENDING or RUNNING state was orphaned by a process
+    crash or SIGKILL.  Transition those to FAILED with a diagnostic message
+    so the user sees a clear explanation rather than a stale "running" entry.
+
+    The dict is mutated in-place and also returned for convenience.
+    """
+    now = time.time()
+    orphaned = 0
+
+    for record in records.values():
+        if record.state in (SubagentState.PENDING, SubagentState.RUNNING):
+            record.state = SubagentState.FAILED
+            record.error = (
+                "Orphaned: the process that was running this sub-agent restarted"
+            )
+            if record.completed_at is None:
+                record.completed_at = now
+            orphaned += 1
+
+    if orphaned:
+        logger.warning(
+            f"restore_subagent_runs: marked {orphaned} orphaned "
+            "record(s) as FAILED (process restarted)"
+        )
+    else:
+        logger.debug("restore_subagent_runs: no orphaned records found")
+
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Background sweeper
+# ---------------------------------------------------------------------------
+
+
+class SubagentSweeper:
+    """Periodic asyncio task that removes stale terminal records.
+
+    Modeled on HeartbeatService: asyncio loop with graceful start/stop,
+    configurable interval, and silent error recovery.
+    """
+
+    _TERMINAL_STATES = frozenset(
+        [SubagentState.COMPLETED, SubagentState.FAILED, SubagentState.CANCELLED]
+    )
+
+    def __init__(
+        self,
+        registry: SubagentRegistry,
+        session_manager: Optional[SessionManager] = None,
+        archive_after_minutes: int = 60,
+        interval_seconds: int = 60,
+    ) -> None:
+        self._registry = registry
+        self._session_manager = session_manager
+        self._archive_threshold = archive_after_minutes * 60.0
+        self._interval = interval_seconds
+        self._running = False
+        self._task: asyncio.Task[None] | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start the background sweep loop."""
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop(), name="subagent-sweeper")
+        logger.info(
+            f"SubagentSweeper: started "
+            f"(interval={self._interval}s, "
+            f"archive_after={self._archive_threshold / 60:.0f}m)"
+        )
+
+    async def stop(self) -> None:
+        """Stop the sweep loop gracefully."""
+        self._running = False
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+        logger.info("SubagentSweeper: stopped")
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    # ------------------------------------------------------------------
+    # Internal loop
+    # ------------------------------------------------------------------
+
+    async def _loop(self) -> None:
+        while self._running:
+            try:
+                await asyncio.sleep(self._interval)
+                if not self._running:
+                    break
+                self._sweep()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:  # noqa: BLE001
+                logger.error(f"SubagentSweeper: unexpected error: {exc}")
+
+    def _sweep(self) -> None:
+        """Remove terminal run-mode records older than the archive threshold.
+
+        Session-mode agents are skipped — they are never auto-archived.
+        Before removing a record, its session data is archived (renamed with
+        a .deleted.{timestamp} suffix rather than hard-deleted) for audit.
+        """
+        now = time.time()
+        to_remove: list[str] = []
+        session_keys_to_archive: list[str] = []
+
+        for record in self._registry.list_all():
+            # Never archive persistent session-mode agents
+            if record.spawn_mode == SpawnMode.SESSION:
+                continue
+            if record.state not in self._TERMINAL_STATES:
+                continue
+            age = now - (record.completed_at or record.created_at)
+            if age >= self._archive_threshold:
+                to_remove.append(record.agent_id)
+                session_keys_to_archive.append(record.session_key)
+
+        # Archive session files before removing registry records
+        for session_key in session_keys_to_archive:
+            self._archive_session(session_key)
+
+        for agent_id in to_remove:
+            self._registry.remove(agent_id)
+
+        if to_remove:
+            logger.info(
+                f"SubagentSweeper: archived {len(to_remove)} stale record(s)"
+            )
+        else:
+            logger.debug("SubagentSweeper: sweep complete, no stale records")
+
+    def _archive_session(self, session_key: str) -> None:
+        """Archive session data via the session manager.
+
+        For FileSessionStore this renames the session files to
+        .deleted.{timestamp} rather than deleting them.
+        For other backends the default delete behaviour is used.
+        """
+        if self._session_manager is None:
+            return
+        try:
+            self._session_manager.archive(session_key)
+        except Exception as exc:
+            logger.debug(
+                f"SubagentSweeper: error archiving session {session_key!r}: {exc}"
+            )

--- a/spoon_bot/subagent/registry.py
+++ b/spoon_bot/subagent/registry.py
@@ -1,0 +1,349 @@
+"""Sub-agent registry — lifecycle state tracking with optional JSON persistence."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from spoon_bot.subagent.models import SubagentRecord, SubagentState
+
+if TYPE_CHECKING:
+    from spoon_bot.subagent.persistence import SubagentRunsFile
+
+
+# Valid state transitions
+_VALID_TRANSITIONS: dict[SubagentState, set[SubagentState]] = {
+    SubagentState.PENDING: {SubagentState.RUNNING, SubagentState.CANCELLED},
+    SubagentState.RUNNING: {
+        SubagentState.COMPLETED,
+        SubagentState.FAILED,
+        SubagentState.CANCELLED,
+    },
+    # Terminal states — no further transitions
+    SubagentState.COMPLETED: set(),
+    SubagentState.FAILED: set(),
+    SubagentState.CANCELLED: set(),
+}
+
+_UNSET = object()
+
+
+class SubagentRegistry:
+    """In-memory registry of sub-agent records with optional JSON persistence.
+
+    Thread-safe via RLock (matching SessionManager pattern).
+    Tracks the full lifecycle of each sub-agent and maintains
+    parent-child relationships.
+
+    When *runs_file* is provided the registry loads previous records from
+    disk on construction (orphan records are reconciled to FAILED) and
+    persists the full records dict to disk after every mutation.
+    Persistence errors are logged but never raised.
+    """
+
+    def __init__(
+        self,
+        runs_file: SubagentRunsFile | None = None,
+    ) -> None:
+        self._records: dict[str, SubagentRecord] = {}
+        self._lock = threading.RLock()
+        self._runs_file = runs_file
+
+        if self._runs_file is not None:
+            self._load_and_restore()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+
+    def _load_and_restore(self) -> None:
+        """Load records from disk and reconcile orphans.
+
+        Called once during __init__ while no other threads are active yet,
+        so we access _records directly without the lock.
+        """
+        from spoon_bot.subagent.persistence import restore_subagent_runs
+
+        loaded = self._runs_file.load()  # type: ignore[union-attr]
+        restored = restore_subagent_runs(loaded)
+        self._records = restored
+        # Write reconciled state back immediately
+        try:
+            self._runs_file.save(self._records)  # type: ignore[union-attr]
+        except Exception as exc:  # noqa: BLE001
+            logger.error(f"SubagentRegistry: initial persist failed: {exc}")
+
+        if restored:
+            logger.info(
+                f"SubagentRegistry: restored {len(restored)} record(s) from "
+                f"{self._runs_file.path}"  # type: ignore[union-attr]
+            )
+
+    def _persist(self) -> None:
+        """Persist current records to disk.
+
+        MUST be called while self._lock is already held.
+        Errors are logged but never raised so that persistence failures
+        cannot break sub-agent logic.
+        """
+        if self._runs_file is None:
+            return
+        try:
+            self._runs_file.save(self._records)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(f"SubagentRegistry: persist failed: {exc}")
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def register(self, record: SubagentRecord) -> None:
+        """Register a new sub-agent record and link it to its parent."""
+        with self._lock:
+            self._records[record.agent_id] = record
+            # Establish parent-child relationship
+            if record.parent_id and record.parent_id in self._records:
+                parent = self._records[record.parent_id]
+                if record.agent_id not in parent.children:
+                    parent.children.append(record.agent_id)
+                    logger.debug(
+                        f"Registered sub-agent {record.agent_id} "
+                        f"as child of {record.parent_id}"
+                    )
+            self._persist()
+
+    def get(self, agent_id: str) -> SubagentRecord | None:
+        """Return the record for *agent_id*, or None if not found."""
+        with self._lock:
+            return self._records.get(agent_id)
+
+    def remove(self, agent_id: str) -> bool:
+        """Remove a record and unlink it from its parent's children list."""
+        with self._lock:
+            record = self._records.pop(agent_id, None)
+            if record is None:
+                return False
+            if record.parent_id and record.parent_id in self._records:
+                parent = self._records[record.parent_id]
+                try:
+                    parent.children.remove(agent_id)
+                except ValueError:
+                    pass
+            self._persist()
+            return True
+
+    def update_fields(self, agent_id: str, **kwargs: Any) -> bool:
+        """Update record fields without changing lifecycle state."""
+        with self._lock:
+            record = self._records.get(agent_id)
+            if record is None:
+                return False
+            for key, value in kwargs.items():
+                if hasattr(record, key):
+                    setattr(record, key, value)
+                else:
+                    logger.debug(f"Unknown field '{key}' in update_fields kwargs")
+            self._persist()
+            return True
+
+    # ------------------------------------------------------------------
+    # State machine
+    # ------------------------------------------------------------------
+
+    def transition(
+        self,
+        agent_id: str,
+        new_state: SubagentState,
+        **kwargs: Any,
+    ) -> bool:
+        """Transition *agent_id* to *new_state* with optional field updates.
+
+        Keyword arguments are applied to the record as attribute updates
+        (e.g. ``result="..."`` or ``started_at=time.time()``).
+
+        Returns True on success, False if the agent is not found or the
+        transition is invalid.
+        """
+        with self._lock:
+            record = self._records.get(agent_id)
+            if record is None:
+                logger.warning(f"Transition failed: agent {agent_id} not found")
+                return False
+
+            allowed = _VALID_TRANSITIONS.get(record.state, set())
+            if new_state not in allowed:
+                logger.warning(
+                    f"Invalid transition {record.state!r} → {new_state!r} "
+                    f"for sub-agent {agent_id}"
+                )
+                return False
+
+            record.state = new_state
+            for key, value in kwargs.items():
+                if hasattr(record, key):
+                    setattr(record, key, value)
+                else:
+                    logger.debug(f"Unknown field '{key}' in transition kwargs")
+
+            logger.debug(
+                f"Sub-agent {agent_id}: {record.state!r} → {new_state!r}"
+            )
+            self._persist()
+            return True
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def list_all(self) -> list[SubagentRecord]:
+        """Return a snapshot of all records."""
+        with self._lock:
+            return list(self._records.values())
+
+    def list_by_parent(self, parent_id: str) -> list[SubagentRecord]:
+        """Return all direct children of *parent_id*."""
+        with self._lock:
+            return [
+                r for r in self._records.values()
+                if r.parent_id == parent_id
+            ]
+
+    def count_active_children(self, parent_id: str) -> int:
+        """Count children of *parent_id* that are PENDING or RUNNING."""
+        with self._lock:
+            return sum(
+                1
+                for r in self._records.values()
+                if r.parent_id == parent_id
+                and r.state in (SubagentState.PENDING, SubagentState.RUNNING)
+            )
+
+    def count_active_total(self) -> int:
+        """Count all PENDING or RUNNING sub-agents across the registry."""
+        with self._lock:
+            return sum(
+                1
+                for r in self._records.values()
+                if r.state in (SubagentState.PENDING, SubagentState.RUNNING)
+            )
+
+    def count_pending_descendants(self, agent_id: str) -> int:
+        """Count PENDING or RUNNING descendants of *agent_id* (recursive BFS)."""
+        with self._lock:
+            root = self._records.get(agent_id)
+            if root is None:
+                return 0
+            count = 0
+            stack = list(root.children)
+            while stack:
+                child_id = stack.pop()
+                child = self._records.get(child_id)
+                if child:
+                    if child.state in (SubagentState.PENDING, SubagentState.RUNNING):
+                        count += 1
+                    stack.extend(child.children)
+            return count
+
+    def get_descendants(self, agent_id: str) -> list[SubagentRecord]:
+        """Return all descendants of *agent_id* via BFS traversal."""
+        with self._lock:
+            root = self._records.get(agent_id)
+            if root is None:
+                return []
+
+            result: list[SubagentRecord] = []
+            stack = list(root.children)
+            while stack:
+                child_id = stack.pop()
+                child = self._records.get(child_id)
+                if child:
+                    result.append(child)
+                    stack.extend(child.children)
+            return result
+
+    def prepare_for_resume(
+        self,
+        agent_id: str,
+        *,
+        task: str,
+        label: str,
+        parent_id: str | None | object = _UNSET,
+        spawner_session_key: str | None | object = _UNSET,
+        spawner_channel: str | None | object = _UNSET,
+        spawner_metadata: Any = _UNSET,
+        spawner_reply_to: str | None | object = _UNSET,
+        model_name: str | None | object = _UNSET,
+        config: Any = _UNSET,
+    ) -> bool:
+        """Reset a terminal session-mode agent for re-invocation.
+
+        Bypasses the normal state machine (which forbids terminal → PENDING)
+        because session-mode agents are designed to be re-invoked.
+
+        Returns True on success, False if the agent is not found.
+        """
+        with self._lock:
+            record = self._records.get(agent_id)
+            if record is None:
+                return False
+            old_parent_id = record.parent_id
+            old_depth = record.depth
+            record.task = task
+            record.label = label
+            if parent_id is not _UNSET:
+                record.parent_id = parent_id
+                if old_parent_id != parent_id:
+                    if old_parent_id and old_parent_id in self._records:
+                        old_parent = self._records[old_parent_id]
+                        try:
+                            old_parent.children.remove(agent_id)
+                        except ValueError:
+                            pass
+                    if parent_id and parent_id in self._records:
+                        new_parent = self._records[parent_id]
+                        if agent_id not in new_parent.children:
+                            new_parent.children.append(agent_id)
+                        record.depth = new_parent.depth + 1
+                    else:
+                        record.depth = 1
+                    depth_delta = record.depth - old_depth
+                    if depth_delta != 0:
+                        stack = list(record.children)
+                        while stack:
+                            child_id = stack.pop()
+                            child = self._records.get(child_id)
+                            if child is None:
+                                continue
+                            child.depth = max(1, child.depth + depth_delta)
+                            stack.extend(child.children)
+            if spawner_session_key is not _UNSET:
+                record.spawner_session_key = spawner_session_key
+            if spawner_channel is not _UNSET:
+                record.spawner_channel = spawner_channel
+            if spawner_metadata is not _UNSET:
+                record.spawner_metadata = dict(spawner_metadata or {})
+            if spawner_reply_to is not _UNSET:
+                record.spawner_reply_to = spawner_reply_to
+            if model_name is not _UNSET:
+                record.model_name = model_name
+            if config is not _UNSET:
+                record.config = config
+            record.state = SubagentState.PENDING
+            record.result = None
+            record.error = None
+            record.started_at = None
+            record.completed_at = None
+            record.token_usage = None
+            record.frozen_result_text = None
+            self._persist()
+            return True
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._records)
+
+    def __repr__(self) -> str:
+        with self._lock:
+            return f"SubagentRegistry(records={len(self._records)})"

--- a/spoon_bot/subagent/tools.py
+++ b/spoon_bot/subagent/tools.py
@@ -1,0 +1,750 @@
+"""LLM-facing tool definitions for sub-agent spawning and management.
+
+Design notes
+------------
+The ``SubagentTool`` is the LLM-facing interface for the sub-agent system.
+It mirrors two key patterns from the reference repos:
+
+* **opencode** ``task.ts`` / ``task.txt``:
+  - The tool description dynamically lists all available agent roles
+    (mirrors the ``{agents}`` placeholder in task.txt).
+  - A ``role`` parameter lets the LLM pick a specialised agent type
+    (mirrors ``subagent_type`` in task.ts).
+  - When a role is specified, its ``system_prompt``, ``tool_profile``,
+    and ``max_iterations`` are loaded from the catalog automatically.
+
+* **openclaw** ``sessions-spawn-tool.ts`` / ``subagents-tool.ts``:
+  - ``label`` and ``model`` parameters on spawn (mirrors sessions_spawn).
+  - ``list_roles`` action so the LLM can query available roles at runtime.
+  - ``status`` / ``cancel`` / ``steer`` management actions (mirrors subagents tool).
+"""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from loguru import logger
+
+from spoon_bot.agent.tools.base import Tool
+from spoon_bot.subagent.catalog import AGENT_CATALOG, format_roles_for_prompt, get_role
+from spoon_bot.subagent.models import CleanupMode, RoutingMode, SpawnMode, SubagentConfig
+
+if TYPE_CHECKING:
+    from spoon_bot.subagent.manager import SubagentManager
+
+# Maximum characters of a sub-agent result surfaced to the parent LLM.
+_RESULT_TRUNCATE_LEN = 3000
+
+
+class SubagentTool(Tool):
+    """Spawn and manage sub-agents from within the LLM reasoning loop.
+
+    Sub-agents are independent AgentLoop instances that run concurrently
+    in the background. Use this tool to decompose complex tasks into
+    parallel subtasks, then collect their results.
+
+    Actions
+    -------
+    spawn   — Create and start a sub-agent with a specific task.
+    status  — List all sub-agents with state, model, and pending descendants.
+    results — Collect completed sub-agent results (optionally with timeout).
+    wait    — Block until a result arrives (configurable timeout).
+    cancel  — Cancel a sub-agent and all its descendants (cascade kill).
+    kill    — Alias for cancel (cascade).
+    steer   — Redirect a running sub-agent with a new message.
+    info    — Show detailed metadata for a specific sub-agent.
+    """
+
+    def __init__(
+        self,
+        manager: SubagentManager | None = None,
+        parent_agent_id: str | None = None,
+    ) -> None:
+        self._manager = manager
+        self._parent_agent_id = parent_agent_id
+        self._spawner_context_bound = False
+        self._spawner_session_key: str | None = None
+        self._spawner_channel: str | None = None
+
+    def set_manager(self, manager: SubagentManager) -> None:
+        """Inject the SubagentManager after tool registration."""
+        self._manager = manager
+
+    def set_spawner_context(
+        self,
+        *,
+        session_key: str | None,
+        channel: str | None,
+    ) -> None:
+        """Bind this tool instance to the session/channel that owns it."""
+        self._spawner_context_bound = True
+        self._spawner_session_key = session_key
+        self._spawner_channel = channel
+
+    def _effective_spawner_session_key(self) -> str | None:
+        if self._spawner_context_bound:
+            return self._spawner_session_key
+        if self._manager is None:
+            return None
+        return getattr(self._manager, "_current_spawner_session", None)
+
+    def _effective_spawner_channel(self) -> str | None:
+        if self._spawner_context_bound:
+            return self._spawner_channel
+        if self._manager is None:
+            return None
+        return getattr(self._manager, "_current_spawner_channel", None)
+
+    # ------------------------------------------------------------------
+    # Tool ABC
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "spawn"
+
+    @property
+    def description(self) -> str:
+        # Dynamically inject the role catalog — mirrors opencode task.txt's {agents} block.
+        roles_block = format_roles_for_prompt()
+        return (
+            "Spawn and manage specialised sub-agents to handle subtasks.\n\n"
+            "## Orchestration (LLM decides the order autonomously)\n"
+            "For complex tasks (e.g. 'build a user management system'), decompose the\n"
+            "work and delegate to specialised sub-agents using the `role` parameter.\n"
+            "You decide which roles to use and in what order — there is no fixed pipeline.\n\n"
+            "## Available agent roles (use role=<name> when spawning)\n"
+            f"{roles_block}\n\n"
+            "## Actions\n"
+            "  spawn      — Start a sub-agent (use `role` to pick a specialised type)\n"
+            "  list_roles — Show all available roles with descriptions\n"
+            "  resume     — Re-invoke a persistent session-mode agent with a new task\n"
+            "  status     — Show all sub-agents, states, models, and pending descendants\n"
+            "  results    — Collect any completed sub-agent results\n"
+            "  wait       — Wait up to timeout seconds for a result\n"
+            "  cancel     — Cascade-cancel a sub-agent and its descendants\n"
+            "  kill       — Alias for cancel (cascade)\n"
+            "  steer      — Redirect a running sub-agent with new instructions\n"
+            "  info       — Show detailed metadata for a specific sub-agent\n\n"
+            "## Orchestration example\n"
+            "  spawn(action='spawn', role='planner', task='Analyse requirements for: ...')\n"
+            "  spawn(action='wait', timeout=120)   # wait for planner\n"
+            "  spawn(action='spawn', role='backend', task='Implement API based on plan: ...')\n"
+            "  spawn(action='spawn', role='frontend', task='Build UI based on plan: ...')\n"
+            "  spawn(action='wait', timeout=180)   # wait for both\n\n"
+            "Tip: launch multiple independent sub-agents in parallel (one tool call each)\n"
+            "to maximise throughput. Wait for results before spawning dependents."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        # Build the role enum dynamically from the catalog
+        role_names = list(AGENT_CATALOG.keys())
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "spawn", "list_roles", "resume", "status", "results",
+                        "wait", "cancel", "kill", "steer", "info",
+                    ],
+                    "description": (
+                        "Action to perform. Use 'list_roles' to see all available "
+                        "specialised agent roles before spawning."
+                    ),
+                },
+                # ---- role parameter (mirrors opencode's subagent_type) ----
+                "role": {
+                    "type": "string",
+                    "enum": role_names,
+                    "description": (
+                        "Specialised agent role to use for this sub-agent. "
+                        "When set, the role's system_prompt, tool_profile, and "
+                        "max_iterations are loaded automatically from the catalog. "
+                        f"Available roles: {', '.join(role_names)}. "
+                        "Use 'list_roles' action to see full descriptions."
+                    ),
+                },
+                "task": {
+                    "type": "string",
+                    "description": (
+                        "Task description for the sub-agent (required for 'spawn'). "
+                        "Be specific and include all context the sub-agent needs — "
+                        "it starts with a fresh context unless task_id is provided."
+                    ),
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Short (3-5 word) label to identify this sub-agent",
+                },
+                "task_id": {
+                    "type": "string",
+                    "description": (
+                        "Resume a previous sub-agent session by its agent_id. "
+                        "The sub-agent will continue with its previous conversation "
+                        "context instead of starting fresh. "
+                        "Mirrors opencode task.ts task_id parameter."
+                    ),
+                },
+                "agent_id": {
+                    "type": "string",
+                    "description": (
+                        "Sub-agent ID (for 'cancel', 'kill', 'wait', "
+                        "'steer', 'info')"
+                    ),
+                },
+                "model": {
+                    "type": "string",
+                    "description": (
+                        "Override LLM model for the sub-agent "
+                        "(inherits from parent if not set)"
+                    ),
+                },
+                "tool_profile": {
+                    "type": "string",
+                    "description": (
+                        "Override tool profile for the sub-agent "
+                        "(core, coding, research, full). "
+                        "Ignored when 'role' is set unless explicitly provided."
+                    ),
+                },
+                "thinking": {
+                    "type": "string",
+                    "description": (
+                        "Enable extended thinking for supported models. "
+                        "Values: 'basic' or 'extended'."
+                    ),
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "description": (
+                        "Hard wall-clock timeout in seconds for the sub-agent "
+                        "(10-3600). None = no timeout."
+                    ),
+                },
+                "timeout": {
+                    "type": "number",
+                    "description": (
+                        "Seconds to wait for results "
+                        "(for 'results' and 'wait'; default 0 = non-blocking)"
+                    ),
+                },
+                "message": {
+                    "type": "string",
+                    "description": "New instruction message (for 'steer')",
+                },
+                "spawn_mode": {
+                    "type": "string",
+                    "enum": ["run", "session"],
+                    "description": (
+                        "Spawn mode: 'run' (ephemeral, default) or "
+                        "'session' (persistent named agent, never auto-archived). "
+                        "Session agents retain conversation context between invocations."
+                    ),
+                },
+                "cleanup": {
+                    "type": "string",
+                    "enum": ["keep", "delete"],
+                    "description": (
+                        "What to do with frozen_result_text after announcing to spawner: "
+                        "'keep' (default) or 'delete' (clear to free memory)."
+                    ),
+                },
+                "agent_name": {
+                    "type": "string",
+                    "description": (
+                        "Name for a persistent session-mode agent "
+                        "(required when spawn_mode='session'). "
+                        "Use only letters, digits, hyphens, and underscores."
+                    ),
+                },
+                "specialization": {
+                    "type": "string",
+                    "description": (
+                        "Short description of what this persistent specialist should "
+                        "handle (for auto-routing and user visibility)."
+                    ),
+                },
+                "auto_route": {
+                    "type": "boolean",
+                    "description": (
+                        "Whether matching top-level user requests should be routed "
+                        "to this persistent specialist automatically."
+                    ),
+                },
+                "match_keywords": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Keywords or phrases that strongly indicate this specialist "
+                        "should handle the task."
+                    ),
+                },
+                "match_examples": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Optional example tasks for this specialist's routing profile."
+                    ),
+                },
+                "routing_mode": {
+                    "type": "string",
+                    "enum": ["direct", "orchestrated"],
+                    "description": (
+                        "How this specialist should be used when auto-routed. "
+                        "'direct' routes the whole request straight to it."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        if not self._manager:
+            return (
+                "Error: Sub-agent system is not initialized. "
+                "SubagentManager was not injected into this tool."
+            )
+
+        action = kwargs.get("action", "status")
+
+        if action == "spawn":
+            return await self._handle_spawn(kwargs)
+        elif action == "list_roles":
+            return self._handle_list_roles()
+        elif action == "resume":
+            return await self._handle_resume(kwargs)
+        elif action == "status":
+            return self._handle_status()
+        elif action == "results":
+            return await self._handle_results(kwargs)
+        elif action == "wait":
+            return await self._handle_wait(kwargs)
+        elif action in ("cancel", "kill"):
+            return await self._handle_cancel(kwargs)
+        elif action == "steer":
+            return await self._handle_steer(kwargs)
+        elif action == "info":
+            return await self._handle_info(kwargs)
+        else:
+            return f"Unknown action: {action!r}"
+
+    # ------------------------------------------------------------------
+    # Action handlers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _handle_list_roles() -> str:
+        """Return a formatted list of all available agent roles.
+
+        Mirrors openclaw's subagents tool 'list' action and opencode's
+        dynamic {agents} block in task.txt — gives the LLM a runtime
+        view of what specialised roles are available.
+        """
+        lines = ["Available agent roles:\n"]
+        for role in AGENT_CATALOG.values():
+            lines.append(f"  {role.name}")
+            lines.append(f"    Description:  {role.description}")
+            lines.append(f"    Tool profile: {role.tool_profile}")
+            lines.append(f"    Max steps:    {role.max_iterations}")
+            lines.append("")
+        lines.append(
+            "Usage: spawn(action='spawn', role='<name>', task='<detailed task>')"
+        )
+        return "\n".join(lines)
+
+    async def _handle_spawn(self, kwargs: dict[str, Any]) -> str:
+        task = kwargs.get("task")
+        if not task:
+            return "Error: 'task' is required for the 'spawn' action."
+        task_id = kwargs.get("task_id")
+
+        config = SubagentConfig()
+
+        # ----------------------------------------------------------------
+        # Role-based configuration (mirrors opencode task.ts subagent_type)
+        # When a role is specified, load its catalog defaults first, then
+        # allow explicit kwargs to override individual fields.
+        # ----------------------------------------------------------------
+        role_name = kwargs.get("role")
+        role_applied: str | None = None
+        if role_name:
+            agent_role = get_role(role_name)
+            if agent_role is None:
+                available = ", ".join(AGENT_CATALOG.keys())
+                return (
+                    f"Error: unknown role {role_name!r}. "
+                    f"Available roles: {available}. "
+                    f"Use spawn(action='list_roles') to see descriptions."
+                )
+            # Apply role defaults
+            config.role = agent_role.name
+            config.system_prompt = agent_role.system_prompt
+            config.tool_profile = agent_role.tool_profile
+            config.max_iterations = agent_role.max_iterations
+            if agent_role.thinking_level:
+                config.thinking_level = agent_role.thinking_level
+            role_applied = agent_role.name
+            logger.info(
+                f"Applying role '{role_name}': "
+                f"profile={agent_role.tool_profile}, "
+                f"max_iter={agent_role.max_iterations}"
+            )
+
+        # Explicit kwargs override role defaults (caller can fine-tune)
+        if kwargs.get("model"):
+            config.model = kwargs["model"]
+        # Only override tool_profile if explicitly provided AND no role set
+        # (or caller explicitly wants to override the role's profile)
+        if kwargs.get("tool_profile") and not role_name:
+            config.tool_profile = kwargs["tool_profile"]
+        elif kwargs.get("tool_profile") and role_name:
+            # Explicit override even when role is set
+            config.tool_profile = kwargs["tool_profile"]
+        if kwargs.get("thinking"):
+            config.thinking_level = kwargs["thinking"]
+        if kwargs.get("timeout_seconds"):
+            try:
+                config.timeout_seconds = int(kwargs["timeout_seconds"])
+            except (ValueError, TypeError):
+                pass
+        if kwargs.get("spawn_mode"):
+            try:
+                config.spawn_mode = SpawnMode(kwargs["spawn_mode"])
+            except ValueError:
+                return f"Error: invalid spawn_mode {kwargs['spawn_mode']!r}. Use 'run' or 'session'."
+        if kwargs.get("cleanup"):
+            try:
+                config.cleanup = CleanupMode(kwargs["cleanup"])
+            except ValueError:
+                return f"Error: invalid cleanup {kwargs['cleanup']!r}. Use 'keep' or 'delete'."
+        if kwargs.get("agent_name"):
+            config.agent_name = kwargs["agent_name"]
+        if kwargs.get("specialization"):
+            config.specialization = str(kwargs["specialization"]).strip()
+        if kwargs.get("auto_route") is not None:
+            config.auto_route = bool(kwargs["auto_route"])
+        if kwargs.get("match_keywords") is not None:
+            raw_keywords = kwargs["match_keywords"]
+            if isinstance(raw_keywords, list):
+                config.match_keywords = [
+                    str(item).strip() for item in raw_keywords if str(item).strip()
+                ]
+            else:
+                return "Error: 'match_keywords' must be an array of strings."
+        if kwargs.get("match_examples") is not None:
+            raw_examples = kwargs["match_examples"]
+            if isinstance(raw_examples, list):
+                config.match_examples = [
+                    str(item).strip() for item in raw_examples if str(item).strip()
+                ]
+            else:
+                return "Error: 'match_examples' must be an array of strings."
+        if kwargs.get("routing_mode"):
+            try:
+                config.routing_mode = RoutingMode(kwargs["routing_mode"])
+            except ValueError:
+                return (
+                    f"Error: invalid routing_mode {kwargs['routing_mode']!r}. "
+                    "Use 'direct' or 'orchestrated'."
+                )
+
+        has_explicit_config_override = any([
+            role_name is not None,
+            kwargs.get("model") is not None,
+            kwargs.get("tool_profile") is not None,
+            kwargs.get("thinking") is not None,
+            kwargs.get("timeout_seconds") is not None,
+            kwargs.get("spawn_mode") is not None,
+            kwargs.get("cleanup") is not None,
+            kwargs.get("agent_name") is not None,
+            kwargs.get("specialization") is not None,
+            kwargs.get("auto_route") is not None,
+            kwargs.get("match_keywords") is not None,
+            kwargs.get("match_examples") is not None,
+            kwargs.get("routing_mode") is not None,
+        ])
+        config_for_call = config if (not task_id or has_explicit_config_override) else None
+
+        # Auto-generate label from role if not provided (mirrors openclaw label)
+        label = kwargs.get("label", "")
+        if not label and role_applied:
+            # Derive a short label: "<role>: first 40 chars of task"
+            task_snippet = task[:40].rstrip() + ("…" if len(task) > 40 else "")
+            label = f"{role_applied}: {task_snippet}"
+
+        try:
+            spawn_kwargs = {
+                "task": task,
+                "label": label,
+                "parent_id": self._parent_agent_id,
+                "config": config_for_call,
+                "spawner_session_key": self._effective_spawner_session_key(),
+                "spawner_channel": self._effective_spawner_channel(),
+            }
+            if task_id:
+                record = await self._manager.resume_task(
+                    task_id=task_id,
+                    **spawn_kwargs,
+                )
+                intro = "Sub-agent session resumed successfully."
+            else:
+                record = await self._manager.spawn(**spawn_kwargs)
+                intro = "Sub-agent spawned successfully."
+            model_str = f" | model: {record.model_name}" if record.model_name else ""
+            thinking_str = (
+                f" | thinking: {config.thinking_level}" if config.thinking_level else ""
+            )
+            timeout_str = (
+                f" | timeout: {config.timeout_seconds}s" if config.timeout_seconds else ""
+            )
+            role_str = f" | role: {role_applied}" if role_applied else ""
+            mode_str = (
+                f" | mode: {record.spawn_mode.value}"
+                + (f" [{record.agent_name}]" if record.agent_name else "")
+            )
+            route_str = ""
+            if getattr(record.config, "auto_route", False):
+                route_str = " | auto-route: on"
+            return (
+                f"{intro}\n"
+                f"  ID:      {record.agent_id}\n"
+                f"  Task ID: {record.agent_id}\n"
+                f"  Label:   {record.label}\n"
+                f"  Depth:   {record.depth}"
+                f"{role_str}{model_str}{thinking_str}{timeout_str}{mode_str}{route_str}\n\n"
+                f"Use spawn(action='results') or spawn(action='wait', timeout=30) "
+                f"to retrieve its output when ready. "
+                f"Results will also be pushed automatically when the sub-agent completes.\n"
+                f"The result will include a task_id you can pass to future spawn calls "
+                f"to resume this sub-agent's session."
+            )
+        except ValueError as exc:
+            logger.warning(f"Spawn rejected: {exc}")
+            return f"Error: {exc}"
+
+    async def _handle_resume(self, kwargs: dict[str, Any]) -> str:
+        agent_name = kwargs.get("agent_name")
+        task = kwargs.get("task")
+        if not agent_name:
+            return "Error: 'agent_name' is required for the 'resume' action."
+        if not task:
+            return "Error: 'task' is required for the 'resume' action."
+
+        try:
+            record = await self._manager.resume_agent(
+                agent_name=agent_name,
+                task=task,
+                parent_id=self._parent_agent_id,
+                spawner_session_key=self._effective_spawner_session_key(),
+                spawner_channel=self._effective_spawner_channel(),
+            )
+            model_str = f" | model: {record.model_name}" if record.model_name else ""
+            return (
+                f"Session agent resumed successfully.\n"
+                f"  ID:    {record.agent_id}\n"
+                f"  Task ID: {record.agent_id}\n"
+                f"  Name:  {agent_name}\n"
+                f"  Label: {record.label}{model_str}\n\n"
+                f"Session history is preserved. Use spawn(action='wait', timeout=30) "
+                f"to retrieve its output."
+            )
+        except ValueError as exc:
+            logger.warning(f"Resume rejected: {exc}")
+            return f"Error: {exc}"
+
+    def _handle_status(self) -> str:
+        summary = self._manager.get_status_summary(
+            parent_id=self._parent_agent_id
+        )
+        if summary["total"] == 0:
+            return "No sub-agents have been spawned."
+
+        lines = [f"Sub-agents ({summary['total']} total):"]
+
+        if summary["active"]:
+            lines.append("\nActive:")
+            for a in summary["active"]:
+                elapsed_str = (
+                    f" — {a['elapsed_seconds']}s"
+                    if a.get("elapsed_seconds") is not None else ""
+                )
+                model_str = f" [{a['model']}]" if a.get("model") else ""
+                desc_str = (
+                    f" (waiting on {a['pending_descendants']} descendants)"
+                    if a.get("pending_descendants", 0) > 0 else ""
+                )
+                mode_str = (
+                    f" [session:{a['agent_name']}]" if a.get("spawn_mode") == "session"
+                    else ""
+                )
+                lines.append(
+                    f"  [{a['agent_id']}] {a['label']}: "
+                    f"{a['state']}{elapsed_str}{model_str}{mode_str}{desc_str}"
+                )
+
+        if summary["recent"]:
+            lines.append("\nRecent:")
+            for a in summary["recent"]:
+                elapsed_str = (
+                    f" — {a['elapsed_seconds']}s"
+                    if a.get("elapsed_seconds") is not None else ""
+                )
+                model_str = f" [{a['model']}]" if a.get("model") else ""
+                mode_str = (
+                    f" [session:{a['agent_name']}]" if a.get("spawn_mode") == "session"
+                    else ""
+                )
+                lines.append(
+                    f"  [{a['agent_id']}] {a['label']}: "
+                    f"{a['state']}{elapsed_str}{model_str}{mode_str}"
+                )
+
+        return "\n".join(lines)
+
+    async def _handle_results(self, kwargs: dict[str, Any]) -> str:
+        timeout = float(kwargs.get("timeout", 0.0))
+        results = await self._manager.collect_results(
+            timeout=timeout,
+            spawner_session_key=self._effective_spawner_session_key(),
+        )
+        if not results:
+            return (
+                "No completed results available yet. "
+                "Use spawn(action='wait', timeout=30) to block until one arrives."
+            )
+        return self._format_results(results)
+
+    async def _handle_wait(self, kwargs: dict[str, Any]) -> str:
+        timeout = float(kwargs.get("timeout", 30.0))
+        agent_id = kwargs.get("agent_id")
+
+        results = await self._manager.collect_results(
+            timeout=timeout,
+            spawner_session_key=self._effective_spawner_session_key(),
+            agent_id=agent_id,
+        )
+
+        if not results:
+            return (
+                f"No results received within {timeout}s. "
+                f"Sub-agents may still be running — try again later."
+            )
+        return self._format_results(results)
+
+    async def _handle_cancel(self, kwargs: dict[str, Any]) -> str:
+        agent_id = kwargs.get("agent_id")
+        if agent_id:
+            # Count descendants before cancelling for the message
+            record = self._manager.registry.get(agent_id)
+            descendants = (
+                self._manager.registry.get_descendants(agent_id)
+                if record else []
+            )
+            success = await self._manager.cancel(agent_id, cascade=True)
+            if success:
+                desc_count = len(descendants)
+                desc_str = f" (+ {desc_count} descendants)" if desc_count else ""
+                return f"Cancellation requested for sub-agent {agent_id}{desc_str}."
+            return (
+                f"Could not cancel sub-agent {agent_id}: "
+                f"it may already be finished or not found."
+            )
+        else:
+            count = await self._manager.cancel_all(
+                parent_id=self._parent_agent_id
+            )
+            return f"Cancellation requested for {count} sub-agent(s) (cascade)."
+
+    async def _handle_steer(self, kwargs: dict[str, Any]) -> str:
+        agent_id = kwargs.get("agent_id")
+        message = kwargs.get("message", "")
+
+        if not agent_id:
+            return "Error: 'agent_id' is required for the 'steer' action."
+        if not message:
+            return "Error: 'message' is required for the 'steer' action."
+
+        result = await self._manager.steer(agent_id, message)
+        status = result.get("status")
+        msg = result.get("message", "")
+
+        if status == "accepted":
+            return f"Steer accepted for sub-agent {agent_id}. {msg}"
+        elif status == "rate_limited":
+            return f"Rate limited: {msg}"
+        elif status == "done":
+            return f"Cannot steer: {msg}"
+        else:
+            return f"Steer failed: {msg}"
+
+    async def _handle_info(self, kwargs: dict[str, Any]) -> str:
+        agent_id = kwargs.get("agent_id")
+        if not agent_id:
+            return "Error: 'agent_id' is required for the 'info' action."
+
+        info = await self._manager.get_info(agent_id)
+        if info is None:
+            return f"Sub-agent {agent_id!r} not found."
+
+        lines = [f"Sub-agent {agent_id} info:"]
+        lines.append(f"  Label:        {info['label']}")
+        lines.append(f"  State:        {info['state']}")
+        lines.append(f"  Task:         {info['task'][:100]}")
+        lines.append(f"  Depth:        {info['depth']}")
+        if info.get("model"):
+            lines.append(f"  Model:        {info['model']}")
+        lines.append(f"  Tool profile: {info['tool_profile']}")
+        if info.get("specialization"):
+            lines.append(f"  Specialization: {info['specialization']}")
+        if info.get("auto_route"):
+            lines.append("  Auto-route:    on")
+        if info.get("routing_mode"):
+            lines.append(f"  Routing mode:  {info['routing_mode']}")
+        if info.get("match_keywords"):
+            lines.append(f"  Keywords:      {', '.join(info['match_keywords'])}")
+        if info.get("thinking_level"):
+            lines.append(f"  Thinking:     {info['thinking_level']}")
+        if info.get("elapsed_seconds") is not None:
+            lines.append(f"  Elapsed:      {info['elapsed_seconds']}s")
+        if info.get("pending_descendants", 0) > 0:
+            lines.append(f"  Pending descendants: {info['pending_descendants']}")
+        if info.get("children"):
+            lines.append(f"  Children:     {', '.join(info['children'])}")
+        if info.get("token_usage"):
+            tu = info["token_usage"]
+            lines.append(
+                f"  Tokens:       {tu.get('total_tokens', 0)} "
+                f"(in {tu.get('input_tokens', 0)} / out {tu.get('output_tokens', 0)})"
+            )
+        if info.get("result_preview"):
+            lines.append(f"  Result preview: {info['result_preview']}")
+        if info.get("error"):
+            lines.append(f"  Error:        {info['error']}")
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Formatting
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_results(results: list) -> str:
+        lines: list[str] = []
+        for r in results:
+            elapsed_str = (
+                f" in {r.elapsed_seconds}s" if r.elapsed_seconds is not None else ""
+            )
+            model_str = f" | {r.model_name}" if getattr(r, "model_name", None) else ""
+            header = (
+                f"--- [{r.agent_id}] {r.label} "
+                f"({r.state.value}{elapsed_str}{model_str}) ---"
+            )
+            content = r.result or r.error or "(no output)"
+            if len(content) > _RESULT_TRUNCATE_LEN:
+                content = (
+                    content[:_RESULT_TRUNCATE_LEN]
+                    + f"\n... [truncated — {len(content) - _RESULT_TRUNCATE_LEN} chars omitted]"
+                )
+            lines.append(f"\n{header}\ntask_id: {r.agent_id}\n{content}")
+        return "\n".join(lines)

--- a/tests/test_subagent_orchestration.py
+++ b/tests/test_subagent_orchestration.py
@@ -1,0 +1,903 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from spoon_bot.bus.events import InboundMessage
+from spoon_bot.channels.manager import ChannelManager
+from spoon_bot.session.manager import Session, SessionManager
+from spoon_bot.subagent.manager import SubagentManager
+from spoon_bot.subagent.models import (
+    RoutingMode,
+    SpawnMode,
+    SubagentConfig,
+    SubagentRecord,
+    SubagentResult,
+    SubagentState,
+)
+from spoon_bot.subagent.tools import SubagentTool
+
+
+def _tool_record(
+    *,
+    agent_id: str = "sub_test",
+    label: str = "planner: analyse",
+    depth: int = 1,
+    model_name: str | None = "test-model",
+    spawn_mode: str = "run",
+    agent_name: str | None = None,
+):
+    return SimpleNamespace(
+        agent_id=agent_id,
+        label=label,
+        depth=depth,
+        model_name=model_name,
+        spawn_mode=SimpleNamespace(value=spawn_mode),
+        agent_name=agent_name,
+        config=SubagentConfig(),
+    )
+
+
+@pytest.fixture
+def workspace_dir():
+    root = Path.cwd() / "workspace" / "pytest_subagents"
+    root.mkdir(parents=True, exist_ok=True)
+    case_dir = root / f"case_{uuid4().hex[:8]}"
+    case_dir.mkdir(parents=True, exist_ok=True)
+    yield case_dir
+
+
+@pytest.mark.asyncio
+async def test_subagent_tool_spawn_uses_task_id_resume(monkeypatch):
+    manager = SimpleNamespace()
+    manager.spawn = AsyncMock()
+    manager.resume_task = AsyncMock(return_value=_tool_record(agent_id="sub_resume"))
+
+    tool = SubagentTool(manager=manager, parent_agent_id="parent_1")
+    tool.set_spawner_context(session_key="session_root", channel="telegram:bot")
+
+    result = await tool.execute(action="spawn", task="Continue implementation", task_id="sub_prev")
+
+    manager.resume_task.assert_awaited_once()
+    kwargs = manager.resume_task.await_args.kwargs
+    assert kwargs["task_id"] == "sub_prev"
+    assert kwargs["task"] == "Continue implementation"
+    assert kwargs["parent_id"] == "parent_1"
+    assert kwargs["spawner_session_key"] == "session_root"
+    assert kwargs["spawner_channel"] == "telegram:bot"
+    assert kwargs["config"] is None
+    manager.spawn.assert_not_called()
+    assert "Task ID: sub_resume" in result
+
+
+@pytest.mark.asyncio
+async def test_subagent_tool_resume_passes_requester_context():
+    manager = SimpleNamespace()
+    manager.resume_agent = AsyncMock(
+        return_value=_tool_record(
+            agent_id="sub_session",
+            label="session agent",
+            spawn_mode="session",
+            agent_name="planner-session",
+        )
+    )
+
+    tool = SubagentTool(manager=manager, parent_agent_id="parent_2")
+    tool.set_spawner_context(session_key="session_child", channel="discord:test")
+
+    result = await tool.execute(
+        action="resume",
+        agent_name="planner-session",
+        task="Refine the plan",
+    )
+
+    manager.resume_agent.assert_awaited_once()
+    kwargs = manager.resume_agent.await_args.kwargs
+    assert kwargs["agent_name"] == "planner-session"
+    assert kwargs["task"] == "Refine the plan"
+    assert kwargs["parent_id"] == "parent_2"
+    assert kwargs["spawner_session_key"] == "session_child"
+    assert kwargs["spawner_channel"] == "discord:test"
+    assert "Task ID: sub_session" in result
+
+
+@pytest.mark.asyncio
+async def test_subagent_manager_collect_results_scoped_and_retains_others(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+
+    await manager._results.put(
+        SubagentResult(
+            agent_id="sub_root",
+            label="root task",
+            state=SubagentState.COMPLETED,
+            result="root done",
+            spawner_session_key="session_root",
+            spawner_channel="cli",
+        )
+    )
+    await manager._results.put(
+        SubagentResult(
+            agent_id="sub_child",
+            label="child task",
+            state=SubagentState.COMPLETED,
+            result="child done",
+            spawner_session_key="session_child",
+            spawner_channel="cli",
+        )
+    )
+
+    root_results = await manager.collect_results(spawner_session_key="session_root")
+    child_results = await manager.collect_results(spawner_session_key="session_child")
+
+    assert [result.agent_id for result in root_results] == ["sub_root"]
+    assert [result.agent_id for result in child_results] == ["sub_child"]
+
+
+@pytest.mark.asyncio
+async def test_subagent_manager_resume_task_preserves_existing_config(workspace_dir, monkeypatch):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+    monkeypatch.setattr(manager, "_start_background_run", lambda *args, **kwargs: None)
+
+    original_config = SubagentConfig(
+        role="planner",
+        tool_profile="research",
+        max_iterations=12,
+        timeout_seconds=120,
+    )
+    record = SubagentRecord(
+        agent_id="sub_existing",
+        label="old label",
+        task="old task",
+        state=SubagentState.COMPLETED,
+        config=original_config,
+        model_name="model-a",
+    )
+    manager.registry.register(record)
+
+    resumed = await manager.resume_task(
+        task_id="sub_existing",
+        task="new task",
+        spawner_session_key="session_nested",
+        spawner_channel="telegram:test",
+    )
+
+    assert resumed.agent_id == "sub_existing"
+    assert resumed.task == "new task"
+    assert resumed.state == SubagentState.PENDING
+    assert resumed.config.tool_profile == "research"
+    assert resumed.config.max_iterations == 12
+    assert resumed.spawner_session_key == "session_nested"
+    assert resumed.spawner_channel == "telegram:test"
+
+
+@pytest.mark.asyncio
+async def test_subagent_manager_spawn_prefers_explicit_spawner_context(workspace_dir, monkeypatch):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+    manager.set_spawner_context(session_key="session_root", channel="discord:root")
+    monkeypatch.setattr(manager, "_start_background_run", lambda *args, **kwargs: None)
+
+    record = await manager.spawn(
+        task="nested task",
+        spawner_session_key="session_child",
+        spawner_channel="discord:child",
+    )
+
+    assert record.spawner_session_key == "session_child"
+    assert record.spawner_channel == "discord:child"
+
+
+def test_subagent_tool_context_clears_stale_channel():
+    manager = SimpleNamespace(
+        _current_spawner_session="session_stale",
+        _current_spawner_channel="telegram:stale",
+    )
+    tool = SubagentTool(manager=manager, parent_agent_id="parent_3")
+    tool.set_spawner_context(session_key="session_first", channel="telegram:first")
+    tool.set_spawner_context(session_key="session_second", channel=None)
+
+    assert tool._effective_spawner_session_key() == "session_second"
+    assert tool._effective_spawner_channel() is None
+
+
+@pytest.mark.asyncio
+async def test_subagent_manager_resume_task_reparents_and_updates_depth(workspace_dir, monkeypatch):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+    monkeypatch.setattr(manager, "_start_background_run", lambda *args, **kwargs: None)
+
+    parent_a = SubagentRecord(
+        agent_id="sub_parent_a",
+        label="parent a",
+        task="parent a",
+        state=SubagentState.COMPLETED,
+        depth=1,
+    )
+    parent_b = SubagentRecord(
+        agent_id="sub_parent_b",
+        label="parent b",
+        task="parent b",
+        state=SubagentState.COMPLETED,
+        depth=3,
+    )
+    child = SubagentRecord(
+        agent_id="sub_child",
+        label="child",
+        task="child",
+        state=SubagentState.COMPLETED,
+        parent_id="sub_parent_a",
+        depth=2,
+    )
+    grandchild = SubagentRecord(
+        agent_id="sub_grandchild",
+        label="grandchild",
+        task="grandchild",
+        state=SubagentState.COMPLETED,
+        parent_id="sub_child",
+        depth=3,
+    )
+
+    manager.registry.register(parent_a)
+    manager.registry.register(parent_b)
+    manager.registry.register(child)
+    manager.registry.register(grandchild)
+
+    resumed = await manager.resume_task(
+        task_id="sub_child",
+        task="reparented task",
+        parent_id="sub_parent_b",
+    )
+
+    assert resumed.parent_id == "sub_parent_b"
+    assert resumed.depth == 4
+    assert "sub_child" not in manager.registry.get("sub_parent_a").children
+    assert "sub_child" in manager.registry.get("sub_parent_b").children
+    assert manager.registry.get("sub_grandchild").depth == 5
+
+
+@pytest.mark.asyncio
+async def test_subagent_manager_collect_results_does_not_block_other_scopes(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+
+    waiter = asyncio.create_task(
+        manager.collect_results(timeout=0.25, spawner_session_key="session_root")
+    )
+    await asyncio.sleep(0.05)
+
+    await manager._results.put(
+        SubagentResult(
+            agent_id="sub_child",
+            label="child task",
+            state=SubagentState.COMPLETED,
+            result="child done",
+            spawner_session_key="session_child",
+            spawner_channel="cli",
+        )
+    )
+    await asyncio.sleep(0.05)
+
+    child_results = await asyncio.wait_for(
+        manager.collect_results(spawner_session_key="session_child"),
+        timeout=0.1,
+    )
+    root_results = await waiter
+
+    assert [result.agent_id for result in child_results] == ["sub_child"]
+    assert root_results == []
+
+
+@pytest.mark.asyncio
+async def test_subagent_manager_spawn_rejects_duplicate_session_agent_name(workspace_dir, monkeypatch):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+        max_persistent_agents=4,
+    )
+    monkeypatch.setattr(manager, "_start_background_run", lambda *args, **kwargs: None)
+
+    await manager.spawn(
+        task="initial task",
+        config=SubagentConfig(
+            spawn_mode=SpawnMode.SESSION,
+            agent_name="planner",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="already exists"):
+        await manager.spawn(
+            task="duplicate task",
+            config=SubagentConfig(
+                spawn_mode=SpawnMode.SESSION,
+                agent_name="planner",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_subagent_manager_spawn_counts_pending_session_agents_against_limit(workspace_dir, monkeypatch):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+        max_persistent_agents=1,
+    )
+    monkeypatch.setattr(manager, "_start_background_run", lambda *args, **kwargs: None)
+
+    await manager.spawn(
+        task="initial task",
+        config=SubagentConfig(
+            spawn_mode=SpawnMode.SESSION,
+            agent_name="planner",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Max persistent agents"):
+        await manager.spawn(
+            task="another task",
+            config=SubagentConfig(
+                spawn_mode=SpawnMode.SESSION,
+                agent_name="reviewer",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_subagent_manager_announce_result_awaits_bus_publish(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+
+    published: list[InboundMessage] = []
+
+    class FakeBus:
+        async def publish(self, message):
+            published.append(message)
+            return True
+
+    manager.set_bus(FakeBus())
+    manager.registry.register(
+        SubagentRecord(
+            agent_id="sub_publish",
+            label="publish task",
+            task="publish task",
+            state=SubagentState.COMPLETED,
+        )
+    )
+
+    await manager._announce_result(
+        SubagentResult(
+            agent_id="sub_publish",
+            label="publish task",
+            state=SubagentState.COMPLETED,
+            result="done",
+            spawner_session_key="session_root",
+            spawner_channel="cli",
+        )
+    )
+
+    assert len(published) == 1
+    assert published[0].session_key == "session_root"
+
+
+def test_session_manager_archive_hides_deleted_file_sessions(workspace_dir):
+    manager = SessionManager(workspace=workspace_dir)
+    session = Session(session_key="alpha")
+    session.add_message("user", "hello")
+    manager.save(session)
+
+    assert "alpha" in manager.list_sessions()
+    assert manager.archive("alpha") is True
+    assert manager.get("alpha") is None
+    assert "alpha" not in manager.list_sessions()
+    assert any(".deleted." in path.name for path in (workspace_dir / "sessions").iterdir())
+
+
+@pytest.mark.asyncio
+async def test_telegram_subagent_spawn_passes_requester_context():
+    from spoon_bot.channels.telegram.commands import CommandHandlers
+
+    handlers = CommandHandlers(
+        SimpleNamespace(
+            account_id="spoon",
+            full_name="telegram:spoon",
+        )
+    )
+    manager = SimpleNamespace(
+        spawn=AsyncMock(return_value=_tool_record(agent_id="sub_cmd"))
+    )
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=12345),
+        message=SimpleNamespace(reply_text=AsyncMock()),
+    )
+
+    await handlers._subagents_spawn(update, manager, ["build", "something"])
+
+    kwargs = manager.spawn.await_args.kwargs
+    assert kwargs["spawner_session_key"] == "telegram_spoon_12345"
+    assert kwargs["spawner_channel"] == "telegram:spoon"
+    assert kwargs["spawner_metadata"]["chat_id"] == 12345
+
+
+@pytest.mark.asyncio
+async def test_telegram_subagent_resume_passes_requester_context():
+    from spoon_bot.channels.telegram.commands import CommandHandlers
+
+    handlers = CommandHandlers(
+        SimpleNamespace(
+            account_id="spoon",
+            full_name="telegram:spoon",
+        )
+    )
+    manager = SimpleNamespace(
+        resume_agent=AsyncMock(return_value=_tool_record(agent_id="sub_resume"))
+    )
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=67890),
+        message=SimpleNamespace(reply_text=AsyncMock()),
+    )
+
+    await handlers._subagents_resume(update, manager, "planner", "continue")
+
+    kwargs = manager.resume_agent.await_args.kwargs
+    assert kwargs["spawner_session_key"] == "telegram_spoon_67890"
+    assert kwargs["spawner_channel"] == "telegram:spoon"
+    assert kwargs["spawner_metadata"]["chat_id"] == 67890
+
+
+@pytest.mark.asyncio
+async def test_channel_manager_formats_rate_limit_error():
+    from spoon_bot.utils.errors import RateLimitExceeded
+
+    manager = ChannelManager()
+    manager._agent = SimpleNamespace(
+        process=AsyncMock(
+            side_effect=RateLimitExceeded(
+                resource="LLM",
+                limit=1,
+                window=60.0,
+                retry_after=4.0,
+            )
+        ),
+        process_with_thinking=AsyncMock(),
+    )
+    manager._channels["telegram:spoon"] = SimpleNamespace(
+        on_processing_start=AsyncMock(),
+        on_processing_end=AsyncMock(),
+    )
+
+    outbound = await manager._handle_message(
+        InboundMessage(
+            content="hello",
+            channel="telegram:spoon",
+            session_key="telegram_spoon_1",
+            sender_id="1",
+            message_id="m1",
+            metadata={},
+        )
+    )
+
+    assert "retry" in outbound.content.lower() or "wait" in outbound.content.lower()
+
+
+def test_subagent_manager_finds_best_auto_route_specialist(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+    manager.registry.register(
+        SubagentRecord(
+            agent_id="sub_auth",
+            label="auth specialist",
+            task="auth specialist",
+            state=SubagentState.COMPLETED,
+            config=SubagentConfig(
+                spawn_mode=SpawnMode.SESSION,
+                agent_name="auth-specialist",
+                auto_route=True,
+                specialization="Handles authentication, login, and password reset requests.",
+                match_keywords=["password reset", "login issue", "authentication"],
+                routing_mode=RoutingMode.DIRECT,
+            ),
+        )
+    )
+    manager.registry.register(
+        SubagentRecord(
+            agent_id="sub_billing",
+            label="billing specialist",
+            task="billing specialist",
+            state=SubagentState.COMPLETED,
+            config=SubagentConfig(
+                spawn_mode=SpawnMode.SESSION,
+                agent_name="billing-specialist",
+                auto_route=True,
+                specialization="Handles billing and invoice tasks.",
+                match_keywords=["invoice", "billing"],
+                routing_mode=RoutingMode.DIRECT,
+            ),
+        )
+    )
+
+    match = manager.find_best_auto_route_specialist(
+        "Please help reset a user's password because login is failing."
+    )
+
+    assert match is not None
+    assert match["agent_name"] == "auth-specialist"
+    assert match["score"] >= 7
+
+
+def test_subagent_manager_parses_natural_language_creation_request(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+
+    parsed = manager.parse_persistent_subagent_request(
+        "帮我创建一个 subagent 来总结今天的新闻"
+    )
+
+    assert parsed is not None
+    assert parsed["suggested_name"] == "news-subagent"
+    assert parsed["specialization"] == "总结今天的新闻"
+    assert "今天的新闻" in parsed["match_keywords"]
+
+
+@pytest.mark.xfail(reason="legacy mojibake fixture; covered by stable profile tests below")
+def test_subagent_manager_create_persistent_subagent_from_description(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+
+    record = manager.create_persistent_subagent(
+        description="总结今天的新闻",
+    )
+
+    assert record.agent_name == "news-subagent"
+    assert record.spawn_mode == SpawnMode.SESSION
+    assert record.state == SubagentState.COMPLETED
+    assert record.config.auto_route is True
+    assert record.config.tool_profile == "research"
+    assert record.config.specialization == "总结今天的新闻"
+    assert "今天的新闻" in record.config.match_keywords
+
+
+def test_subagent_manager_skips_ambiguous_auto_route_specialist_match(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+    for agent_name in ("invoice-a", "invoice-b"):
+        manager.registry.register(
+            SubagentRecord(
+                agent_id=f"sub_{agent_name}",
+                label=agent_name,
+                task=agent_name,
+                state=SubagentState.COMPLETED,
+                config=SubagentConfig(
+                    spawn_mode=SpawnMode.SESSION,
+                    agent_name=agent_name,
+                    auto_route=True,
+                    specialization="Handles invoice review.",
+                    match_keywords=["invoice review"],
+                    routing_mode=RoutingMode.DIRECT,
+                ),
+            )
+        )
+
+    assert manager.find_best_auto_route_specialist("Please do an invoice review.") is None
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_process_auto_routes_to_specialist(workspace_dir):
+    pytest.importorskip("spoon_ai")
+    from spoon_bot.agent.loop import AgentLoop
+
+    loop = AgentLoop(
+        workspace=workspace_dir,
+        model="gpt-5.2",
+        provider="openai",
+        api_key="test-key",
+    )
+    loop._initialized = True
+    loop._subagent_manager._current_spawner_channel = "telegram:spoon"
+    loop._subagent_manager.find_best_auto_route_specialist = lambda message: {
+        "agent_name": "auth-specialist",
+        "score": 12,
+        "reasons": ["keyword:password reset"],
+    }
+    loop._subagent_manager.resume_agent = AsyncMock(
+        return_value=SubagentRecord(
+            agent_id="sub_auth",
+            label="auth specialist",
+            task="Reset password for alice",
+            state=SubagentState.PENDING,
+            config=SubagentConfig(
+                spawn_mode=SpawnMode.SESSION,
+                agent_name="auth-specialist",
+                auto_route=True,
+                specialization="Handles authentication tasks.",
+            ),
+        )
+    )
+    loop._subagent_manager.collect_results = AsyncMock(
+        return_value=[
+            SubagentResult(
+                agent_id="sub_auth",
+                label="auth specialist",
+                state=SubagentState.COMPLETED,
+                result="Password reset flow has been implemented.",
+                spawner_session_key="root_session",
+                spawner_channel="telegram:spoon",
+            )
+        ]
+    )
+
+    result = await loop.process(
+        "Reset password for alice",
+        session_key="root_session",
+    )
+
+    assert "auth-specialist" in result
+    assert "Password reset flow has been implemented." in result
+    loop._subagent_manager.resume_agent.assert_awaited_once()
+    resume_kwargs = loop._subagent_manager.resume_agent.await_args.kwargs
+    assert resume_kwargs["agent_name"] == "auth-specialist"
+    assert resume_kwargs["task"] == "Reset password for alice"
+    assert resume_kwargs["spawner_session_key"] == "root_session"
+    assert resume_kwargs["spawner_channel"] == "telegram:spoon"
+
+
+@pytest.mark.asyncio
+async def test_telegram_subagent_spawn_sets_specialist_metadata():
+    from spoon_bot.channels.telegram.commands import CommandHandlers
+
+    handlers = CommandHandlers(
+        SimpleNamespace(
+            account_id="spoon",
+            full_name="telegram:spoon",
+        )
+    )
+    manager = SimpleNamespace(
+        spawn=AsyncMock(return_value=_tool_record(agent_id="sub_specialist"))
+    )
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=999),
+        message=SimpleNamespace(reply_text=AsyncMock()),
+    )
+
+    await handlers._subagents_spawn(
+        update,
+        manager,
+        [
+            "--mode", "session",
+            "--name", "auth-specialist",
+            "--specialization", "Handles", "authentication", "tasks",
+            "--keywords", "login,password reset",
+            "--auto-route",
+            "handle", "auth",
+        ],
+    )
+
+    kwargs = manager.spawn.await_args.kwargs
+    config = kwargs["config"]
+    assert config.spawn_mode == SpawnMode.SESSION
+    assert config.agent_name == "auth-specialist"
+    assert config.specialization == "Handles authentication tasks"
+    assert config.auto_route is True
+    assert config.match_keywords == ["login", "password reset"]
+
+
+def test_subagent_manager_parses_creation_request_with_sender_prefix_english(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+
+    parsed = manager.parse_persistent_subagent_request(
+        "[Alice]: Create a persistent subagent to summarize today's news"
+    )
+
+    assert parsed is not None
+    assert parsed["suggested_name"] == "news-subagent"
+
+
+def test_subagent_manager_creates_research_profile_from_english_description(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+
+    profile = manager.create_persistent_subagent(
+        description="handle literature search, paper discovery, paper summaries, and research material collection",
+    )
+
+    assert profile.name == "academic-research-subagent"
+    assert profile.auto_route is True
+    assert profile.tool_profile == "research"
+    assert "paper search" in profile.match_keywords
+
+
+def test_subagent_manager_matches_research_profile_for_related_request(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+    manager.create_persistent_subagent(
+        description="handle literature search, paper discovery, paper summaries, and research material collection",
+        agent_name="academic-research-subagent",
+    )
+
+    match = manager.find_best_auto_route_specialist(
+        "Please find representative papers on multi-agent systems and provide a brief summary."
+    )
+
+    assert match is not None
+    assert match["agent_name"] == "academic-research-subagent"
+
+
+def test_subagent_manager_creates_research_profile_from_chinese_description(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+
+    profile = manager.create_persistent_subagent(
+        description="\u4eca\u540e\u4e13\u95e8\u5904\u7406\u6587\u732e\u67e5\u8be2\u3001\u8bba\u6587\u68c0\u7d22\u3001\u8bba\u6587\u6458\u8981\u6574\u7406\u548c\u7814\u7a76\u8d44\u6599\u6536\u96c6\u76f8\u5173\u4efb\u52a1",
+    )
+
+    assert profile.name == "academic-research-subagent"
+    assert profile.tool_profile == "research"
+    assert "\u6587\u732e\u67e5\u8be2" in profile.match_keywords
+
+
+@pytest.mark.asyncio
+async def test_subagent_manager_announce_result_preserves_spawner_metadata(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+
+    published: list[InboundMessage] = []
+
+    class FakeBus:
+        async def publish(self, message):
+            published.append(message)
+            return True
+
+    manager.set_bus(FakeBus())
+    manager.registry.register(
+        SubagentRecord(
+            agent_id="sub_publish_meta",
+            label="publish task",
+            task="publish task",
+            state=SubagentState.COMPLETED,
+        )
+    )
+
+    await manager._announce_result(
+        SubagentResult(
+            agent_id="sub_publish_meta",
+            label="publish task",
+            state=SubagentState.COMPLETED,
+            result="done",
+            spawner_session_key="telegram_spoon_1",
+            spawner_channel="telegram:spoon",
+            spawner_metadata={"chat_id": 1001, "chat_type": "private"},
+            spawner_reply_to="777",
+        )
+    )
+
+    assert len(published) == 1
+    assert published[0].metadata["chat_id"] == 1001
+    assert published[0].metadata["reply_to"] == "777"
+
+
+@pytest.mark.asyncio
+async def test_channel_manager_uses_metadata_reply_target():
+    manager = ChannelManager()
+    manager._agent = SimpleNamespace(
+        process=AsyncMock(return_value="hello"),
+        process_with_thinking=AsyncMock(),
+    )
+    manager._channels["telegram:spoon"] = SimpleNamespace(
+        on_processing_start=AsyncMock(),
+        on_processing_end=AsyncMock(),
+    )
+
+    outbound = await manager._handle_message(
+        InboundMessage(
+            content="hello",
+            channel="telegram:spoon",
+            session_key="telegram_spoon_1",
+            sender_id="1",
+            message_id="internal_wake_id",
+            metadata={"chat_id": 1001, "reply_to": "42"},
+        )
+    )
+
+    assert outbound.reply_to == "42"
+
+
+def test_subagent_manager_routes_from_persistent_profile_without_runtime_record(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+    manager.create_persistent_subagent(
+        description="专门处理文献查询、论文检索、论文摘要整理和研究资料收集",
+        agent_name="academic-research-subagent",
+        config=SubagentConfig(
+            tool_profile="research",
+            auto_route=True,
+            specialization="专门处理文献查询、论文检索、论文摘要整理和研究资料收集",
+            match_keywords=["文献查询", "论文检索", "论文摘要", "研究资料", "学术研究"],
+        ),
+    )
+
+    reloaded = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+    match = reloaded.find_best_auto_route_specialist(
+        "帮我查一下多智能体系统方向最近的代表性论文，并做一个简要总结。"
+    )
+
+    assert match is not None
+    assert match["agent_name"] == "academic-research-subagent"
+
+
+@pytest.mark.asyncio
+async def test_resume_agent_uses_persistent_profile_when_runtime_record_missing(workspace_dir):
+    manager = SubagentManager(
+        session_manager=SessionManager(workspace=workspace_dir),
+        workspace=workspace_dir,
+    )
+    manager._start_background_run = lambda *args, **kwargs: None  # type: ignore[method-assign]
+    manager.create_persistent_subagent(
+        description="summarize today's news",
+        agent_name="news-subagent",
+        config=SubagentConfig(
+            tool_profile="research",
+            auto_route=True,
+            specialization="summarize today's news",
+            match_keywords=["today's news", "daily news", "news summary"],
+        ),
+    )
+
+    spawned: list[tuple[str, SubagentConfig]] = []
+
+    original_spawn = manager.spawn
+
+    async def wrapped_spawn(*, task, config=None, **kwargs):
+        spawned.append((task, config))
+        return await original_spawn(task=task, config=config, **kwargs)
+
+    manager.spawn = wrapped_spawn  # type: ignore[method-assign]
+
+    record = await manager.resume_agent(
+        agent_name="news-subagent",
+        task="Please summarize today's news",
+    )
+
+    assert record.agent_name == "news-subagent"
+    assert spawned
+    assert spawned[0][1] is not None
+    assert spawned[0][1].spawn_mode == SpawnMode.SESSION

--- a/verify_orchestration.py
+++ b/verify_orchestration.py
@@ -1,0 +1,246 @@
+"""
+验证脚本：测试 LLM 自主决策多 SubAgent 编排能力的各个组件。
+
+运行方式：
+    uv run python verify_orchestration.py
+
+此脚本不依赖 spoon-ai-sdk，直接测试新增的编排相关代码。
+"""
+
+import sys
+import json
+import io
+
+# Force UTF-8 output on Windows to avoid GBK encode errors
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+
+print("=" * 60)
+print("spoon-bot Multi-Agent Orchestration Verification")
+print("=" * 60)
+
+# ----------------------------------------------------------------
+# 1. catalog.py — AgentRole 和 AGENT_CATALOG
+# ----------------------------------------------------------------
+print("\n[1] 验证 catalog.py ...")
+from spoon_bot.subagent.catalog import (
+    AGENT_CATALOG, AgentRole, get_role, list_roles, format_roles_for_prompt
+)
+
+assert len(AGENT_CATALOG) == 7, f"期望 7 个角色，实际 {len(AGENT_CATALOG)}"
+assert set(AGENT_CATALOG.keys()) == {
+    "planner", "backend", "frontend", "researcher", "reviewer", "devops", "tester"
+}
+
+planner = get_role("planner")
+assert planner is not None
+assert planner.tool_profile == "research"
+assert planner.max_iterations == 12
+assert "plan" in planner.system_prompt.lower()
+
+backend = get_role("backend")
+assert backend.tool_profile == "coding"
+assert backend.max_iterations == 25
+
+assert get_role("nonexistent") is None
+
+roles = list_roles()
+assert len(roles) == 7
+
+roles_text = format_roles_for_prompt()
+assert "planner" in roles_text
+assert "backend" in roles_text
+assert "frontend" in roles_text
+
+print(f"  ✓ AGENT_CATALOG: {list(AGENT_CATALOG.keys())}")
+print(f"  ✓ get_role('planner'): profile={planner.tool_profile}, max_iter={planner.max_iterations}")
+print(f"  ✓ get_role('nonexistent'): None")
+print(f"  ✓ format_roles_for_prompt() 包含所有角色")
+
+# ----------------------------------------------------------------
+# 2. models.py — SubagentConfig.role 字段
+# ----------------------------------------------------------------
+print("\n[2] 验证 models.py (SubagentConfig.role 字段) ...")
+from spoon_bot.subagent.models import SubagentConfig, SpawnMode, CleanupMode
+
+# 默认无 role
+cfg_default = SubagentConfig()
+assert cfg_default.role is None
+assert cfg_default.tool_profile == "core"
+assert cfg_default.max_iterations == 15
+
+# 指定 role
+cfg_planner = SubagentConfig(role="planner")
+assert cfg_planner.role == "planner"
+
+# role 不影响其他字段（由 tools.py 在 spawn 时填充）
+cfg_backend = SubagentConfig(role="backend", model="anthropic/sonnet-4")
+assert cfg_backend.role == "backend"
+assert cfg_backend.model == "anthropic/sonnet-4"
+
+print(f"  ✓ SubagentConfig() 默认 role=None")
+print(f"  ✓ SubagentConfig(role='planner').role = 'planner'")
+print(f"  ✓ SubagentConfig(role='backend', model=...) 字段共存正常")
+
+# ----------------------------------------------------------------
+# 3. tools.py — SubagentTool 描述、参数、list_roles action
+# ----------------------------------------------------------------
+print("\n[3] 验证 tools.py (SubagentTool) ...")
+from spoon_bot.subagent.tools import SubagentTool
+
+tool = SubagentTool()
+
+# 工具名称
+assert tool.name == "spawn"
+
+# description 动态注入了角色目录
+desc = tool.description
+assert "planner" in desc, "description 应包含 planner 角色"
+assert "backend" in desc, "description 应包含 backend 角色"
+assert "list_roles" in desc, "description 应包含 list_roles action 说明"
+assert "Orchestration" in desc, "description 应包含 Orchestration 引导"
+assert "no fixed pipeline" in desc, "description 应说明无固定 pipeline"
+
+# parameters 包含 role 枚举和 list_roles action
+params = tool.parameters
+actions = params["properties"]["action"]["enum"]
+assert "list_roles" in actions, f"actions 应包含 list_roles，实际: {actions}"
+assert "spawn" in actions
+assert "wait" in actions
+
+role_param = params["properties"]["role"]
+assert "planner" in role_param["enum"]
+assert "backend" in role_param["enum"]
+assert "task_id" in params["properties"], "应有 task_id 参数（镜像 opencode task.ts）"
+
+print(f"  ✓ tool.name = 'spawn'")
+print(f"  ✓ description 包含角色目录 + Orchestration 引导 + no fixed pipeline")
+print(f"  ✓ parameters.action.enum 包含 list_roles: {actions}")
+print(f"  ✓ parameters.role.enum: {role_param['enum']}")
+print(f"  ✓ parameters 包含 task_id 字段")
+
+# list_roles action 输出
+roles_output = tool._handle_list_roles()
+assert "planner" in roles_output
+assert "Tool profile: research" in roles_output
+assert "Max steps:    12" in roles_output
+assert "backend" in roles_output
+assert "Usage:" in roles_output
+
+print(f"  ✓ _handle_list_roles() 输出格式正确")
+print()
+print("  list_roles 输出预览:")
+for line in roles_output.split("\n")[:12]:
+    print(f"    {line}")
+
+# ----------------------------------------------------------------
+# 4. __init__.py — 公共 API 导出
+# ----------------------------------------------------------------
+print("\n[4] 验证 __init__.py 导出 ...")
+from spoon_bot.subagent import (
+    AGENT_CATALOG as _cat,
+    AgentRole as _role,
+    get_role as _get,
+    list_roles as _list,
+    format_roles_for_prompt as _fmt,
+    SubagentConfig as _cfg,
+    SubagentTool as _tool,
+)
+assert _cat is AGENT_CATALOG
+assert _role is AgentRole
+print(f"  ✓ 所有新增符号从 spoon_bot.subagent 正确导出")
+
+# ----------------------------------------------------------------
+# 5. loop.py — format_roles_for_prompt 导入 + spawn 检测逻辑
+# ----------------------------------------------------------------
+print("\n[5] 验证 loop.py 中的导入 ...")
+import ast, pathlib
+
+loop_src = pathlib.Path(
+    "C:/Users/lal/Desktop/Agent/Neo/spoon/spoon-bot/spoon_bot/agent/loop.py"
+).read_text(encoding="utf-8")
+
+assert "from spoon_bot.subagent.catalog import format_roles_for_prompt" in loop_src, \
+    "loop.py 应导入 format_roles_for_prompt"
+assert "Multi-Agent Orchestration" in loop_src, \
+    "loop.py 应包含 Multi-Agent Orchestration 引导段"
+assert "if \"spawn\" in self.tools:" in loop_src, \
+    "loop.py 应检测 spawn 工具是否可用"
+assert "no fixed pipeline" not in loop_src or "there is no fixed" in loop_src or \
+    "no fixed" in loop_src, \
+    "loop.py 应说明无固定 pipeline"
+assert "format_roles_for_prompt()" in loop_src, \
+    "loop.py 应调用 format_roles_for_prompt() 注入角色列表"
+assert "list_roles" in loop_src, \
+    "loop.py 应提及 list_roles action"
+
+print(f"  ✓ loop.py 导入 format_roles_for_prompt")
+print(f"  ✓ loop.py 包含 Multi-Agent Orchestration 引导段")
+print(f"  ✓ loop.py 检测 'spawn' in self.tools 后才注入")
+print(f"  ✓ loop.py 调用 format_roles_for_prompt() 动态注入角色列表")
+
+# ----------------------------------------------------------------
+# 6. 模拟 spawn 时 role 参数的处理逻辑（不需要真实 manager）
+# ----------------------------------------------------------------
+print("\n[6] 模拟 role 参数处理逻辑 ...")
+
+# 模拟 _handle_spawn 中的 role 解析逻辑
+role_name = "planner"
+agent_role = get_role(role_name)
+assert agent_role is not None
+
+config = SubagentConfig()
+config.role = agent_role.name
+config.system_prompt = agent_role.system_prompt
+config.tool_profile = agent_role.tool_profile
+config.max_iterations = agent_role.max_iterations
+
+assert config.role == "planner"
+assert config.tool_profile == "research"
+assert config.max_iterations == 12
+assert "architect" in config.system_prompt.lower() or "plan" in config.system_prompt.lower()
+
+# 自动生成 label
+task = "实现一个用户管理系统，包含注册、登录、权限管理"
+task_snippet = task[:40].rstrip() + ("…" if len(task) > 40 else "")
+label = f"{role_name}: {task_snippet}"
+assert label.startswith("planner:")
+print(f"  ✓ role='planner' → tool_profile='research', max_iterations=12")
+print(f"  ✓ 自动生成 label: '{label}'")
+
+# 未知 role 返回错误
+unknown_role = get_role("unknown_role")
+assert unknown_role is None
+print(f"  ✓ 未知 role 返回 None（tools.py 会返回错误信息）")
+
+# ----------------------------------------------------------------
+# 总结
+# ----------------------------------------------------------------
+print("\n" + "=" * 60)
+print("✅ 所有验证通过！")
+print("=" * 60)
+print()
+print("📋 功能总结：")
+print("  用户输入: '实现一个用户管理系统'")
+print()
+print("  LLM 自主决策流程（无固定 Pipeline）：")
+print("  1. 看到 system prompt 中的 Orchestration 引导段")
+print("     → 知道自己是 Orchestrator，知道有哪些专业角色")
+print()
+print("  2. 调用 spawn(action='list_roles')")
+print("     → 获取所有角色的详细描述")
+print()
+print("  3. 自主决定：先 spawn planner 分析需求")
+print("     spawn(action='spawn', role='planner',")
+print("           task='分析用户管理系统需求...')")
+print("     → SubagentTool 自动加载 planner 的 system_prompt")
+print("        (tool_profile='research', max_iterations=12)")
+print()
+print("  4. 等待规划结果：spawn(action='wait', timeout=120)")
+print()
+print("  5. 根据规划，LLM 自主决定并行 spawn backend + frontend")
+print("     spawn(action='spawn', role='backend', task='...<plan>...')")
+print("     spawn(action='spawn', role='frontend', task='...<plan>...')")
+print()
+print("  6. 等待实现结果，汇总给用户")
+print()
+print("  关键：编排顺序由 LLM 自主决定，不是硬编码 Pipeline ✓")


### PR DESCRIPTION
## Summary

Introduce a complete sub-agent orchestration module that enables the LLM to autonomously decompose complex tasks by spawning specialized child agents.

## New: `spoon_bot/subagent/` package

- **catalog.py** — 7 built-in roles (planner, backend, frontend, researcher, reviewer, devops, tester) with per-role system prompts, tool profiles, and iteration limits
- **manager.py** — SubagentManager: lifecycle management, concurrency control, cascade cancellation, sweeper
- **models.py** — Data models (SubagentConfig, SubagentState, SpawnMode, CleanupMode)
- **registry.py** — Subagent registry for tracking active/completed agents
- **persistence.py** — Run persistence and archival
- **tools.py** — SubagentTool (the `spawn` tool exposed to the LLM with actions: spawn, wait, cancel, list, list_roles, steer, info)

## Integration

- **agent/loop.py** — SubagentManager lifecycle, spawn tool registration, orchestration prompt injection, auto-routing logic
- **config.py** — `SubagentLimitsConfig` for max_depth, max_children, max_total, persist settings
- **channels/manager.py** — Bus wiring for wake-continuation messages from completed subagents
- **channels/telegram/commands.py** — `/subagents` command suite (list/spawn/resume/cancel/steer/info)
- **channels/telegram/constants.py** — Register `/subagents` and `/agents` bot commands
- **channels/discord/channel.py** — Subagent lifecycle event notifications

## Tests

- `tests/test_subagent_orchestration.py` — Unit tests for catalog, models, tools, registry
- `verify_orchestration.py` — End-to-end verification script