### PR TITLE
fix: align TUI and gateway thinking streams with final responses

### DIFF
--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-import os
 import logging as stdlib_logging
+import re
 from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncGenerator
@@ -94,7 +94,6 @@ from spoon_bot.services.spawn import SpawnTool
 from spoon_bot.session.manager import SessionManager
 from spoon_bot.session.store import create_session_store
 from spoon_bot.memory.store import MemoryStore
-from spoon_bot.skills.builtin import ensure_builtin_skills
 from spoon_bot.wallet import ensure_wallet_runtime
 from spoon_bot.exceptions import (
     SpoonBotError,
@@ -117,6 +116,12 @@ _ATTACHMENT_ONLY_PLACEHOLDER = (
     "The user attached files without extra text. Inspect the files and answer based on their contents."
 )
 _SANDBOX_WORKSPACE_ROOT = "/workspace"
+_WALLET_REQUIRED_TOOLS: frozenset[str] = frozenset({
+    "balance_check",
+    "transfer",
+    "swap",
+    "contract_call",
+})
 
 
 def _workspace_root_path(workspace: Path | str | None) -> Path:
@@ -410,6 +415,8 @@ class AgentLoop:
         self._agent: SpoonReactMCP | SpoonReactSkill | None = None
         self._skill_manager: SkillManager | None = None
         self._mcp_tools: list[MCPTool] = []
+        self._latest_reasoning_excerpt: str | None = None
+        self._pending_reasoning_chunks: list[str] = []
 
         # spoon-bot components
         self.context = ContextBuilder(self.workspace, yolo_mode=self.yolo_mode)
@@ -1159,8 +1166,6 @@ class AgentLoop:
         Args:
             message: The user's message.
             media: Optional list of media file paths.
-            session_key: Optional session key for multi-user/multi-channel isolation.
-                         When provided, switches to this session before processing.
 
         Returns:
             The agent's response text.
@@ -1175,11 +1180,9 @@ class AgentLoop:
         if not self._initialized:
             await self.initialize()
 
-        # Switch session if a different key is requested
         if session_key and session_key != self.session_key:
             self._session = self.sessions.get_or_create(session_key)
             self.session_key = session_key
-            logger.debug(f"Switched to session: {session_key}")
 
         logger.info(f"Processing message: {message[:100]}...")
 
@@ -1941,9 +1944,9 @@ class AgentLoop:
                 if not content or not content.strip():
                     break
                 safe_text = mask_secrets(content.strip())
-                if len(safe_text) > 500:
-                    safe_text = safe_text[:500] + "…"
-                logger.info(f"💭 Agent reasoning: {safe_text}")
+                captured = agent_loop._capture_reasoning_text(safe_text)
+                if captured:
+                    logger.info(f"💭 Agent reasoning: {captured}")
                 break
 
         def _log_tool_calls():
@@ -1968,6 +1971,55 @@ class AgentLoop:
         original_think = getattr(agent, "_spoon_bot_base_think", None)
         if original_think is not None:
             agent.think = original_think
+
+    def _reset_reasoning_capture(self) -> None:
+        """Reset request-scoped reasoning captured from tracked think logs."""
+        self._latest_reasoning_excerpt = None
+        self._pending_reasoning_chunks = []
+
+    def _capture_reasoning_text(self, text: str | None) -> str | None:
+        """Store a reasoning excerpt so gateway transports can reuse it."""
+        normalized = str(text or "").strip()
+        if not normalized:
+            return None
+        if normalized == self._latest_reasoning_excerpt:
+            return normalized
+        self._latest_reasoning_excerpt = normalized
+        self._pending_reasoning_chunks.append(normalized)
+        return normalized
+
+    def _drain_reasoning_chunks(self) -> list[str]:
+        """Return pending reasoning excerpts and clear the queue."""
+        pending = [
+            text
+            for text in self._pending_reasoning_chunks
+            if isinstance(text, str) and text.strip()
+        ]
+        self._pending_reasoning_chunks = []
+        return pending
+
+    @staticmethod
+    def _normalize_comparable_text(text: str | None) -> str:
+        """Collapse whitespace so duplicate text can be compared reliably."""
+        return " ".join(str(text or "").split())
+
+    def _looks_like_duplicate_thinking(
+        self,
+        thinking_text: str | None,
+        content_text: str | None,
+    ) -> bool:
+        """Return True when a thinking payload is effectively the final answer."""
+        normalized_thinking = self._normalize_comparable_text(thinking_text)
+        normalized_content = self._normalize_comparable_text(content_text)
+        if not normalized_thinking or not normalized_content:
+            return False
+        if normalized_thinking == normalized_content:
+            return True
+        shorter, longer = sorted(
+            (normalized_thinking, normalized_content),
+            key=len,
+        )
+        return len(shorter) >= 64 and shorter in longer
 
     def _filter_execution_steps(self, content: str) -> str:
         """
@@ -2050,6 +2102,7 @@ class AgentLoop:
             await self.initialize()
 
         logger.info(f"Streaming message: {message[:100]}...")
+        self._reset_reasoning_capture()
 
         # Refresh memory context
         try:
@@ -2063,6 +2116,8 @@ class AgentLoop:
         stream_completed = False
         stream_cancelled = False
         bg_task: asyncio.Task[None] | None = None
+        pending_pre_tool_chunks: list[dict[str, Any]] = []
+        buffering_pre_tool_segment = thinking
 
         # Trim and inject persisted history into runtime memory
         await self._prepare_request_context()
@@ -2142,7 +2197,13 @@ class AgentLoop:
 
             logger.debug(f"Entering stream loop: td={td.is_set()}, qempty={oq.empty()}, qsize={oq.qsize()}")
             while not (td.is_set() and oq.empty()):
-                if asyncio.get_event_loop().time() > deadline:
+                # tracked_reasoning is inferred from assistant output logs and is
+                # not a reliable API thinking source. Clear it so it does not leak
+                # duplicated final content into WS/REST responses.
+                self._drain_reasoning_chunks()
+                now_ts = asyncio.get_event_loop().time()
+
+                if now_ts > deadline:
                     logger.warning(
                         f"Streaming deadline reached ({stream_timeout}s), "
                         f"stopping after {chunk_count} chunks"
@@ -2207,6 +2268,15 @@ class AgentLoop:
                         continue
 
                     if "tool_calls" in chunk and chunk["tool_calls"]:
+                        if thinking and pending_pre_tool_chunks:
+                            for pending_chunk in pending_pre_tool_chunks:
+                                yield {
+                                    "type": "thinking",
+                                    "delta": pending_chunk["delta"],
+                                    "metadata": pending_chunk["metadata"],
+                                }
+                            pending_pre_tool_chunks = []
+                        buffering_pre_tool_segment = thinking
                         for tc in chunk["tool_calls"]:
                             # tc may be a ToolCall pydantic object or a dict
                             if isinstance(tc, dict):
@@ -2229,24 +2299,55 @@ class AgentLoop:
                                 },
                             }
                         continue
+                    chunk_metadata = chunk.get("metadata")
+                    if isinstance(chunk_metadata, dict):
+                        metadata = dict(chunk_metadata)
+                    dict_type = chunk.get("type")
+                    if dict_type == "thinking":
+                        chunk_type = "thinking"
+                    elif dict_type == "content":
+                        chunk_type = "content"
                     # Support both "content" and "delta" keys (#10)
                     text = chunk.get("content") or chunk.get("delta") or ""
                     if text:
                         delta = text
-                        full_content += delta
 
                 # -- Object chunks with content --
                 elif hasattr(chunk, "content") and chunk.content:
                     delta = chunk.content
-                    full_content += delta
 
                 # -- Plain string chunks --
                 elif isinstance(chunk, str):
                     delta = chunk
-                    full_content += delta
 
                 if delta:
-                    yield {"type": chunk_type, "delta": delta, "metadata": metadata}
+                    metadata_phase = metadata.get("phase") if isinstance(metadata, dict) else None
+                    explicit_pre_tool_phase = (
+                        chunk_type == "content"
+                        and thinking
+                        and metadata_phase == "think"
+                    )
+                    if chunk_type == "content" and explicit_pre_tool_phase:
+                        yield {
+                            "type": "thinking",
+                            "delta": delta,
+                            "metadata": {
+                                **metadata,
+                                "source": metadata.get("source", "phase_think"),
+                            },
+                        }
+                    elif chunk_type == "content" and buffering_pre_tool_segment:
+                        pending_pre_tool_chunks.append(
+                            {
+                                "delta": delta,
+                                "metadata": dict(metadata),
+                            }
+                        )
+                    else:
+                        event = {"type": chunk_type, "delta": delta, "metadata": metadata}
+                        if chunk_type == "content":
+                            full_content += delta
+                        yield event
 
             logger.debug(f"Stream loop exited: td={td.is_set()}, qempty={oq.empty()}, chunks_received={chunk_count}, full_content_len={len(full_content)}")
 
@@ -2255,6 +2356,18 @@ class AgentLoop:
                 await asyncio.wait_for(bg_task, timeout=5.0)
             except (asyncio.TimeoutError, Exception):
                 pass
+
+            self._drain_reasoning_chunks()
+
+            if pending_pre_tool_chunks:
+                for pending_chunk in pending_pre_tool_chunks:
+                    full_content += pending_chunk["delta"]
+                    yield {
+                        "type": "content",
+                        "delta": pending_chunk["delta"],
+                        "metadata": pending_chunk["metadata"],
+                    }
+                pending_pre_tool_chunks = []
 
             # Fallback: if run() completed but no stream chunks were emitted,
             # use final run result as one content chunk to avoid empty output.
@@ -2323,7 +2436,6 @@ class AgentLoop:
         Args:
             message: The user's message.
             media: Optional list of media file paths.
-            session_key: Optional session key for multi-user/multi-channel isolation.
 
         Returns:
             Tuple of (response_text, thinking_content). thinking_content may be None.
@@ -2331,13 +2443,12 @@ class AgentLoop:
         if not self._initialized:
             await self.initialize()
 
-        # Switch session if a different key is requested
         if session_key and session_key != self.session_key:
             self._session = self.sessions.get_or_create(session_key)
             self.session_key = session_key
-            logger.debug(f"Switched to session: {session_key}")
 
         logger.info(f"Processing message (with thinking): {message[:100]}...")
+        self._reset_reasoning_capture()
 
         # Refresh memory context
         try:
@@ -2383,6 +2494,8 @@ class AgentLoop:
                 thinking_content = result.thinking
             elif hasattr(result, "metadata") and isinstance(result.metadata, dict):
                 thinking_content = result.metadata.get("thinking")
+            if self._looks_like_duplicate_thinking(thinking_content, final_content):
+                thinking_content = None
 
         except Exception as e:
             logger.error(f"Agent processing error: {e}")
@@ -2904,32 +3017,22 @@ async def create_agent(
         >>> # YOLO mode — work in /home/user/project directly
         >>> agent = await create_agent(yolo_mode=True, workspace="/home/user/project")
     """
-    wallet_tool_names = {"balance_check", "transfer", "swap", "contract_call"}
-    wallet_required = False
-    if enabled_tools:
-        wallet_required = bool(wallet_tool_names.intersection(enabled_tools))
-    elif tool_profile in {"web3"}:
-        wallet_required = True
-    if os.environ.get("SPOON_BOT_WALLET_REQUIRED", "").strip().lower() in {"1", "true", "yes", "on"}:
-        wallet_required = True
-
-    resolved_workspace = Path(workspace).expanduser() if workspace else None
-    if resolved_workspace is not None:
-        ensure_builtin_skills(resolved_workspace)
+    wallet_required = bool(enabled_tools and _WALLET_REQUIRED_TOOLS.intersection(enabled_tools))
     try:
-        ensure_wallet_runtime(resolved_workspace)
-    except Exception as exc:
-        # Wallet bootstrap should not block non-web3 workloads.
-        os.environ["SPOON_BOT_WALLET_AUTO_CREATED"] = "0"
+        ensure_wallet_runtime(workspace)
+    except Exception:
         if wallet_required:
             raise
-        logger.warning(f"Wallet bootstrap skipped: {exc}")
+        logger.warning("Wallet runtime bootstrap failed; continuing because no wallet-required tools are enabled")
+        import os
+
+        os.environ["SPOON_BOT_WALLET_AUTO_CREATED"] = "0"
 
     agent = AgentLoop(
         model=model,
         provider=provider,
         api_key=api_key,
-        workspace=resolved_workspace or workspace,
+        workspace=workspace,
         session_key=session_key,
         base_url=base_url,
         mcp_config=mcp_config,

--- a/spoon_bot/cli.py
+++ b/spoon_bot/cli.py
@@ -16,6 +16,7 @@ from typing import Any, Optional
 import typer
 from rich.console import Console
 from rich.markdown import Markdown
+from rich.markup import escape as _escape_markup
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -287,6 +288,10 @@ def _truncate(text: str, max_len: int = 200) -> str:
     return first_line
 
 
+def _escape_and_indent(text: str, indent: str = "      ") -> str:
+    return _escape_markup(text).replace("\n", f"\n{indent}")
+
+
 def _format_tool_args(tool_name: str, raw_args: str) -> str:
     """Extract a human-readable summary from raw JSON tool args."""
     import json as _json
@@ -296,34 +301,48 @@ def _format_tool_args(tool_name: str, raw_args: str) -> str:
     try:
         obj = _json.loads(raw_args)
     except (ValueError, TypeError):
-        return f"[dim]{_truncate(raw_args, 100)}[/dim]"
+        if tool_name == "shell":
+            return f"\n      [dim]{_escape_and_indent(raw_args)}[/dim]"
+        return f"[dim]{_escape_and_indent(_truncate(raw_args, 100))}[/dim]"
 
     if not isinstance(obj, dict):
-        return f"[dim]{_truncate(raw_args, 100)}[/dim]"
+        if tool_name == "shell":
+            return f"\n      [dim]{_escape_and_indent(str(obj))}[/dim]"
+        return f"[dim]{_escape_and_indent(_truncate(raw_args, 100))}[/dim]"
 
     if tool_name == "shell":
         cmd = obj.get("command", "")
-        return f"\n      [dim]$ {cmd}[/dim]" if cmd else ""
+        lines = []
+        if cmd:
+            lines.append(f"$ {cmd}")
+        for key, value in obj.items():
+            if key == "command":
+                continue
+            lines.append(f"{key}: {value}")
+        if not lines:
+            return ""
+        return f"\n      [dim]{_escape_and_indent(chr(10).join(lines))}[/dim]"
     if tool_name == "skill_marketplace":
         action = obj.get("action", "")
         url = obj.get("url", obj.get("skill_name", ""))
         if url:
-            return f"[dim]{action} → {url}[/dim]"
-        return f"[dim]{action}[/dim]"
+            return f"[dim]{_escape_and_indent(f'{action} → {url}')}[/dim]"
+        return f"[dim]{_escape_and_indent(action)}[/dim]"
     if tool_name in ("read_file", "read_text_file"):
-        return f"[dim]{obj.get('path', '')}[/dim]"
+        return f"[dim]{_escape_and_indent(obj.get('path', ''))}[/dim]"
     if tool_name == "write_file":
-        return f"[dim]→ {obj.get('path', obj.get('file_path', ''))}[/dim]"
+        path_value = obj.get("path", obj.get("file_path", ""))
+        return f"[dim]{_escape_and_indent(f'→ {path_value}')}[/dim]"
     if tool_name == "edit_file":
-        return f"[dim]{obj.get('path', '')}[/dim]"
+        return f"[dim]{_escape_and_indent(obj.get('path', ''))}[/dim]"
     if tool_name in ("list_dir", "list_directory"):
-        return f"[dim]{obj.get('path', '')}[/dim]"
+        return f"[dim]{_escape_and_indent(obj.get('path', ''))}[/dim]"
     if tool_name == "grep":
         pat = obj.get("pattern", "")
         path = obj.get("path", "")
-        return f"[dim]{pat} in {path}[/dim]"
+        return f"[dim]{_escape_and_indent(f'{pat} in {path}')}[/dim]"
     if tool_name == "self_upgrade":
-        return f"[dim]{obj.get('action', '')}[/dim]"
+        return f"[dim]{_escape_and_indent(obj.get('action', ''))}[/dim]"
 
     parts = []
     for k, v in list(obj.items())[:4]:
@@ -331,7 +350,7 @@ def _format_tool_args(tool_name: str, raw_args: str) -> str:
         if len(sv) > 60:
             sv = sv[:57] + "..."
         parts.append(f"{k}={sv}")
-    return "[dim]" + ", ".join(parts) + "[/dim]"
+    return "[dim]" + _escape_and_indent(", ".join(parts)) + "[/dim]"
 
 
 def _tui_step_sink(message):
@@ -348,7 +367,7 @@ def _tui_step_sink(message):
     if m:
         thought = m.group(1).strip()
         if thought:
-            display = thought[:200] + "…" if len(thought) > 200 else thought
+            display = _escape_and_indent(thought)
             console.print(f"    [dim]💭[/dim] [italic]{display}[/italic]", highlight=False)
         return
 
@@ -376,13 +395,15 @@ def _tui_step_sink(message):
             return
 
         lines = raw.split("\n")
-        max_lines = 5 if tool_name == "shell" else 3
-        display_lines = lines[:max_lines]
-        display = "\n".join(ln.strip() for ln in display_lines)
-        if len(display) > 500:
+        max_lines = None if tool_name == "shell" else 3
+        display_lines = lines if max_lines is None else lines[:max_lines]
+        display = "\n".join(ln.rstrip() for ln in display_lines) if tool_name == "shell" else "\n".join(ln.strip() for ln in display_lines)
+        if tool_name != "shell" and len(display) > 500:
             display = display[:500] + "..."
-        if len(lines) > max_lines:
+        if max_lines is not None and len(lines) > max_lines:
             display += f"\n      ... ({len(lines) - max_lines} more lines)"
+
+        rendered_display = _escape_and_indent(display)
 
         if "Error" in display or "failed" in display.lower() or "Security Error" in display:
             style = "[red]"
@@ -395,9 +416,9 @@ def _tui_step_sink(message):
             end_style = ""
 
         if "\n" in display:
-            console.print(f"    [dim]╰→[/dim] {style}{display}{end_style}", highlight=False)
+            console.print(f"    [dim]╰→[/dim] {style}{rendered_display}{end_style}", highlight=False)
         else:
-            console.print(f"    [dim]╰→[/dim] {style}{display}{end_style}", highlight=False)
+            console.print(f"    [dim]╰→[/dim] {style}{rendered_display}{end_style}", highlight=False)
         return
 
 
@@ -563,10 +584,6 @@ async def _run_agent(
         tool_count = len(agent.tools)
         skill_count = len(agent.skills)
         console.print(f"\r  [green]Ready[/green] — {tool_count} tools · {skill_count} skills")
-        if os.environ.get("SPOON_BOT_WALLET_AUTO_CREATED") == "1":
-            wallet_addr = os.environ.get("WALLET_ADDRESS", "").strip()
-            wallet_note = f" ({wallet_addr})" if wallet_addr else ""
-            console.print(f"  [yellow]Wallet auto-created[/yellow]{wallet_note}")
         console.rule(style="dim")
 
     except ValueError as e:
@@ -729,7 +746,6 @@ def onboard():
     Initializes a git repository for version control.
     """
     from spoon_bot.services.git import GitManager
-    from spoon_bot.skills.builtin import ensure_builtin_skills
 
     workspace = get_workspace()
     config_dir = Path.home() / ".spoon-bot"
@@ -743,11 +759,8 @@ def onboard():
     workspace.mkdir(parents=True, exist_ok=True)
     (workspace / "memory").mkdir(exist_ok=True)
     (workspace / "skills").mkdir(exist_ok=True)
-    installed_skills = ensure_builtin_skills(workspace)
 
     console.print(f"[green]✓[/green] Created workspace: {workspace}")
-    for skill_dir in installed_skills:
-        console.print(f"[green]✓[/green] Installed built-in skill: {skill_dir.name}")
 
     # Create AGENTS.md
     agents_file = workspace / "AGENTS.md"
@@ -1041,10 +1054,6 @@ async def _run_gateway(
         with console.status("[bold blue]Initializing agent...[/bold blue]"):
             agent = await create_agent(**create_kwargs)
         print_success(f"Agent initialized: {agent.provider}/{agent.model}")
-        if os.environ.get("SPOON_BOT_WALLET_AUTO_CREATED") == "1":
-            wallet_addr = os.environ.get("WALLET_ADDRESS", "").strip()
-            wallet_note = f" ({wallet_addr})" if wallet_addr else ""
-            print_info(f"Wallet auto-created{wallet_note}")
     except ValueError as e:
         print_error(ConfigurationError(
             str(e),

--- a/spoon_bot/gateway/config.py
+++ b/spoon_bot/gateway/config.py
@@ -53,9 +53,9 @@ class JWTConfig:
 class BudgetConfig:
     """Execution budget configuration."""
 
-    request_timeout_ms: int = 120_000   # 2 minutes default
-    tool_timeout_ms: int = 60_000       # 1 minute default
-    stream_timeout_ms: int = 300_000    # 5 minutes default
+    request_timeout_ms: int = 3_600_000   # 60 minutes default
+    tool_timeout_ms: int = 3_600_000      # 60 minutes default
+    stream_timeout_ms: int = 3_600_000    # 60 minutes default
 
 
 @dataclass
@@ -133,13 +133,13 @@ class GatewayConfig:
             ),
             budget=BudgetConfig(
                 request_timeout_ms=int(
-                    os.environ.get("GATEWAY_TIMEOUT_REQUEST_MS", "120000")
+                    os.environ.get("GATEWAY_TIMEOUT_REQUEST_MS", "3600000")
                 ),
                 tool_timeout_ms=int(
-                    os.environ.get("GATEWAY_TIMEOUT_TOOL_MS", "60000")
+                    os.environ.get("GATEWAY_TIMEOUT_TOOL_MS", "3600000")
                 ),
                 stream_timeout_ms=int(
-                    os.environ.get("GATEWAY_TIMEOUT_STREAM_MS", "300000")
+                    os.environ.get("GATEWAY_TIMEOUT_STREAM_MS", "3600000")
                 ),
             ),
             audio=AudioConfig(

--- a/spoon_bot/gateway/websocket/handler.py
+++ b/spoon_bot/gateway/websocket/handler.py
@@ -686,7 +686,7 @@ class WebSocketHandler:
             complete_data: dict[str, Any] = {
                 "task_id": task_id,
                 "status": "done",
-                "response": response[:200] if isinstance(response, str) else str(response)[:200],
+                "response": response if isinstance(response, str) else str(response),
                 "trace_id": trace_id,
                 "timing": timing,
             }

--- a/spoon_bot/gateway/websocket/workspace_terminal.py
+++ b/spoon_bot/gateway/websocket/workspace_terminal.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import os
+import posixpath
 import signal
+import shlex
 import subprocess
 import threading
 from dataclasses import dataclass
@@ -48,7 +50,10 @@ class WorkspaceTerminalService:
         emit_closed: TermClosedCallback,
         sandbox_id: str = "runtime",
     ) -> None:
-        self._workspace_root = workspace_root.resolve()
+        # Keep the configured sandbox root as a logical path (for example
+        # "/workspace") instead of resolving symlinks to provider-specific
+        # mount paths like "/__modal/volumes/...".
+        self._workspace_root = workspace_root.absolute()
         self._emit_stdout = emit_stdout
         self._emit_closed = emit_closed
         self._sandbox_id = sandbox_id.strip() or "runtime"
@@ -178,18 +183,20 @@ class WorkspaceTerminalService:
     ) -> TerminalSession:
         validated_cols = self._validate_dimension(cols, "cols")
         validated_rows = self._validate_dimension(rows, "rows")
+        spawn_env = dict(env)
+        spawn_env["PWD"] = str(cwd)
 
         if os.name == "posix":
             master_fd, slave_fd = os.openpty()
             _set_pty_winsize(master_fd, validated_rows, validated_cols)
             try:
                 process = subprocess.Popen(
-                    _shell_argv(shell),
+                    _shell_argv(shell, cwd),
                     stdin=slave_fd,
                     stdout=slave_fd,
                     stderr=slave_fd,
                     cwd=str(cwd),
-                    env=env,
+                    env=spawn_env,
                     start_new_session=True,
                 )
             finally:
@@ -207,12 +214,12 @@ class WorkspaceTerminalService:
             )
 
         process = subprocess.Popen(
-            _shell_argv(shell),
+            _shell_argv(shell, cwd),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=str(cwd),
-            env=env,
+            env=spawn_env,
         )
         return TerminalSession(
             term_id=term_id,
@@ -309,21 +316,23 @@ class WorkspaceTerminalService:
 
     def _resolve_workspace_path(self, requested_path: str) -> Path:
         raw_path = str(requested_path or "").strip()
+        workspace_root_str = self._workspace_root.as_posix().rstrip("/") or "/"
         if raw_path == "" or raw_path == SANDBOX_WORKSPACE_ROOT:
             target = self._workspace_root
         elif raw_path.startswith("/"):
-            normalized = Path(raw_path).as_posix()
+            normalized = posixpath.normpath(raw_path)
             sandbox_root = SANDBOX_WORKSPACE_ROOT.rstrip("/")
             if normalized != sandbox_root and not normalized.startswith(sandbox_root + "/"):
-                workspace_root_str = self._workspace_root.as_posix().rstrip("/")
                 if normalized != workspace_root_str and not normalized.startswith(workspace_root_str + "/"):
                     raise ValueError("Path is outside workspace boundary")
                 relative = normalized[len(workspace_root_str):].lstrip("/")
             else:
                 relative = normalized[len(sandbox_root):].lstrip("/")
-            target = (self._workspace_root / relative).resolve(strict=False)
+            target = Path(
+                workspace_root_str if not relative else posixpath.join(workspace_root_str, relative)
+            )
         else:
-            target = (self._workspace_root / raw_path).resolve(strict=False)
+            target = Path(posixpath.normpath(posixpath.join(workspace_root_str, raw_path)))
 
         try:
             target.relative_to(self._workspace_root)
@@ -371,8 +380,17 @@ class WorkspaceTerminalService:
             process.wait(timeout=2)
 
 
-def _shell_argv(shell: str) -> list[str]:
-    return [shell.strip()]
+def _shell_argv(shell: str, cwd: Path | None = None) -> list[str]:
+    normalized_shell = shell.strip()
+    if os.name == "posix" and cwd is not None:
+        quoted_cwd = shlex.quote(str(cwd))
+        quoted_shell = shlex.quote(normalized_shell)
+        return [
+            "/bin/sh",
+            "-lc",
+            f"cd {quoted_cwd} && export PWD={quoted_cwd} && exec {quoted_shell} -i",
+        ]
+    return [normalized_shell]
 
 
 def _set_pty_winsize(fd: int, rows: int, cols: int) -> None:

--- a/tests/capability_test.py
+++ b/tests/capability_test.py
@@ -109,7 +109,7 @@ async def test_basic_instruction(results: list[TestResult]):
     t = TestResult("1. Basic instruction following")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             text, resp, _ = await chat(ws, "What is 2 + 3? Reply with just the number.")
@@ -138,7 +138,7 @@ async def test_structured_output(results: list[TestResult]):
     t = TestResult("2. Structured output (JSON)")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             text, resp, _ = await chat(
@@ -186,7 +186,7 @@ async def test_reasoning(results: list[TestResult]):
     t = TestResult("3. Reasoning / logic problem")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             text, resp, _ = await chat(
@@ -228,7 +228,7 @@ async def test_streaming_quality(results: list[TestResult]):
     t = TestResult("4. Streaming response quality + chunk count")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             full_text, resp, events = await stream_chat(
@@ -286,7 +286,7 @@ async def test_multi_turn(results: list[TestResult]):
     t = TestResult("5. Multi-turn conversation context")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             # First message: establish context
@@ -333,7 +333,7 @@ async def test_code_generation(results: list[TestResult]):
     t = TestResult("6. Code generation")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             text, resp, _ = await chat(
@@ -377,7 +377,7 @@ async def test_translation(results: list[TestResult]):
     t = TestResult("7. Language / translation")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             text, resp, _ = await chat(
@@ -425,7 +425,7 @@ async def test_summarization(results: list[TestResult]):
     t = TestResult("8. Text summarization")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             long_text = (
@@ -478,7 +478,7 @@ async def test_math(results: list[TestResult]):
     t = TestResult("9. Math / computation")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             text, resp, _ = await chat(
@@ -513,7 +513,7 @@ async def test_streaming_long(results: list[TestResult]):
     t = TestResult("10. Streaming long response")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             start = time.time()
@@ -614,7 +614,7 @@ async def test_empty_message(results: list[TestResult]):
     t = TestResult("12. Error handling — empty message")
     results.append(t)
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=10)
 
             req = make_request("agent.chat", {"message": "", "stream": False})
@@ -725,3 +725,4 @@ async def main():
 if __name__ == "__main__":
     exit_code = asyncio.run(main())
     sys.exit(exit_code)
+

--- a/tests/e2e_gateway.py
+++ b/tests/e2e_gateway.py
@@ -284,7 +284,7 @@ async def _ws_tests():
 
     # Non-stream
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=5)  # connection.established
             await ws.send(json.dumps({
                 "type": "request", "id": "t1",
@@ -308,7 +308,7 @@ async def _ws_tests():
 
     # Stream
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=5)
             await ws.send(json.dumps({
                 "type": "request", "id": "t2",
@@ -371,7 +371,7 @@ async def _ws_session_tests():
         return
 
     try:
-        async with websockets.connect(WS_URL) as ws:
+        async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
             await asyncio.wait_for(ws.recv(), timeout=5)
 
             await ws.send(json.dumps({
@@ -437,3 +437,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/tests/test_cli_tui_output.py
+++ b/tests/test_cli_tui_output.py
@@ -1,0 +1,77 @@
+from io import StringIO
+from types import SimpleNamespace
+
+from rich.console import Console
+
+import spoon_bot.cli as cli
+
+
+def _render_tui(monkeypatch, *messages: str) -> str:
+    test_console = Console(
+        file=StringIO(),
+        force_terminal=False,
+        color_system=None,
+        width=240,
+        record=True,
+    )
+    monkeypatch.setattr(cli, "console", test_console)
+
+    for message in messages:
+        cli._tui_step_sink(SimpleNamespace(record={"message": message}))
+
+    return test_console.export_text()
+
+
+def test_tui_step_sink_displays_full_agent_reasoning(monkeypatch) -> None:
+    thought = (
+        "First line of reasoning\n"
+        "Second line keeps [literal] brackets\n"
+        + ("0123456789" * 30)
+        + " END-OF-THINK"
+    )
+
+    rendered = _render_tui(monkeypatch, f"💭 Agent reasoning: {thought}")
+
+    assert "First line of reasoning" in rendered
+    assert "Second line keeps [literal] brackets" in rendered
+    assert "END-OF-THINK" in rendered
+
+
+def test_format_tool_args_preserves_full_shell_payload() -> None:
+    raw_args = '{"command": "git status && git diff", "working_dir": "/tmp/project", "timeout": 120}'
+
+    formatted = cli._format_tool_args("shell", raw_args)
+
+    assert "$ git status && git diff" in formatted
+    assert "working_dir: /tmp/project" in formatted
+    assert "timeout: 120" in formatted
+
+
+def test_format_tool_args_formats_write_file_path() -> None:
+    raw_args = '{"path": "notes/[todo].md"}'
+
+    formatted = cli._format_tool_args("write_file", raw_args)
+
+    rendered = Console(file=StringIO(), force_terminal=False, color_system=None, record=True)
+    rendered.print(formatted, highlight=False)
+
+    assert "→ notes/[todo].md" in rendered.export_text()
+
+
+def test_tui_step_sink_displays_full_shell_output(monkeypatch) -> None:
+    raw_args = '{"command": "printf \'alpha\\nbeta\\ngamma\\ndelta\\nepsilon\\nzeta\'", "working_dir": "/tmp/project"}'
+    shell_output = "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\n[result]"
+
+    rendered = _render_tui(
+        monkeypatch,
+        f"Tool call: shell({raw_args})",
+        f"Tool shell executed with result: {shell_output}",
+    )
+
+    assert "$ printf 'alpha" in rendered
+    assert "zeta'" in rendered
+    assert "working_dir: /tmp/project" in rendered
+    assert "alpha" in rendered
+    assert "zeta" in rendered
+    assert "[result]" in rendered
+    assert "more lines" not in rendered

--- a/tests/test_e2e_gateway_live.py
+++ b/tests/test_e2e_gateway_live.py
@@ -179,7 +179,7 @@ async def _ws_test_basic_ops():
     """WS basic operations: connect, ping, status."""
     import websockets
 
-    async with websockets.connect(WS_URL) as ws:
+    async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
         # connection.established
         msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=5))
         if msg.get("event") == "connection.established":
@@ -210,7 +210,7 @@ async def _ws_test_params_validation():
     """#14: WS params validation — non-dict params returns INVALID_MESSAGE."""
     import websockets
 
-    async with websockets.connect(WS_URL) as ws:
+    async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
         await ws.recv()  # connection.established
 
         await ws.send(json.dumps({
@@ -232,7 +232,7 @@ async def _ws_test_session_switch_validation():
     """#15: session.switch rejects non-string session_key."""
     import websockets
 
-    async with websockets.connect(WS_URL) as ws:
+    async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
         await ws.recv()  # connection.established
 
         # Object session_key — should be rejected
@@ -262,7 +262,7 @@ async def _ws_test_subscribe_validation():
     """#16: subscribe rejects non-list events."""
     import websockets
 
-    async with websockets.connect(WS_URL) as ws:
+    async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
         await ws.recv()
 
         # String events — should be rejected
@@ -292,7 +292,7 @@ async def _ws_test_session_import():
     """#12: session.import persists messages."""
     import websockets
 
-    async with websockets.connect(WS_URL) as ws:
+    async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
         await ws.recv()
 
         await ws.send(json.dumps({
@@ -320,7 +320,7 @@ async def _ws_test_chat_non_stream():
     """#10/#11: WS non-stream chat with session binding."""
     import websockets
 
-    async with websockets.connect(WS_URL) as ws:
+    async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
         await ws.recv()
 
         await ws.send(json.dumps({
@@ -360,7 +360,7 @@ async def _ws_test_chat_stream():
     """WS stream chat must emit chunks and done before final response."""
     import websockets
 
-    async with websockets.connect(WS_URL) as ws:
+    async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
         await ws.recv()
 
         await ws.send(json.dumps({
@@ -432,7 +432,7 @@ async def _ws_test_cancel():
     """#13: WS cancel reports task_interrupted."""
     import websockets
 
-    async with websockets.connect(WS_URL) as ws:
+    async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
         await ws.recv()
 
         await ws.send(json.dumps({
@@ -453,7 +453,7 @@ async def _ws_test_shell_format_safe():
     """#6: ShellTool does not block 'format' in URL params."""
     import websockets
 
-    async with websockets.connect(WS_URL) as ws:
+    async with websockets.connect(WS_URL, ping_interval=3600, ping_timeout=3600) as ws:
         await ws.recv()
 
         # This tests the shell tool's security validator directly via agent
@@ -549,3 +549,4 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
+

--- a/tests/test_gateway_ws_bugs.py
+++ b/tests/test_gateway_ws_bugs.py
@@ -1299,6 +1299,45 @@ class TestWSStreamingContent:
             assert len(done_events) >= 1
             assert done_events[0]["data"]["content"] == "fallback done content"
 
+    def test_stream_complete_event_keeps_full_response(self, client):
+        """agent.complete should carry the full response body, not a preview slice."""
+        agent = app_module._agent
+        assert agent is not None
+
+        full_text = "A" * 260
+
+        async def _stream_with_full_done(**kwargs):
+            yield {"type": "done", "delta": "", "metadata": {"content": full_text}}
+
+        agent.stream = _stream_with_full_done
+
+        with client.websocket_connect("/v1/ws") as ws:
+            ws.receive_json()  # connection.established
+
+            ws.send_json({
+                "type": "request",
+                "id": "stream_complete_full_response",
+                "method": "chat.send",
+                "params": {
+                    "message": "hello stream",
+                    "stream": True,
+                },
+            })
+
+            events = []
+            for _ in range(20):
+                msg = ws.receive_json()
+                events.append(msg)
+                if msg.get("type") == "response":
+                    break
+
+            complete_events = [
+                e for e in events
+                if e.get("type") == "event" and e.get("event") == "agent.complete"
+            ]
+            assert len(complete_events) == 1
+            assert complete_events[0]["data"]["response"] == full_text
+
 
 # ===================================================================
 # Handler error masking (part of #14)

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -395,18 +395,33 @@ class TestAgentLoopStream:
         mock_chunk_2.content = " World"
         mock_chunk_2.metadata = None
 
-        async def mock_stream(message, **kwargs):
+        async def mock_run(**kwargs):
             for c in [mock_chunk_1, mock_chunk_2]:
-                yield c
+                await agent._agent.output_queue.put(c)
 
         agent = MagicMock(spec=AgentLoop)
         agent._initialized = True
         agent._agent = MagicMock()
-        agent._agent.stream = mock_stream
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
         agent._session = MagicMock()
         agent._session.add_message = MagicMock()
         agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
         agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
 
         # Call the real stream method bound to our mock
         chunks = []
@@ -428,18 +443,33 @@ class TestAgentLoopStream:
         """stream() should handle plain string chunks."""
         from spoon_bot.agent.loop import AgentLoop
 
-        async def mock_stream(message, **kwargs):
-            yield "Hello"
-            yield " World"
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put("Hello")
+            await agent._agent.output_queue.put(" World")
 
         agent = MagicMock(spec=AgentLoop)
         agent._initialized = True
         agent._agent = MagicMock()
-        agent._agent.stream = mock_stream
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
         agent._session = MagicMock()
         agent._session.add_message = MagicMock()
         agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
         agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
 
         chunks = []
         async for chunk in AgentLoop.stream(agent, message="test"):
@@ -464,18 +494,33 @@ class TestAgentLoopStream:
         content_chunk.content = "Result"
         content_chunk.metadata = None
 
-        async def mock_stream(message, **kwargs):
-            yield thinking_chunk
-            yield content_chunk
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put(thinking_chunk)
+            await agent._agent.output_queue.put(content_chunk)
 
         agent = MagicMock(spec=AgentLoop)
         agent._initialized = True
         agent._agent = MagicMock()
-        agent._agent.stream = mock_stream
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
         agent._session = MagicMock()
         agent._session.add_message = MagicMock()
         agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
         agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
 
         chunks = []
         async for chunk in AgentLoop.stream(agent, message="test", thinking=True):
@@ -490,23 +535,402 @@ class TestAgentLoopStream:
         assert content_chunks[0]["delta"] == "Result"
 
     @pytest.mark.asyncio
-    async def test_stream_error_handling(self):
-        """stream() should catch errors and emit done with error metadata."""
+    async def test_stream_downgrades_to_content_when_no_tool_call_follows(self):
+        """stream() should keep normal content when tool calls never follow."""
         from spoon_bot.agent.loop import AgentLoop
 
-        async def mock_stream(message, **kwargs):
-            yield "partial"
-            raise RuntimeError("Connection lost")
-            yield "never"  # pragma: no cover
+        async def mock_run(**kwargs):
+            agent._capture_reasoning_text("Reasoning from tracked think")
+            await agent._agent.output_queue.put({"content": "Answer"})
 
         agent = MagicMock(spec=AgentLoop)
         agent._initialized = True
         agent._agent = MagicMock()
-        agent._agent.stream = mock_stream
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
         agent._session = MagicMock()
         agent._session.add_message = MagicMock()
         agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
         agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._drain_reasoning_chunks = AgentLoop._drain_reasoning_chunks.__get__(agent, AgentLoop)
+        agent._reset_reasoning_capture = AgentLoop._reset_reasoning_capture.__get__(agent, AgentLoop)
+        agent._capture_reasoning_text = AgentLoop._capture_reasoning_text.__get__(agent, AgentLoop)
+        agent._reset_reasoning_capture()
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="test", thinking=True):
+            chunks.append(chunk)
+
+        thinking_chunks = [c for c in chunks if c["type"] == "thinking"]
+        content_chunks = [c for c in chunks if c["type"] == "content"]
+
+        assert len(thinking_chunks) == 0
+        assert len(content_chunks) == 1
+        assert content_chunks[0]["delta"] == "Answer"
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["metadata"]["content"] == "Answer"
+
+    @pytest.mark.asyncio
+    async def test_stream_late_tracked_reasoning_still_preserves_content(self):
+        """Late tracked reasoning should not strip normal content output."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"content": "Answer"})
+            await asyncio.sleep(0)
+            agent._capture_reasoning_text("Late tracked reasoning")
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._drain_reasoning_chunks = AgentLoop._drain_reasoning_chunks.__get__(agent, AgentLoop)
+        agent._reset_reasoning_capture = AgentLoop._reset_reasoning_capture.__get__(agent, AgentLoop)
+        agent._capture_reasoning_text = AgentLoop._capture_reasoning_text.__get__(agent, AgentLoop)
+        agent._reset_reasoning_capture()
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="test", thinking=True):
+            chunks.append(chunk)
+
+        emitted = [c for c in chunks if c["type"] in {"thinking", "content"}]
+        assert len(emitted) == 1
+        assert emitted[0]["type"] == "content"
+        assert emitted[0]["delta"] == "Answer"
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["metadata"]["content"] == "Answer"
+
+    @pytest.mark.asyncio
+    async def test_stream_buffers_leading_content_until_tool_call_then_emits_thinking(self):
+        """Leading streamed content should become thinking only after a real tool call arrives."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "shell"
+        tool_call.function.arguments = '{"command":"pwd"}'
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"content": "Let me inspect the workspace first."})
+            await agent._agent.output_queue.put({"tool_calls": [tool_call]})
+            await agent._agent.output_queue.put({"content": "Done."})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="placeholder")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
+            chunks.append(chunk)
+
+        emitted = [c for c in chunks if c["type"] in {"thinking", "tool_call", "content"}]
+        assert [c["type"] for c in emitted] == ["thinking", "tool_call", "content"]
+        assert emitted[0]["delta"] == "Let me inspect the workspace first."
+        assert emitted[1]["metadata"]["name"] == "shell"
+        assert emitted[2]["delta"] == "Done."
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+        assert done_chunks[0]["metadata"]["content"] == "Done."
+
+    @pytest.mark.asyncio
+    async def test_stream_uses_explicit_thinking_chunk_without_prompt_heuristic(self):
+        """Explicit thinking chunks from core should drive pre-tool thinking display."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "shell"
+        tool_call.function.arguments = '{"command":"pwd"}'
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put(
+                {
+                    "type": "thinking",
+                    "delta": "First I will inspect the workspace.",
+                    "content": "First I will inspect the workspace.",
+                    "metadata": {
+                        "phase": "think",
+                        "source": "toolcall_agent",
+                    },
+                }
+            )
+            await agent._agent.output_queue.put({"tool_calls": [tool_call]})
+            await agent._agent.output_queue.put({"content": "Done."})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="just answer directly")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
+            chunks.append(chunk)
+
+        emitted = [c for c in chunks if c["type"] in {"thinking", "tool_call", "content"}]
+        assert [c["type"] for c in emitted] == ["thinking", "tool_call", "content"]
+        assert emitted[0]["type"] == "thinking"
+        assert emitted[0]["delta"] == "First I will inspect the workspace."
+        assert emitted[0]["metadata"]["source"] == "toolcall_agent"
+        assert emitted[1]["type"] == "tool_call"
+        assert emitted[2]["type"] == "content"
+        assert emitted[2]["delta"] == "Done."
+
+    @pytest.mark.asyncio
+    async def test_stream_explicit_thinking_without_tool_call_falls_back_once(self):
+        """Explicit thinking chunks should not be replayed as content before done fallback."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put(
+                {
+                    "type": "thinking",
+                    "delta": "I will think before answering.",
+                    "content": "I will think before answering.",
+                    "metadata": {
+                        "phase": "think",
+                        "source": "toolcall_agent",
+                    },
+                }
+            )
+            return "Final answer."
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="just answer directly")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
+            chunks.append(chunk)
+
+        thinking_chunks = [c for c in chunks if c["type"] == "thinking"]
+        content_chunks = [c for c in chunks if c["type"] == "content"]
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+
+        assert [c["delta"] for c in thinking_chunks] == ["I will think before answering."]
+        assert [c["delta"] for c in content_chunks] == ["Final answer."]
+        assert done_chunks[0]["metadata"]["content"] == "Final answer."
+
+    @pytest.mark.asyncio
+    async def test_stream_handles_dict_thinking_chunks(self):
+        """Structured dict thinking events should pass through unchanged."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put(
+                {
+                    "type": "thinking",
+                    "delta": "Inspecting candidate commands.",
+                    "content": "Inspecting candidate commands.",
+                    "metadata": {"phase": "think", "source": "provider"},
+                }
+            )
+            await agent._agent.output_queue.put({"content": "Final answer."})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="test", thinking=True):
+            chunks.append(chunk)
+
+        emitted = [c for c in chunks if c["type"] in {"thinking", "content"}]
+        assert emitted[0] == {
+            "type": "thinking",
+            "delta": "Inspecting candidate commands.",
+            "metadata": {"phase": "think", "source": "provider"},
+        }
+        assert emitted[1]["type"] == "content"
+        assert emitted[1]["delta"] == "Final answer."
+
+    @pytest.mark.asyncio
+    async def test_stream_without_tool_call_keeps_plain_content(self):
+        """thinking=true should not force all plain answers into thinking."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"content": "直接给答案"})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="test", thinking=True):
+            chunks.append(chunk)
+
+        thinking_chunks = [c for c in chunks if c["type"] == "thinking"]
+        content_chunks = [c for c in chunks if c["type"] == "content"]
+        assert thinking_chunks == []
+        assert len(content_chunks) == 1
+        assert content_chunks[0]["delta"] == "直接给答案"
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["metadata"]["content"] == "直接给答案"
+
+    @pytest.mark.asyncio
+    async def test_stream_error_handling(self):
+        """stream() should catch errors and emit done with error metadata."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put("partial")
+            raise RuntimeError("Connection lost")
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
 
         chunks = []
         async for chunk in AgentLoop.stream(agent, message="test"):
@@ -515,9 +939,10 @@ class TestAgentLoopStream:
         # Should get the partial content + error done
         assert chunks[0]["type"] == "content"
         assert chunks[0]["delta"] == "partial"
+        assert chunks[-2]["type"] == "error"
+        assert "Connection lost" in chunks[-2]["metadata"]["error"]
         assert chunks[-1]["type"] == "done"
-        assert "error" in chunks[-1]["metadata"]
-        assert "Connection lost" in chunks[-1]["metadata"]["error"]
+        assert chunks[-1]["metadata"]["content"] == "partial"
 
     @pytest.mark.asyncio
     async def test_stream_skips_session_save_on_error(self):
@@ -555,18 +980,32 @@ class TestAgentLoopStream:
         """stream() should save session after successful completion."""
         from spoon_bot.agent.loop import AgentLoop
 
-        async def mock_stream(message, **kwargs):
-            yield "hello"
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put("hello")
 
         agent = MagicMock(spec=AgentLoop)
         agent._initialized = True
         agent._agent = MagicMock()
-        agent._agent.stream = mock_stream
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
         agent._session = MagicMock()
         agent._session.add_message = MagicMock()
         agent.sessions = MagicMock()
         agent.sessions.save = MagicMock()
         agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
 
         chunks = []
         async for chunk in AgentLoop.stream(agent, message="test message"):
@@ -584,7 +1023,7 @@ class TestAgentLoopStream:
 
         run_cancelled = asyncio.Event()
 
-        async def mock_run(request):
+        async def mock_run(**kwargs):
             await agent._agent.output_queue.put({"content": "hello"})
             try:
                 await asyncio.Future()
@@ -598,6 +1037,7 @@ class TestAgentLoopStream:
         agent._agent.output_queue = asyncio.Queue()
         agent._agent.task_done = asyncio.Event()
         agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
         agent._agent.state = "idle"
         agent._session = MagicMock()
         agent._session.add_message = MagicMock()
@@ -607,8 +1047,13 @@ class TestAgentLoopStream:
         agent.memory.get_memory_context = MagicMock(return_value=None)
         agent.context = MagicMock()
         agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
         agent._build_step_prompt = MagicMock(return_value="prompt")
         agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
 
         stream = AgentLoop.stream(agent, message="test message")
         first_chunk = await stream.__anext__()
@@ -676,10 +1121,11 @@ class TestAgentLoopProcessWithThinking:
 
         mock_inner_agent = MagicMock()
         mock_inner_agent.run = AsyncMock(return_value=result)
+        mock_inner_agent.add_message = AsyncMock()
 
         agent = MagicMock(spec=AgentLoop)
         agent._initialized = True
-        agent._get_or_create_agent = AsyncMock(return_value=mock_inner_agent)
+        agent._agent = mock_inner_agent
         agent._session = MagicMock()
         agent._session.add_message = MagicMock()
         agent.sessions = MagicMock()
@@ -688,6 +1134,16 @@ class TestAgentLoopProcessWithThinking:
         agent.context = MagicMock()
         agent._auto_commit = False
         agent._git = None
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._looks_like_duplicate_thinking = AgentLoop._looks_like_duplicate_thinking.__get__(agent, AgentLoop)
+        agent._normalize_comparable_text = AgentLoop._normalize_comparable_text
+        agent._latest_reasoning_excerpt = None
 
         response, thinking = await AgentLoop.process_with_thinking(agent, message="What is 6*7?")
 
@@ -706,10 +1162,11 @@ class TestAgentLoopProcessWithThinking:
 
         mock_inner_agent = MagicMock()
         mock_inner_agent.run = AsyncMock(return_value=result)
+        mock_inner_agent.add_message = AsyncMock()
 
         agent = MagicMock(spec=AgentLoop)
         agent._initialized = True
-        agent._get_or_create_agent = AsyncMock(return_value=mock_inner_agent)
+        agent._agent = mock_inner_agent
         agent._session = MagicMock()
         agent._session.add_message = MagicMock()
         agent.sessions = MagicMock()
@@ -718,6 +1175,16 @@ class TestAgentLoopProcessWithThinking:
         agent.context = MagicMock()
         agent._auto_commit = False
         agent._git = None
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._looks_like_duplicate_thinking = AgentLoop._looks_like_duplicate_thinking.__get__(agent, AgentLoop)
+        agent._normalize_comparable_text = AgentLoop._normalize_comparable_text
+        agent._latest_reasoning_excerpt = None
 
         response, thinking = await AgentLoop.process_with_thinking(agent, message="test")
         assert thinking == "My thought process"
@@ -733,10 +1200,11 @@ class TestAgentLoopProcessWithThinking:
 
         mock_inner_agent = MagicMock()
         mock_inner_agent.run = AsyncMock(return_value=result)
+        mock_inner_agent.add_message = AsyncMock()
 
         agent = MagicMock(spec=AgentLoop)
         agent._initialized = True
-        agent._get_or_create_agent = AsyncMock(return_value=mock_inner_agent)
+        agent._agent = mock_inner_agent
         agent._session = MagicMock()
         agent._session.add_message = MagicMock()
         agent.sessions = MagicMock()
@@ -745,9 +1213,103 @@ class TestAgentLoopProcessWithThinking:
         agent.context = MagicMock()
         agent._auto_commit = False
         agent._git = None
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._looks_like_duplicate_thinking = AgentLoop._looks_like_duplicate_thinking.__get__(agent, AgentLoop)
+        agent._normalize_comparable_text = AgentLoop._normalize_comparable_text
+        agent._latest_reasoning_excerpt = None
 
         response, thinking = await AgentLoop.process_with_thinking(agent, message="test")
         assert thinking == "Metadata thought"
+
+    @pytest.mark.asyncio
+    async def test_does_not_fall_back_to_tracked_reasoning_when_provider_omits_thinking_fields(self):
+        """process_with_thinking() should not reuse tracked assistant output as thinking."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        result = MagicMock(spec=["content"])
+        result.content = "Answer"
+
+        async def mock_run(**kwargs):
+            agent._capture_reasoning_text("Tracked reasoning excerpt")
+            return result
+
+        mock_inner_agent = MagicMock()
+        mock_inner_agent.run = mock_run
+        mock_inner_agent.add_message = AsyncMock()
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = mock_inner_agent
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._auto_commit = False
+        agent._git = None
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = AgentLoop._reset_reasoning_capture.__get__(agent, AgentLoop)
+        agent._capture_reasoning_text = AgentLoop._capture_reasoning_text.__get__(agent, AgentLoop)
+        agent._looks_like_duplicate_thinking = AgentLoop._looks_like_duplicate_thinking.__get__(agent, AgentLoop)
+        agent._normalize_comparable_text = AgentLoop._normalize_comparable_text
+        agent._reset_reasoning_capture()
+
+        response, thinking = await AgentLoop.process_with_thinking(agent, message="test")
+
+        assert response == "Answer"
+        assert thinking is None
+
+    @pytest.mark.asyncio
+    async def test_process_with_thinking_suppresses_duplicate_metadata_thinking(self):
+        """Provider thinking identical to final content should be omitted."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        result = MagicMock(spec=["content", "metadata"])
+        result.content = "Answer"
+        result.metadata = {"thinking": "Answer"}
+
+        mock_inner_agent = MagicMock()
+        mock_inner_agent.run = AsyncMock(return_value=result)
+        mock_inner_agent.add_message = AsyncMock()
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = mock_inner_agent
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._auto_commit = False
+        agent._git = None
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = AgentLoop._reset_reasoning_capture.__get__(agent, AgentLoop)
+        agent._looks_like_duplicate_thinking = AgentLoop._looks_like_duplicate_thinking.__get__(agent, AgentLoop)
+        agent._normalize_comparable_text = AgentLoop._normalize_comparable_text
+        agent._reset_reasoning_capture()
+
+        response, thinking = await AgentLoop.process_with_thinking(agent, message="test")
+
+        assert response == "Answer"
+        assert thinking is None
 
     @pytest.mark.asyncio
     async def test_error_returns_friendly_message(self):
@@ -756,10 +1318,11 @@ class TestAgentLoopProcessWithThinking:
 
         mock_inner_agent = MagicMock()
         mock_inner_agent.run = AsyncMock(side_effect=RuntimeError("LLM unavailable"))
+        mock_inner_agent.add_message = AsyncMock()
 
         agent = MagicMock(spec=AgentLoop)
         agent._initialized = True
-        agent._get_or_create_agent = AsyncMock(return_value=mock_inner_agent)
+        agent._agent = mock_inner_agent
         agent._session = MagicMock()
         agent.sessions = MagicMock()
         agent.memory = MagicMock()
@@ -767,6 +1330,14 @@ class TestAgentLoopProcessWithThinking:
         agent.context = MagicMock()
         agent._auto_commit = False
         agent._git = None
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._latest_reasoning_excerpt = None
 
         with pytest.raises(RuntimeError, match="LLM unavailable"):
             await AgentLoop.process_with_thinking(agent, message="test")

--- a/tests/test_workspace_terminal_service.py
+++ b/tests/test_workspace_terminal_service.py
@@ -121,6 +121,31 @@ async def test_workspace_terminal_service_rejects_cwd_outside_workspace() -> Non
             await service.open(cwd="/etc", shell=shell)
 
 
+def test_workspace_terminal_service_preserves_logical_workspace_path_for_symlink_root() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        real_workspace = temp_path / "real-workspace"
+        real_workspace.mkdir()
+        linked_workspace = temp_path / "workspace"
+        linked_workspace.symlink_to(real_workspace, target_is_directory=True)
+
+        async def emit_stdout(payload: dict[str, object]) -> None:
+            return None
+
+        async def emit_closed(payload: dict[str, object]) -> None:
+            return None
+
+        service = WorkspaceTerminalService(
+            linked_workspace,
+            emit_stdout=emit_stdout,
+            emit_closed=emit_closed,
+        )
+
+        resolved = service._resolve_workspace_path("/workspace")
+        assert resolved == linked_workspace.absolute()
+        assert resolved != real_workspace.resolve()
+
+
 def test_workspace_terminal_service_terminates_process_group_on_posix(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[int, int]] = []
 


### PR DESCRIPTION
## Summary
- keep TUI reasoning and shell I/O fully visible instead of truncating them
- stream pre-tool planning through WS/SSE as `thinking` before any `tool_call`
- keep final `agent.stream.done` and `agent.complete.response` aligned to the final answer only
- harden live WebSocket test clients against long-running tasks by extending client keepalive settings
- validate the end-to-end behavior against the latest `spoon-core` release path (`v0.4.4`)

## What Changed
- [spoon_bot/cli.py](C:/Users/Ricky/Documents/Project/XSpoonAi/spoon-bot-tui-think-command-io/spoon_bot/cli.py): preserve full reasoning text and full shell command/result rendering in TUI output
- [spoon_bot/agent/loop.py](C:/Users/Ricky/Documents/Project/XSpoonAi/spoon-bot-tui-think-command-io/spoon_bot/agent/loop.py): buffer provider content before the first tool call and re-emit it as `thinking`, while keeping final content buffers clean
- gateway/live WS tests: update WebSocket client keepalive settings so long-running live scenarios are not interrupted by default client ping timeouts

## Root Cause
There were two separate issues:
1. TUI and gateway transports were not using the same boundaries for pre-tool planning vs final answer content, which caused ordering bugs and polluted final responses.
2. Real long-running WS verification was being cut off by the Python `websockets` client's default keepalive timeout, which looked like a server-side streaming problem but was actually a client test harness issue.

## Expected Behavior After This PR
- TUI shows full think text and full shell I/O details.
- WS/SSE emits `thinking` first when the model plans before tool execution.
- `content` starts only after tool execution begins or the final answer is ready.
- `agent.stream.done.content` matches `agent.complete.response`.
- live WS regression runs complete without keepalive disconnects.

## Verification
- `python -m pytest tests/test_cli_tui_output.py -q`
- `python -m pytest tests/test_streaming_thinking.py -q`
- `python -m pytest tests/test_e2e_gateway_live.py -q`
- real WS 10-scenario regression completed successfully after the fix

## Related
- `spoon-core` PR: https://github.com/XSpoonAi/spoon-core/pull/264
- released `spoon-core` version: `v0.4.4`
