### PR TITLE
Keep long-running WS tasks alive and background long tool executions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 This document describes the **Gateway API** exposed by spoon-bot. The frontend should connect to these endpoints for agent interactions, session management, tool/skill control, and real-time streaming.
 
-> **Auto-generated** from source code on 2026-04-07 08:14 UTC.  
+> **Auto-generated** from source code on 2026-04-08 03:40 UTC.  
 > Regenerate with: `python scripts/generate_api_docs.py`
 
 Base URL (local): `http://localhost:8080`  
@@ -57,7 +57,7 @@ Authenticate and get tokens.
 
 **Response Model:** `TokenResponse`
 
-*Source: `spoon_bot/gateway/api/v1/auth.py:22`*
+*Source: `spoon_bot\gateway\api\v1\auth.py:22`*
 
 ### `POST /v1/auth/refresh`
 
@@ -67,7 +67,7 @@ Refresh access token using refresh token.
 
 **Response Model:** `TokenResponse`
 
-*Source: `spoon_bot/gateway/api/v1/auth.py:68`*
+*Source: `spoon_bot\gateway\api\v1\auth.py:68`*
 
 ### `POST /v1/auth/logout`
 
@@ -75,13 +75,13 @@ Logout and invalidate refresh token.
 
 **Request Body:** `RefreshRequest`
 
-*Source: `spoon_bot/gateway/api/v1/auth.py:103`*
+*Source: `spoon_bot\gateway\api\v1\auth.py:103`*
 
 ### `GET /v1/auth/verify`
 
 Verify current authentication.
 
-*Source: `spoon_bot/gateway/api/v1/auth.py:114`*
+*Source: `spoon_bot\gateway\api\v1\auth.py:114`*
 
 ---
 
@@ -95,21 +95,21 @@ Health check endpoint.
 
 **Response Model:** `HealthResponse`
 
-*Source: `spoon_bot/gateway/api/health.py:19`*
+*Source: `spoon_bot\gateway\api\health.py:19`*
 
 ### `GET /ready`
 
 Readiness check endpoint.
 
 
-*Source: `spoon_bot/gateway/api/health.py:62`*
+*Source: `spoon_bot\gateway\api\health.py:62`*
 
 ### `GET /`
 
 Root endpoint with API information.
 
 
-*Source: `spoon_bot/gateway/api/health.py:94`*
+*Source: `spoon_bot\gateway\api\health.py:94`*
 
 ---
 
@@ -171,7 +171,7 @@ Otherwise returns a standard JSON response.
 }
 ```
 
-*Source: `spoon_bot/gateway/api/v1/agent.py:293`*
+*Source: `spoon_bot\gateway\api\v1\agent.py:293`*
 
 ### `POST /v1/agent/voice/chat`
 
@@ -224,7 +224,7 @@ Send voice + optional text to the agent (multipart upload).
 }
 ```
 
-*Source: `spoon_bot/gateway/api/v1/agent.py:722`*
+*Source: `spoon_bot\gateway\api\v1\agent.py:722`*
 
 ---
 
@@ -278,7 +278,7 @@ Get agent status and statistics, including channel health.
 
 **Response Model:** `APIResponse[StatusResponse]`
 
-*Source: `spoon_bot/gateway/api/v1/agent.py:597`*
+*Source: `spoon_bot\gateway\api\v1\agent.py:597`*
 
 ---
 
@@ -290,19 +290,19 @@ Get agent status and statistics, including channel health.
 
 Send a message asynchronously.
 
-*Source: `spoon_bot/gateway/api/v1/agent.py:497`*
+*Source: `spoon_bot\gateway\api\v1\agent.py:497`*
 
 ### `GET /v1/agent/tasks/{task_id}`
 
 Get the status of an async task.
 
-*Source: `spoon_bot/gateway/api/v1/agent.py:533`*
+*Source: `spoon_bot\gateway\api\v1\agent.py:533`*
 
 ### `POST /v1/agent/tasks/{task_id}/cancel`
 
 Cancel an async task.
 
-*Source: `spoon_bot/gateway/api/v1/agent.py:566`*
+*Source: `spoon_bot\gateway\api\v1\agent.py:566`*
 
 ---
 
@@ -315,7 +315,7 @@ List all sessions.
 **Auth Required:** Yes
 
 
-*Source: `spoon_bot/gateway/api/v1/sessions.py:26`*
+*Source: `spoon_bot\gateway\api\v1\sessions.py:26`*
 
 ### `POST /v1/sessions`
 
@@ -325,7 +325,7 @@ Create a new session.
 
 **Request Body:** `SessionCreateRequest`
 
-*Source: `spoon_bot/gateway/api/v1/sessions.py:63`*
+*Source: `spoon_bot\gateway\api\v1\sessions.py:63`*
 
 ### `GET /v1/sessions/{session_key}`
 
@@ -334,7 +334,7 @@ Get session details.
 **Auth Required:** Yes
 
 
-*Source: `spoon_bot/gateway/api/v1/sessions.py:103`*
+*Source: `spoon_bot\gateway\api\v1\sessions.py:103`*
 
 ### `DELETE /v1/sessions/{session_key}`
 
@@ -343,7 +343,7 @@ Delete a session.
 **Auth Required:** Yes
 
 
-*Source: `spoon_bot/gateway/api/v1/sessions.py:138`*
+*Source: `spoon_bot\gateway\api\v1\sessions.py:138`*
 
 ### `POST /v1/sessions/{session_key}/clear`
 
@@ -352,7 +352,7 @@ Clear session history.
 **Auth Required:** Yes
 
 
-*Source: `spoon_bot/gateway/api/v1/sessions.py:157`*
+*Source: `spoon_bot\gateway\api\v1\sessions.py:157`*
 
 ---
 
@@ -365,7 +365,7 @@ List all available tools.
 **Auth Required:** Yes
 
 
-*Source: `spoon_bot/gateway/api/v1/tools.py:25`*
+*Source: `spoon_bot\gateway\api\v1\tools.py:26`*
 
 ### `GET /v1/tools/{tool_name}/schema`
 
@@ -374,7 +374,7 @@ Get the schema for a specific tool.
 **Auth Required:** Yes
 
 
-*Source: `spoon_bot/gateway/api/v1/tools.py:52`*
+*Source: `spoon_bot\gateway\api\v1\tools.py:53`*
 
 ### `POST /v1/tools/{tool_name}/execute`
 
@@ -384,7 +384,7 @@ Execute a tool directly.
 
 **Request Body:** `ToolExecuteRequest`
 
-*Source: `spoon_bot/gateway/api/v1/tools.py:83`*
+*Source: `spoon_bot\gateway\api\v1\tools.py:84`*
 
 ---
 
@@ -397,7 +397,7 @@ List all available skills.
 **Auth Required:** Yes
 
 
-*Source: `spoon_bot/gateway/api/v1/skills.py:51`*
+*Source: `spoon_bot\gateway\api\v1\skills.py:51`*
 
 ### `POST /v1/skills/{skill_name}/activate`
 
@@ -407,7 +407,7 @@ Activate a skill.
 
 **Request Body:** `SkillActivateRequest`
 
-*Source: `spoon_bot/gateway/api/v1/skills.py:86`*
+*Source: `spoon_bot\gateway\api\v1\skills.py:86`*
 
 ### `POST /v1/skills/{skill_name}/deactivate`
 
@@ -416,7 +416,7 @@ Deactivate a skill.
 **Auth Required:** Yes
 
 
-*Source: `spoon_bot/gateway/api/v1/skills.py:144`*
+*Source: `spoon_bot\gateway\api\v1\skills.py:144`*
 
 ---
 
@@ -525,7 +525,7 @@ Handle audio.stream.end
 
 ### Request Models
 
-*Source: `spoon_bot/gateway/models/requests.py`*
+*Source: `spoon_bot\gateway\models\requests.py`*
 
 #### `ChatOptions`
 
@@ -628,7 +628,7 @@ Configuration update request model.
 
 ### Response Models
 
-*Source: `spoon_bot/gateway/models/responses.py`*
+*Source: `spoon_bot\gateway\models\responses.py`*
 
 #### `MetaInfo`
 
@@ -966,9 +966,9 @@ Health check response.
 | `GATEWAY_PORT` | `8080` | config.py |
 | `GATEWAY_DEBUG` | *(none)* | config.py |
 | `JWT_ACCESS_EXPIRE_MINUTES` | `15` | config.py |
-| `GATEWAY_TIMEOUT_REQUEST_MS` | `3600000` | config.py |
+| `GATEWAY_TIMEOUT_REQUEST_MS` | `0` | config.py |
 | `GATEWAY_TIMEOUT_TOOL_MS` | `3600000` | config.py |
-| `GATEWAY_TIMEOUT_STREAM_MS` | `3600000` | config.py |
+| `GATEWAY_TIMEOUT_STREAM_MS` | `0` | config.py |
 | `GATEWAY_AUDIO_ENABLED` | `true` | config.py |
 | `GATEWAY_AUDIO_STT_PROVIDER` | `whisper` | config.py |
 | `GATEWAY_AUDIO_STT_MODEL` | `whisper-1` | config.py |

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2191,8 +2191,6 @@ class AgentLoop:
             oq = self._agent.output_queue
             td = self._agent.task_done
             logger.debug(f"output_queue type={type(oq).__name__}, task_done type={type(td).__name__}")
-            stream_timeout = 600.0 if thinking else 300.0
-            deadline = asyncio.get_event_loop().time() + stream_timeout
             chunk_count = 0
 
             logger.debug(f"Entering stream loop: td={td.is_set()}, qempty={oq.empty()}, qsize={oq.qsize()}")
@@ -2201,26 +2199,9 @@ class AgentLoop:
                 # not a reliable API thinking source. Clear it so it does not leak
                 # duplicated final content into WS/REST responses.
                 self._drain_reasoning_chunks()
-                now_ts = asyncio.get_event_loop().time()
-
-                if now_ts > deadline:
-                    logger.warning(
-                        f"Streaming deadline reached ({stream_timeout}s), "
-                        f"stopping after {chunk_count} chunks"
-                    )
-                    yield {
-                        "type": "error",
-                        "delta": f"Stream timeout after {int(stream_timeout)}s",
-                        "metadata": {
-                            "error": "STREAM_TIMEOUT",
-                            "error_code": "STREAM_TIMEOUT",
-                            "timeout_seconds": stream_timeout,
-                            "chunks_received": chunk_count,
-                        },
-                    }
-                    break
-
                 try:
+                    # Poll without a hard stream deadline so long-running tasks
+                    # only stop when the caller explicitly cancels them.
                     # Use oq.get() without timeout kwarg — works for both
                     # asyncio.Queue and ThreadSafeOutputQueue. Timeout is
                     # handled by the outer asyncio.wait_for.

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2472,7 +2472,8 @@ class AgentLoop:
             run_kwargs: dict[str, Any] = {}
             if self._callable_accepts_kwarg(self._agent.run, "thinking"):
                 run_kwargs["thinking"] = True
-            result = await self._agent.run(**run_kwargs)
+            with bind_tool_owner(self._current_tool_owner_key()):
+                result = await self._agent.run(**run_kwargs)
 
             # Extract content and thinking
             if hasattr(result, "content"):

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -81,6 +81,7 @@ from spoon_bot.agent.tools.filesystem import (
     ListDirTool,
 )
 from spoon_bot.agent.tools.grep import GrepTool
+from spoon_bot.agent.tools.execution_context import bind_tool_owner
 from spoon_bot.agent.tools.self_config import (
     ActivateToolTool,
     SelfConfigTool,
@@ -1244,7 +1245,8 @@ class AgentLoop:
                     ):
                         await self._agent.add_message("user", runtime_message)
                     retry_requires_runtime_message_check = False
-                    result = await self._agent.run()
+                    with bind_tool_owner(getattr(self, "session_key", "default")):
+                        result = await self._agent.run()
 
                     logger.debug(f"Agent result type: {type(result)}")
                     if hasattr(result, 'content'):
@@ -2161,7 +2163,8 @@ class AgentLoop:
                     run_kwargs: dict[str, Any] = {}
                     if thinking and self._callable_accepts_kwarg(self._agent.run, "thinking"):
                         run_kwargs["thinking"] = True
-                    result = await self._agent.run(**run_kwargs)
+                    with bind_tool_owner(getattr(self, "session_key", "default")):
+                        result = await self._agent.run(**run_kwargs)
                     if hasattr(result, "content"):
                         run_result_text = result.content or ""
                     elif isinstance(result, str):
@@ -2182,7 +2185,8 @@ class AgentLoop:
                     self._agent.task_done.set()
 
             logger.debug(f"Creating bg task, agent state={self._agent.state}")
-            bg_task = asyncio.create_task(_run_and_signal())
+            with bind_tool_owner(getattr(self, "session_key", "default")):
+                bg_task = asyncio.create_task(_run_and_signal())
 
             # Force a yield to allow the background task to start
             await asyncio.sleep(0)

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -81,7 +81,7 @@ from spoon_bot.agent.tools.filesystem import (
     ListDirTool,
 )
 from spoon_bot.agent.tools.grep import GrepTool
-from spoon_bot.agent.tools.execution_context import bind_tool_owner
+from spoon_bot.agent.tools.execution_context import bind_tool_owner, build_tool_owner_key
 from spoon_bot.agent.tools.self_config import (
     ActivateToolTool,
     SelfConfigTool,
@@ -402,6 +402,7 @@ class AgentLoop:
         self.shell_timeout = self._config.shell_timeout
         self.max_output = self._config.max_output
         self.session_key = self._config.session_key
+        self.user_id = "anonymous"
         self._enable_skills = enable_skills
         self._mcp_config = mcp_config or {}
         self._system_prompt = system_prompt
@@ -1154,6 +1155,13 @@ class AgentLoop:
             return self.context._build_user_content(text_content, media)
         return text_content
 
+    def _current_tool_owner_key(self, session_key: str | None = None) -> str:
+        """Resolve a user-scoped ownership key for background tool jobs."""
+        return build_tool_owner_key(
+            getattr(self, "user_id", None),
+            session_key if session_key is not None else getattr(self, "session_key", None),
+        )
+
     async def process(
         self,
         message: str,
@@ -1245,7 +1253,7 @@ class AgentLoop:
                     ):
                         await self._agent.add_message("user", runtime_message)
                     retry_requires_runtime_message_check = False
-                    with bind_tool_owner(getattr(self, "session_key", "default")):
+                    with bind_tool_owner(self._current_tool_owner_key()):
                         result = await self._agent.run()
 
                     logger.debug(f"Agent result type: {type(result)}")
@@ -2163,7 +2171,7 @@ class AgentLoop:
                     run_kwargs: dict[str, Any] = {}
                     if thinking and self._callable_accepts_kwarg(self._agent.run, "thinking"):
                         run_kwargs["thinking"] = True
-                    with bind_tool_owner(getattr(self, "session_key", "default")):
+                    with bind_tool_owner(self._current_tool_owner_key()):
                         result = await self._agent.run(**run_kwargs)
                     if hasattr(result, "content"):
                         run_result_text = result.content or ""
@@ -2185,7 +2193,7 @@ class AgentLoop:
                     self._agent.task_done.set()
 
             logger.debug(f"Creating bg task, agent state={self._agent.state}")
-            with bind_tool_owner(getattr(self, "session_key", "default")):
+            with bind_tool_owner(self._current_tool_owner_key()):
                 bg_task = asyncio.create_task(_run_and_signal())
 
             # Force a yield to allow the background task to start

--- a/spoon_bot/agent/tools/execution_context.py
+++ b/spoon_bot/agent/tools/execution_context.py
@@ -1,0 +1,29 @@
+"""Task-local execution context for tool ownership scoping."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+
+
+_TOOL_OWNER: ContextVar[str] = ContextVar("tool_owner", default="default")
+
+
+def get_tool_owner() -> str:
+    """Return current task-local tool owner key."""
+    owner = _TOOL_OWNER.get()
+    if isinstance(owner, str) and owner.strip():
+        return owner.strip()
+    return "default"
+
+
+@contextmanager
+def bind_tool_owner(owner: str | None) -> Iterator[str]:
+    """Bind tool owner for the current task context."""
+    normalized = owner.strip() if isinstance(owner, str) and owner.strip() else "default"
+    token = _TOOL_OWNER.set(normalized)
+    try:
+        yield normalized
+    finally:
+        _TOOL_OWNER.reset(token)

--- a/spoon_bot/agent/tools/execution_context.py
+++ b/spoon_bot/agent/tools/execution_context.py
@@ -10,6 +10,28 @@ from typing import Iterator
 _TOOL_OWNER: ContextVar[str] = ContextVar("tool_owner", default="default")
 
 
+def normalize_tool_owner_user(user_id: str | None) -> str:
+    """Normalize user identity component for tool ownership."""
+    if isinstance(user_id, str) and user_id.strip():
+        return user_id.strip()
+    return "anonymous"
+
+
+def normalize_tool_owner_session(session_key: str | None) -> str:
+    """Normalize session component for tool ownership."""
+    if isinstance(session_key, str) and session_key.strip():
+        return session_key.strip()
+    return "default"
+
+
+def build_tool_owner_key(user_id: str | None, session_key: str | None) -> str:
+    """Build a stable user+session ownership key."""
+    return (
+        f"user:{normalize_tool_owner_user(user_id)}"
+        f"|session:{normalize_tool_owner_session(session_key)}"
+    )
+
+
 def get_tool_owner() -> str:
     """Return current task-local tool owner key."""
     owner = _TOOL_OWNER.get()

--- a/spoon_bot/agent/tools/shell.py
+++ b/spoon_bot/agent/tools/shell.py
@@ -8,8 +8,10 @@ import re
 import shlex
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from loguru import logger
 
@@ -356,6 +358,37 @@ class CommandValidator:
         return command
 
 
+@dataclass
+class _BackgroundShellJob:
+    job_id: str
+    command: str
+    cwd: str
+    process: Any
+    stdout_task: asyncio.Task[None]
+    stderr_task: asyncio.Task[None]
+    buffer_limit: int
+    stdout_text: str = ""
+    stderr_text: str = ""
+    status: str = "running"
+    returncode: int | None = None
+
+    def append_stdout(self, text: str) -> None:
+        self.stdout_text = _append_capped_text(self.stdout_text, text, self.buffer_limit)
+
+    def append_stderr(self, text: str) -> None:
+        self.stderr_text = _append_capped_text(self.stderr_text, text, self.buffer_limit)
+
+
+def _append_capped_text(existing: str, addition: str, limit: int) -> str:
+    combined = existing + addition
+    if len(combined) <= limit:
+        return combined
+    return combined[-limit:]
+
+
+_SHELL_BACKGROUND_JOBS: dict[str, _BackgroundShellJob] = {}
+
+
 class ShellTool(Tool):
     """
     Tool to execute shell commands with comprehensive safety guards.
@@ -436,9 +469,10 @@ class ShellTool(Tool):
     def description(self) -> str:
         mode = "whitelist" if self.validator.whitelist_mode else "blocklist"
         return (
-            f"Execute a shell command and return its output. "
-            f"Commands timeout after {self.timeout}s. "
+            "Execute a shell command or manage a long-running background shell job. "
+            f"Foreground wait budget: {self.timeout}s, then the command stays running in the background. "
             f"Security mode: {mode}. "
+            "Actions: execute, list_jobs, job_status, job_output, terminate_job. "
             "Dangerous commands and injection patterns are blocked."
         )
 
@@ -449,14 +483,30 @@ class ShellTool(Tool):
             "properties": {
                 "command": {
                     "type": "string",
-                    "description": "The shell command to execute (validated for safety)",
+                    "description": "The shell command to execute (required for action=execute)",
                 },
                 "working_dir": {
                     "type": "string",
                     "description": "Optional working directory for the command",
                 },
+                "action": {
+                    "type": "string",
+                    "enum": ["execute", "list_jobs", "job_status", "job_output", "terminate_job"],
+                    "description": "Tool action. Defaults to execute.",
+                    "default": "execute",
+                },
+                "job_id": {
+                    "type": "string",
+                    "description": "Background shell job ID for status/output/terminate actions",
+                },
+                "tail_chars": {
+                    "type": "integer",
+                    "description": "How many trailing characters of output to return for background job inspection",
+                    "default": 4000,
+                    "minimum": 200,
+                    "maximum": 50000,
+                },
             },
-            "required": ["command"],
         }
 
     def _parse_command_args(self, command: str) -> list[str]:
@@ -671,10 +721,255 @@ class ShellTool(Tool):
             )
         return result.stdout, result.stderr, result.returncode
 
-    async def execute(
+    def _build_output_result(
+        self,
+        stdout_text: str,
+        stderr_text: str,
+        returncode: int | None,
+        *,
+        max_chars: int | None = None,
+    ) -> str:
+        output_parts = []
+
+        if stdout_text:
+            output_parts.append(stdout_text)
+
+        if stderr_text and stderr_text.strip():
+            output_parts.append(f"STDERR:\n{stderr_text}")
+
+        if returncode not in (None, 0):
+            output_parts.append(f"\nExit code: {returncode}")
+
+        result = "\n".join(output_parts) if output_parts else "(no output)"
+        result = self._mask_secrets(result)
+
+        limit = max_chars or self.max_output
+        if len(result) > limit:
+            truncated = len(result) - limit
+            result = result[:limit] + f"\n... (truncated, {truncated} more chars)"
+
+        return result
+
+    async def _consume_process_stream(
+        self,
+        stream: Any,
+        append: Any,
+    ) -> None:
+        if stream is None:
+            return
+        while True:
+            chunk = await asyncio.to_thread(stream.read, 4096)
+            if not chunk:
+                return
+            append(chunk.decode("utf-8", errors="replace"))
+
+    async def _create_process(
         self,
         command: str,
+        cwd: str,
+    ) -> subprocess.Popen[bytes]:
+        env = os.environ.copy()
+        userprofile = env.get("USERPROFILE", "").strip()
+        if userprofile and env.get("HOME", "").strip() in {"", "/root"}:
+            env["HOME"] = userprofile.replace("\\", "/")
+
+        if sys.platform == "win32":
+            home_path = str(Path.home())
+            env["USERPROFILE"] = home_path
+            if len(home_path) >= 2 and home_path[1] == ":":
+                env["HOMEDRIVE"] = home_path[:2]
+                env["HOMEPATH"] = home_path[2:] or "\\"
+            bash = self._find_bash()
+            if bash:
+                env["HOME"] = self._windows_home_to_bash(home_path)
+                command = self._convert_win_paths_to_posix(command)
+                cwd = cwd.replace("\\", "/")
+                return subprocess.Popen(
+                    [bash, "-c", command],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    stdin=subprocess.DEVNULL,
+                    cwd=cwd,
+                    env=env,
+                )
+            env["HOME"] = home_path.replace("\\", "/")
+            return subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.DEVNULL,
+                shell=True,
+                cwd=cwd,
+                env=env,
+            )
+
+        if self.use_shell:
+            return subprocess.Popen(
+                command,
+                shell=True,
+                executable="/bin/sh",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.DEVNULL,
+                cwd=cwd,
+                env=env,
+            )
+
+        args = self._parse_command_args(command)
+        if not args:
+            raise ValueError("Empty command after parsing")
+        return subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            cwd=cwd,
+            env=env,
+        )
+
+    @staticmethod
+    def _get_process_returncode(process: Any) -> int | None:
+        poll = getattr(process, "poll", None)
+        if callable(poll):
+            try:
+                return poll()
+            except Exception:
+                pass
+        return getattr(process, "returncode", None)
+
+    async def _wait_for_process(self, process: Any) -> int | None:
+        wait = getattr(process, "wait")
+        if asyncio.iscoroutinefunction(wait):
+            return await wait()
+        return await asyncio.to_thread(wait)
+
+    async def _start_background_job(
+        self,
+        command: str,
+        cwd: str,
+    ) -> _BackgroundShellJob:
+        process = await self._create_process(command, cwd)
+        job = _BackgroundShellJob(
+            job_id=f"sh_{uuid4().hex[:10]}",
+            command=command,
+            cwd=cwd,
+            process=process,
+            stdout_task=asyncio.create_task(asyncio.sleep(0)),
+            stderr_task=asyncio.create_task(asyncio.sleep(0)),
+            buffer_limit=max(self.max_output * 20, 200_000),
+        )
+        job.stdout_task = asyncio.create_task(
+            self._consume_process_stream(process.stdout, job.append_stdout)
+        )
+        job.stderr_task = asyncio.create_task(
+            self._consume_process_stream(process.stderr, job.append_stderr)
+        )
+        _SHELL_BACKGROUND_JOBS[job.job_id] = job
+        return job
+
+    async def _refresh_background_job(self, job: _BackgroundShellJob) -> _BackgroundShellJob:
+        returncode = self._get_process_returncode(job.process)
+        if job.status == "running" and returncode is not None:
+            job.returncode = returncode
+            job.status = "completed" if job.returncode == 0 else "failed"
+        if returncode is not None:
+            await asyncio.gather(job.stdout_task, job.stderr_task, return_exceptions=True)
+        return job
+
+    def _format_background_job_summary(
+        self,
+        job: _BackgroundShellJob,
+        *,
+        timeout_seconds: int,
+        tail_chars: int = 4000,
+    ) -> str:
+        recent_output = self._build_output_result(
+            job.stdout_text,
+            job.stderr_text,
+            job.returncode,
+            max_chars=tail_chars,
+        )
+        return (
+            f"Foreground wait budget ({timeout_seconds}s) expired; command is still running in the background.\n"
+            f"job_id: {job.job_id}\n"
+            f"command: {job.command}\n"
+            f"cwd: {job.cwd}\n"
+            "status: running\n"
+            "Recent output tail:\n"
+            f"{recent_output}\n\n"
+            "Use action='job_status' or action='job_output' with this job_id to inspect it. "
+            "Use action='terminate_job' to stop it."
+        )
+
+    async def _handle_background_action(
+        self,
+        action: str,
+        job_id: str | None,
+        tail_chars: int,
+    ) -> str:
+        if action == "list_jobs":
+            if not _SHELL_BACKGROUND_JOBS:
+                return "No background shell jobs"
+            lines = ["Background shell jobs:"]
+            for job in list(_SHELL_BACKGROUND_JOBS.values()):
+                await self._refresh_background_job(job)
+                lines.append(
+                    f"[{job.job_id}] {job.status} cwd={job.cwd} command={self.validator.sanitize_for_display(job.command)}"
+                )
+            return "\n".join(lines)
+
+        if not job_id:
+            return "Error: 'job_id' is required for this action"
+
+        job = _SHELL_BACKGROUND_JOBS.get(job_id)
+        if not job:
+            return f"Error: Background shell job not found: {job_id}"
+
+        await self._refresh_background_job(job)
+
+        if action == "job_status":
+            return (
+                f"job_id: {job.job_id}\n"
+                f"status: {job.status}\n"
+                f"cwd: {job.cwd}\n"
+                f"command: {job.command}\n"
+                f"returncode: {job.returncode if job.returncode is not None else 'running'}\n"
+                "Recent output tail:\n"
+                f"{self._build_output_result(job.stdout_text, job.stderr_text, job.returncode, max_chars=tail_chars)}"
+            )
+
+        if action == "job_output":
+            return self._build_output_result(
+                job.stdout_text,
+                job.stderr_text,
+                job.returncode,
+                max_chars=tail_chars,
+            )
+
+        if action == "terminate_job":
+            if self._get_process_returncode(job.process) is None:
+                job.process.terminate()
+                try:
+                    await asyncio.wait_for(self._wait_for_process(job.process), timeout=5.0)
+                except asyncio.TimeoutError:
+                    job.process.kill()
+                    await self._wait_for_process(job.process)
+            await self._refresh_background_job(job)
+            job.status = "terminated"
+            return (
+                f"Terminated background shell job {job.job_id}.\n"
+                f"{self._build_output_result(job.stdout_text, job.stderr_text, job.returncode, max_chars=tail_chars)}"
+            )
+
+        return f"Error: Unknown action '{action}'"
+
+    async def execute(
+        self,
+        command: str | None = None,
         working_dir: str | None = None,
+        action: str = "execute",
+        job_id: str | None = None,
+        tail_chars: int = 4000,
         **kwargs: Any,
     ) -> str:
         """
@@ -687,6 +982,12 @@ class ShellTool(Tool):
         Returns:
             Command output or error message.
         """
+        if action != "execute":
+            return await self._handle_background_action(action, job_id, tail_chars)
+
+        if not command or not str(command).strip():
+            return "Error: 'command' is required for action='execute'"
+
         # Apply rate limiting
         if self._rate_limit_config.enabled:
             wait_time = await self._rate_limiter.wait_and_acquire()
@@ -706,39 +1007,18 @@ class ShellTool(Tool):
             return f"Error: Working directory not found: {cwd}"
 
         try:
-            loop = asyncio.get_running_loop()
-            stdout, stderr, returncode = await loop.run_in_executor(
-                None, self._run_sync, command, cwd
-            )
-
-            output_parts = []
-
-            if stdout:
-                stdout_text = stdout.decode("utf-8", errors="replace")
-                output_parts.append(stdout_text)
-
-            if stderr:
-                stderr_text = stderr.decode("utf-8", errors="replace")
-                if stderr_text.strip():
-                    output_parts.append(f"STDERR:\n{stderr_text}")
-
-            if returncode != 0:
-                output_parts.append(f"\nExit code: {returncode}")
-
-            result = "\n".join(output_parts) if output_parts else "(no output)"
-
-            # Mask private keys / secrets so they don't leak into logs or context
-            result = self._mask_secrets(result)
-
-            # Truncate very long output
-            if len(result) > self.max_output:
-                truncated = len(result) - self.max_output
-                result = result[: self.max_output] + f"\n... (truncated, {truncated} more chars)"
-
-            return result
-
-        except (asyncio.TimeoutError, subprocess.TimeoutExpired):
-            return f"Error: Command timed out after {self.timeout} seconds"
+            job = await self._start_background_job(command, cwd)
+            try:
+                await asyncio.wait_for(self._wait_for_process(job.process), timeout=self.timeout)
+                await self._refresh_background_job(job)
+                return self._build_output_result(job.stdout_text, job.stderr_text, job.returncode)
+            except asyncio.TimeoutError:
+                await self._refresh_background_job(job)
+                return self._format_background_job_summary(
+                    job,
+                    timeout_seconds=self.timeout,
+                    tail_chars=tail_chars,
+                )
         except FileNotFoundError as e:
             return f"Error: Command or file not found: {e}"
         except PermissionError:
@@ -767,7 +1047,7 @@ class SafeShellTool(ShellTool):
 
     def __init__(
         self,
-        timeout: int = 60,
+        timeout: int = 3600,
         max_output: int = 10000,
         working_dir: str | None = None,
         custom_whitelist: set[str] | None = None,
@@ -800,6 +1080,6 @@ class SafeShellTool(ShellTool):
     def description(self) -> str:
         return (
             "Execute a shell command from a whitelist of safe commands. "
-            f"Commands timeout after {self.timeout}s. "
+            f"Foreground wait budget: {self.timeout}s, then the command stays running in the background. "
             "Only predefined commands are allowed for security."
         )

--- a/spoon_bot/agent/tools/shell.py
+++ b/spoon_bot/agent/tools/shell.py
@@ -8,7 +8,8 @@ import re
 import shlex
 import subprocess
 import sys
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -16,6 +17,7 @@ from uuid import uuid4
 from loguru import logger
 
 from spoon_bot.agent.tools.base import Tool
+from spoon_bot.agent.tools.execution_context import get_tool_owner
 from spoon_bot.utils.rate_limit import (
     RateLimitConfig,
     get_rate_limiter,
@@ -367,10 +369,13 @@ class _BackgroundShellJob:
     stdout_task: asyncio.Task[None]
     stderr_task: asyncio.Task[None]
     buffer_limit: int
+    owner_key: str = "default"
     stdout_text: str = ""
     stderr_text: str = ""
     status: str = "running"
     returncode: int | None = None
+    created_at: float = field(default_factory=time.time)
+    finished_at: float | None = None
 
     def append_stdout(self, text: str) -> None:
         self.stdout_text = _append_capped_text(self.stdout_text, text, self.buffer_limit)
@@ -847,10 +852,13 @@ class ShellTool(Tool):
         self,
         command: str,
         cwd: str,
+        owner_key: str | None = None,
     ) -> _BackgroundShellJob:
+        owner = owner_key or get_tool_owner()
         process = await self._create_process(command, cwd)
         job = _BackgroundShellJob(
             job_id=f"sh_{uuid4().hex[:10]}",
+            owner_key=owner,
             command=command,
             cwd=cwd,
             process=process,
@@ -865,6 +873,7 @@ class ShellTool(Tool):
             self._consume_process_stream(process.stderr, job.append_stderr)
         )
         _SHELL_BACKGROUND_JOBS[job.job_id] = job
+        self._prune_background_jobs(owner_key=owner)
         return job
 
     async def _refresh_background_job(self, job: _BackgroundShellJob) -> _BackgroundShellJob:
@@ -872,9 +881,33 @@ class ShellTool(Tool):
         if job.status == "running" and returncode is not None:
             job.returncode = returncode
             job.status = "completed" if job.returncode == 0 else "failed"
+            job.finished_at = time.time()
         if returncode is not None:
             await asyncio.gather(job.stdout_task, job.stderr_task, return_exceptions=True)
         return job
+
+    @staticmethod
+    def _is_terminal_status(status: str) -> bool:
+        return status in {"completed", "failed", "terminated", "cancelled"}
+
+    def _prune_background_jobs(
+        self,
+        *,
+        owner_key: str | None = None,
+        keep_completed_per_owner: int = 20,
+    ) -> None:
+        completed_jobs: dict[str, list[_BackgroundShellJob]] = {}
+        for job in _SHELL_BACKGROUND_JOBS.values():
+            if not self._is_terminal_status(job.status):
+                continue
+            if owner_key is not None and job.owner_key != owner_key:
+                continue
+            completed_jobs.setdefault(job.owner_key, []).append(job)
+
+        for owner, jobs in completed_jobs.items():
+            jobs.sort(key=lambda j: j.finished_at or j.created_at, reverse=True)
+            for stale_job in jobs[keep_completed_per_owner:]:
+                _SHELL_BACKGROUND_JOBS.pop(stale_job.job_id, None)
 
     def _format_background_job_summary(
         self,
@@ -907,11 +940,18 @@ class ShellTool(Tool):
         job_id: str | None,
         tail_chars: int,
     ) -> str:
+        owner_key = get_tool_owner()
+        self._prune_background_jobs(owner_key=owner_key)
+
         if action == "list_jobs":
-            if not _SHELL_BACKGROUND_JOBS:
+            owner_jobs = [
+                job for job in _SHELL_BACKGROUND_JOBS.values()
+                if job.owner_key == owner_key
+            ]
+            if not owner_jobs:
                 return "No background shell jobs"
             lines = ["Background shell jobs:"]
-            for job in list(_SHELL_BACKGROUND_JOBS.values()):
+            for job in owner_jobs:
                 await self._refresh_background_job(job)
                 lines.append(
                     f"[{job.job_id}] {job.status} cwd={job.cwd} command={self.validator.sanitize_for_display(job.command)}"
@@ -922,7 +962,7 @@ class ShellTool(Tool):
             return "Error: 'job_id' is required for this action"
 
         job = _SHELL_BACKGROUND_JOBS.get(job_id)
-        if not job:
+        if not job or job.owner_key != owner_key:
             return f"Error: Background shell job not found: {job_id}"
 
         await self._refresh_background_job(job)
@@ -956,6 +996,7 @@ class ShellTool(Tool):
                     await self._wait_for_process(job.process)
             await self._refresh_background_job(job)
             job.status = "terminated"
+            job.finished_at = time.time()
             return (
                 f"Terminated background shell job {job.job_id}.\n"
                 f"{self._build_output_result(job.stdout_text, job.stderr_text, job.returncode, max_chars=tail_chars)}"
@@ -1007,13 +1048,18 @@ class ShellTool(Tool):
             return f"Error: Working directory not found: {cwd}"
 
         try:
-            job = await self._start_background_job(command, cwd)
+            owner_key = get_tool_owner()
+            job = await self._start_background_job(command, cwd, owner_key=owner_key)
             try:
                 await asyncio.wait_for(self._wait_for_process(job.process), timeout=self.timeout)
                 await self._refresh_background_job(job)
-                return self._build_output_result(job.stdout_text, job.stderr_text, job.returncode)
+                result = self._build_output_result(job.stdout_text, job.stderr_text, job.returncode)
+                _SHELL_BACKGROUND_JOBS.pop(job.job_id, None)
+                self._prune_background_jobs(owner_key=owner_key)
+                return result
             except asyncio.TimeoutError:
                 await self._refresh_background_job(job)
+                self._prune_background_jobs(owner_key=owner_key)
                 return self._format_background_job_summary(
                     job,
                     timeout_seconds=self.timeout,

--- a/spoon_bot/gateway/api/v1/agent.py
+++ b/spoon_bot/gateway/api/v1/agent.py
@@ -193,6 +193,7 @@ async def _stream_sse(
     thinking: bool,
     *,
     session_key: str | None = None,
+    user_id: str | None = None,
     trace_id: str | None = None,
     request_id: str | None = None,
     cancel_event: asyncio.Event | None = None,
@@ -217,6 +218,7 @@ async def _stream_sse(
     async with session_lock:
         async with agent_lock:
             _switch_session(agent, resolved_session_key)
+            setattr(agent, "user_id", user_id or "anonymous")
 
             kwargs = {"message": message, "thinking": thinking}
             if media:
@@ -311,6 +313,7 @@ async def chat(
 
     try:
         agent = get_agent()
+        owner_user_id = getattr(user, "user_id", "anonymous")
 
         # Session key: request body takes priority over user token.
         session_key = _resolve_session_key(request.session_key, user)
@@ -343,6 +346,7 @@ async def chat(
                     attachments or None,
                     thinking,
                     session_key=session_key,
+                    user_id=owner_user_id,
                     trace_id=trace_id,
                     request_id=request_id,
                 ),
@@ -361,6 +365,7 @@ async def chat(
             async with agent_lock:
                 # Non-streaming mode — switch session before processing
                 _switch_session(agent, session_key)
+                setattr(agent, "user_id", owner_user_id)
 
                 kwargs = {"message": message}
                 if media:
@@ -465,7 +470,13 @@ class AsyncTask:
 _task_store: dict[str, AsyncTask] = {}
 
 
-async def _run_async_task(task: AsyncTask, agent, message: str, session_key: str | None = None):
+async def _run_async_task(
+    task: AsyncTask,
+    agent,
+    message: str,
+    session_key: str | None = None,
+    user_id: str | None = None,
+):
     """Background coroutine that drives agent processing for an async task."""
     task.status = TaskStatus.RUNNING
     try:
@@ -475,6 +486,7 @@ async def _run_async_task(task: AsyncTask, agent, message: str, session_key: str
         async with session_lock:
             async with agent_lock:
                 _switch_session(agent, resolved_session_key)
+                setattr(agent, "user_id", user_id or "anonymous")
                 if task._cancel_event.is_set():
                     task.status = TaskStatus.CANCELLED
                     return
@@ -519,7 +531,15 @@ async def chat_async(
     task = AsyncTask(task_id=task_id, owner_user_id=owner_user_id)
     _task_store[task_id] = task
 
-    bg = asyncio.create_task(_run_async_task(task, agent, request.message, session_key=session_key))
+    bg = asyncio.create_task(
+        _run_async_task(
+            task,
+            agent,
+            request.message,
+            session_key=session_key,
+            user_id=owner_user_id,
+        )
+    )
     task._bg_task = bg
 
     return {
@@ -776,6 +796,7 @@ async def voice_chat(
                 None,
                 False,
                 session_key=session_key,
+                user_id=owner_user_id,
                 trace_id=trace_id,
                 request_id=request_id,
             ),
@@ -789,6 +810,7 @@ async def voice_chat(
         )
 
     _switch_session(agent, session_key)
+    setattr(agent, "user_id", owner_user_id)
     response_text = await agent.process(message=processed_message)
     duration_ms = int((time.time() - start_time) * 1000)
 

--- a/spoon_bot/gateway/api/v1/agent.py
+++ b/spoon_bot/gateway/api/v1/agent.py
@@ -751,6 +751,7 @@ async def voice_chat(
     request_id = f"req_{uuid4().hex[:12]}"
     start_time = time.time()
     trace_id = new_trace_id()
+    owner_user_id = getattr(user, "user_id", "anonymous") if user else "anonymous"
 
     config = get_config()
     if not config.audio.enabled:

--- a/spoon_bot/gateway/api/v1/tools.py
+++ b/spoon_bot/gateway/api/v1/tools.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from spoon_bot.gateway.app import get_agent
 from spoon_bot.gateway.auth.dependencies import CurrentUser, require_scope
 from spoon_bot.gateway.models.requests import ToolExecuteRequest
-from spoon_bot.agent.tools.execution_context import bind_tool_owner
+from spoon_bot.agent.tools.execution_context import bind_tool_owner, build_tool_owner_key
 from spoon_bot.gateway.models.responses import (
     APIResponse,
     MetaInfo,
@@ -102,8 +102,11 @@ async def execute_tool(
         )
 
     try:
-        owner_key = getattr(user, "session_key", None) or getattr(user, "user_id", None) or "admin"
-        with bind_tool_owner(str(owner_key)):
+        owner_key = build_tool_owner_key(
+            getattr(user, "user_id", None),
+            getattr(user, "session_key", None),
+        )
+        with bind_tool_owner(owner_key):
             result = await agent.tools.execute(tool_name, request.arguments)
         if isinstance(result, str):
             try:

--- a/spoon_bot/gateway/api/v1/tools.py
+++ b/spoon_bot/gateway/api/v1/tools.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from spoon_bot.gateway.app import get_agent
 from spoon_bot.gateway.auth.dependencies import CurrentUser, require_scope
 from spoon_bot.gateway.models.requests import ToolExecuteRequest
+from spoon_bot.agent.tools.execution_context import bind_tool_owner
 from spoon_bot.gateway.models.responses import (
     APIResponse,
     MetaInfo,
@@ -101,7 +102,9 @@ async def execute_tool(
         )
 
     try:
-        result = await agent.tools.execute(tool_name, request.arguments)
+        owner_key = getattr(user, "session_key", None) or getattr(user, "user_id", None) or "admin"
+        with bind_tool_owner(str(owner_key)):
+            result = await agent.tools.execute(tool_name, request.arguments)
         if isinstance(result, str):
             try:
                 parsed = json.loads(result)

--- a/spoon_bot/gateway/app.py
+++ b/spoon_bot/gateway/app.py
@@ -84,6 +84,14 @@ def _normalize_session_key(session_key: str | None) -> str:
     return session_key.strip() if isinstance(session_key, str) and session_key.strip() else "default"
 
 
+def _normalize_user_id(user_id: str | None) -> str:
+    return user_id.strip() if isinstance(user_id, str) and user_id.strip() else "anonymous"
+
+
+def _ws_session_chat_registry_key(session_key: str | None, user_id: str | None) -> str:
+    return f"user:{_normalize_user_id(user_id)}|session:{_normalize_session_key(session_key)}"
+
+
 def get_session_execution_lock(session_key: str) -> asyncio.Lock:
     """Get/create a lock for a specific session key."""
     key = _normalize_session_key(session_key)
@@ -98,20 +106,21 @@ def register_ws_session_chat_task(
     session_key: str,
     task: asyncio.Task,
     *,
+    user_id: str | None = None,
     cancel_cb: Callable[[], None] | None = None,
     task_id_cb: Callable[[], str | None] | None = None,
 ) -> None:
     """Register the active websocket chat task for a session."""
-    _ws_session_chat_tasks[_normalize_session_key(session_key)] = _WSSessionTaskHandle(
+    _ws_session_chat_tasks[_ws_session_chat_registry_key(session_key, user_id)] = _WSSessionTaskHandle(
         task=task,
         cancel_cb=cancel_cb,
         task_id_cb=task_id_cb,
     )
 
 
-def get_ws_session_chat_task_id(session_key: str) -> str | None:
+def get_ws_session_chat_task_id(session_key: str, user_id: str | None = None) -> str | None:
     """Get the current websocket chat task id for a session, if available."""
-    handle = _ws_session_chat_tasks.get(_normalize_session_key(session_key))
+    handle = _ws_session_chat_tasks.get(_ws_session_chat_registry_key(session_key, user_id))
     if handle is None or handle.task_id_cb is None:
         return None
     try:
@@ -120,15 +129,20 @@ def get_ws_session_chat_task_id(session_key: str) -> str | None:
         return None
 
 
-def has_active_ws_session_chat_task(session_key: str) -> bool:
+def has_active_ws_session_chat_task(session_key: str, user_id: str | None = None) -> bool:
     """Whether a session currently has a running websocket chat task."""
-    handle = _ws_session_chat_tasks.get(_normalize_session_key(session_key))
+    handle = _ws_session_chat_tasks.get(_ws_session_chat_registry_key(session_key, user_id))
     return bool(handle is not None and not handle.task.done())
 
 
-def clear_ws_session_chat_task(session_key: str, *, task: asyncio.Task | None = None) -> bool:
+def clear_ws_session_chat_task(
+    session_key: str,
+    *,
+    user_id: str | None = None,
+    task: asyncio.Task | None = None,
+) -> bool:
     """Clear the active websocket chat task for a session."""
-    key = _normalize_session_key(session_key)
+    key = _ws_session_chat_registry_key(session_key, user_id)
     handle = _ws_session_chat_tasks.get(key)
     if handle is None:
         return False
@@ -138,16 +152,21 @@ def clear_ws_session_chat_task(session_key: str, *, task: asyncio.Task | None = 
     return True
 
 
-async def cancel_ws_session_chat_task(session_key: str, timeout: float = 2.0) -> bool:
+async def cancel_ws_session_chat_task(
+    session_key: str,
+    timeout: float = 2.0,
+    *,
+    user_id: str | None = None,
+) -> bool:
     """Cancel and await an active websocket chat task for a session."""
-    key = _normalize_session_key(session_key)
+    key = _ws_session_chat_registry_key(session_key, user_id)
     handle = _ws_session_chat_tasks.get(key)
     if handle is None:
         return False
 
     task = handle.task
     if task.done():
-        clear_ws_session_chat_task(key, task=task)
+        clear_ws_session_chat_task(session_key, user_id=user_id, task=task)
         return True
 
     if handle.cancel_cb is not None:
@@ -165,7 +184,7 @@ async def cancel_ws_session_chat_task(session_key: str, timeout: float = 2.0) ->
         timed_out = True
         logger.warning(f"Timed out waiting for ws chat task cleanup: session={key}")
     if task.done():
-        clear_ws_session_chat_task(key, task=task)
+        clear_ws_session_chat_task(session_key, user_id=user_id, task=task)
         return True
     return False if timed_out else task.done()
 

--- a/spoon_bot/gateway/app.py
+++ b/spoon_bot/gateway/app.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -35,6 +36,14 @@ _payments: SpoonCorePayments | None = None
 _auth_required: bool = True  # Can be set to False via GATEWAY_AUTH_REQUIRED=false
 _agent_execution_lock: asyncio.Lock | None = None
 _session_execution_locks: dict[str, asyncio.Lock] = {}
+_ws_session_chat_tasks: dict[str, "_WSSessionTaskHandle"] = {}
+
+
+@dataclass
+class _WSSessionTaskHandle:
+    task: asyncio.Task
+    cancel_cb: Callable[[], None] | None = None
+    task_id_cb: Callable[[], str | None] | None = None
 
 
 def is_auth_required() -> bool:
@@ -71,14 +80,94 @@ def get_agent_execution_lock() -> asyncio.Lock:
     return _agent_execution_lock
 
 
+def _normalize_session_key(session_key: str | None) -> str:
+    return session_key.strip() if isinstance(session_key, str) and session_key.strip() else "default"
+
+
 def get_session_execution_lock(session_key: str) -> asyncio.Lock:
     """Get/create a lock for a specific session key."""
-    key = session_key.strip() if isinstance(session_key, str) and session_key.strip() else "default"
+    key = _normalize_session_key(session_key)
     lock = _session_execution_locks.get(key)
     if lock is None:
         lock = asyncio.Lock()
         _session_execution_locks[key] = lock
     return lock
+
+
+def register_ws_session_chat_task(
+    session_key: str,
+    task: asyncio.Task,
+    *,
+    cancel_cb: Callable[[], None] | None = None,
+    task_id_cb: Callable[[], str | None] | None = None,
+) -> None:
+    """Register the active websocket chat task for a session."""
+    _ws_session_chat_tasks[_normalize_session_key(session_key)] = _WSSessionTaskHandle(
+        task=task,
+        cancel_cb=cancel_cb,
+        task_id_cb=task_id_cb,
+    )
+
+
+def get_ws_session_chat_task_id(session_key: str) -> str | None:
+    """Get the current websocket chat task id for a session, if available."""
+    handle = _ws_session_chat_tasks.get(_normalize_session_key(session_key))
+    if handle is None or handle.task_id_cb is None:
+        return None
+    try:
+        return handle.task_id_cb()
+    except Exception:
+        return None
+
+
+def has_active_ws_session_chat_task(session_key: str) -> bool:
+    """Whether a session currently has a running websocket chat task."""
+    handle = _ws_session_chat_tasks.get(_normalize_session_key(session_key))
+    return bool(handle is not None and not handle.task.done())
+
+
+def clear_ws_session_chat_task(session_key: str, *, task: asyncio.Task | None = None) -> bool:
+    """Clear the active websocket chat task for a session."""
+    key = _normalize_session_key(session_key)
+    handle = _ws_session_chat_tasks.get(key)
+    if handle is None:
+        return False
+    if task is not None and handle.task is not task:
+        return False
+    _ws_session_chat_tasks.pop(key, None)
+    return True
+
+
+async def cancel_ws_session_chat_task(session_key: str, timeout: float = 2.0) -> bool:
+    """Cancel and await an active websocket chat task for a session."""
+    key = _normalize_session_key(session_key)
+    handle = _ws_session_chat_tasks.get(key)
+    if handle is None:
+        return False
+
+    task = handle.task
+    if task.done():
+        clear_ws_session_chat_task(key, task=task)
+        return True
+
+    if handle.cancel_cb is not None:
+        try:
+            handle.cancel_cb()
+        except Exception:
+            pass
+    task.cancel()
+    timed_out = False
+    try:
+        await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
+    except asyncio.CancelledError:
+        pass
+    except asyncio.TimeoutError:
+        timed_out = True
+        logger.warning(f"Timed out waiting for ws chat task cleanup: session={key}")
+    if task.done():
+        clear_ws_session_chat_task(key, task=task)
+        return True
+    return False if timed_out else task.done()
 
 
 def set_agent(agent: SpoonCoreAgent | AgentLoop) -> None:
@@ -170,11 +259,12 @@ def create_app(config: GatewayConfig | None = None) -> FastAPI:
     Returns:
         Configured FastAPI application.
     """
-    global _config, _agent_execution_lock, _session_execution_locks
+    global _config, _agent_execution_lock, _session_execution_locks, _ws_session_chat_tasks
 
     _config = config or GatewayConfig.from_env()
     _agent_execution_lock = None
     _session_execution_locks = {}
+    _ws_session_chat_tasks = {}
 
     app = FastAPI(
         title="spoon-bot Gateway",

--- a/spoon_bot/gateway/app.py
+++ b/spoon_bot/gateway/app.py
@@ -37,6 +37,7 @@ _auth_required: bool = True  # Can be set to False via GATEWAY_AUTH_REQUIRED=fal
 _agent_execution_lock: asyncio.Lock | None = None
 _session_execution_locks: dict[str, asyncio.Lock] = {}
 _ws_session_chat_tasks: dict[str, "_WSSessionTaskHandle"] = {}
+_ws_session_chat_locks: dict[str, asyncio.Lock] = {}
 
 
 @dataclass
@@ -116,6 +117,16 @@ def register_ws_session_chat_task(
         cancel_cb=cancel_cb,
         task_id_cb=task_id_cb,
     )
+
+
+def get_ws_session_chat_lock(session_key: str, user_id: str | None = None) -> asyncio.Lock:
+    """Get/create the serialized replacement lock for a WS user+session key."""
+    key = _ws_session_chat_registry_key(session_key, user_id)
+    lock = _ws_session_chat_locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _ws_session_chat_locks[key] = lock
+    return lock
 
 
 def get_ws_session_chat_task_id(session_key: str, user_id: str | None = None) -> str | None:
@@ -278,12 +289,13 @@ def create_app(config: GatewayConfig | None = None) -> FastAPI:
     Returns:
         Configured FastAPI application.
     """
-    global _config, _agent_execution_lock, _session_execution_locks, _ws_session_chat_tasks
+    global _config, _agent_execution_lock, _session_execution_locks, _ws_session_chat_tasks, _ws_session_chat_locks
 
     _config = config or GatewayConfig.from_env()
     _agent_execution_lock = None
     _session_execution_locks = {}
     _ws_session_chat_tasks = {}
+    _ws_session_chat_locks = {}
 
     app = FastAPI(
         title="spoon-bot Gateway",

--- a/spoon_bot/gateway/config.py
+++ b/spoon_bot/gateway/config.py
@@ -53,9 +53,9 @@ class JWTConfig:
 class BudgetConfig:
     """Execution budget configuration."""
 
-    request_timeout_ms: int = 3_600_000   # 60 minutes default
+    request_timeout_ms: int = 0            # unlimited by default
     tool_timeout_ms: int = 3_600_000      # 60 minutes default
-    stream_timeout_ms: int = 3_600_000    # 60 minutes default
+    stream_timeout_ms: int = 0            # unlimited by default
 
 
 @dataclass
@@ -133,13 +133,13 @@ class GatewayConfig:
             ),
             budget=BudgetConfig(
                 request_timeout_ms=int(
-                    os.environ.get("GATEWAY_TIMEOUT_REQUEST_MS", "3600000")
+                    os.environ.get("GATEWAY_TIMEOUT_REQUEST_MS", "0")
                 ),
                 tool_timeout_ms=int(
                     os.environ.get("GATEWAY_TIMEOUT_TOOL_MS", "3600000")
                 ),
                 stream_timeout_ms=int(
-                    os.environ.get("GATEWAY_TIMEOUT_STREAM_MS", "3600000")
+                    os.environ.get("GATEWAY_TIMEOUT_STREAM_MS", "0")
                 ),
             ),
             audio=AudioConfig(

--- a/spoon_bot/gateway/websocket/handler.py
+++ b/spoon_bot/gateway/websocket/handler.py
@@ -338,7 +338,7 @@ async def websocket_endpoint(
 
     # Connect
     conn_id = await manager.connect(websocket, user_id, session_key)
-    handler = WebSocketHandler(conn_id, session_key)
+    handler = WebSocketHandler(conn_id, session_key, user_id=user_id)
 
     try:
         # Send connection success event
@@ -371,9 +371,19 @@ async def websocket_endpoint(
                         session_key = handler._resolve_effective_session_key(_req.params)
 
                         # New chat for the same session should replace any stale/disconnected run.
-                        had_active_task = has_active_ws_session_chat_task(session_key)
-                        cancelled = await cancel_ws_session_chat_task(session_key)
-                        if had_active_task and not cancelled and has_active_ws_session_chat_task(session_key):
+                        registry_user_id = handler._resolve_registry_user_id()
+                        had_active_task = has_active_ws_session_chat_task(
+                            session_key,
+                            user_id=registry_user_id,
+                        )
+                        cancelled = await cancel_ws_session_chat_task(
+                            session_key,
+                            user_id=registry_user_id,
+                        )
+                        if had_active_task and not cancelled and has_active_ws_session_chat_task(
+                            session_key,
+                            user_id=registry_user_id,
+                        ):
                             await manager.send_message(
                                 conn_id,
                                 WSError(
@@ -387,7 +397,11 @@ async def websocket_endpoint(
                             )
                             continue
 
-                        async def _run_chat(req: WSRequest = _req, bound_session_key: str = session_key) -> None:
+                        async def _run_chat(
+                            req: WSRequest = _req,
+                            bound_session_key: str = session_key,
+                            bound_user_id: str = registry_user_id,
+                        ) -> None:
                             try:
                                 result = await handler._handle_chat(req.params)
                                 await manager.send_message(
@@ -401,13 +415,18 @@ async def websocket_endpoint(
                                 )
                             finally:
                                 handler._current_task = None
-                                clear_ws_session_chat_task(bound_session_key, task=asyncio.current_task())
+                                clear_ws_session_chat_task(
+                                    bound_session_key,
+                                    user_id=bound_user_id,
+                                    task=asyncio.current_task(),
+                                )
 
                         chat_task = asyncio.create_task(_run_chat())
                         handler._current_task = chat_task
                         register_ws_session_chat_task(
                             session_key,
                             chat_task,
+                            user_id=registry_user_id,
                             cancel_cb=handler._request_current_task_cancel,
                             task_id_cb=handler._current_task_id_for_cancel,
                         )
@@ -449,10 +468,17 @@ class WebSocketHandler:
     Supports confirmation flow for dangerous tool calls.
     """
 
-    def __init__(self, connection_id: str, session_id: str | None = None):
+    def __init__(
+        self,
+        connection_id: str,
+        session_id: str | None = None,
+        *,
+        user_id: str | None = None,
+    ):
         self.connection_id = connection_id
         self.session_id = session_id or connection_id
         self._default_session_key = session_id or "default"
+        self._user_id = user_id.strip() if isinstance(user_id, str) and user_id.strip() else "anonymous"
         self._cancel_requested = False
         self._current_task_id: str | None = None
         self._current_task: asyncio.Task | None = None
@@ -584,6 +610,18 @@ class WebSocketHandler:
             session_key = bound_session_key
         return session_key.strip()
 
+    def _resolve_registry_user_id(self) -> str:
+        """Resolve the user identity key for WS task ownership."""
+        user_id = self._user_id
+        try:
+            manager = get_connection_manager()
+            conn = manager.get_connection(self.connection_id)
+        except RuntimeError:
+            conn = None
+        if conn and isinstance(conn.user_id, str) and conn.user_id.strip():
+            user_id = conn.user_id.strip()
+        return user_id
+
     def _request_current_task_cancel(self) -> None:
         """Signal cancellation for the current task owned by this handler."""
         self._cancel_requested = True
@@ -638,6 +676,7 @@ class WebSocketHandler:
                 async with agent_lock:
                     # Switch agent session to the requested session_key (#11)
                     _switch_agent_session(agent, session_key)
+                    setattr(agent, "user_id", self._resolve_registry_user_id())
 
                     # Emit thinking event
                     await manager.send_message(
@@ -814,10 +853,17 @@ class WebSocketHandler:
         """Handle cancel request (#13) — cancels both stream and non-stream."""
         self._cancel_requested = True
         target_session_key = self._resolve_effective_session_key(params)
-        task_id = get_ws_session_chat_task_id(target_session_key) or self._current_task_id
+        registry_user_id = self._resolve_registry_user_id()
+        task_id = (
+            get_ws_session_chat_task_id(target_session_key, user_id=registry_user_id)
+            or self._current_task_id
+        )
 
         # Prefer session-level cancellation so reconnects can stop stale tasks.
-        cancelled = await cancel_ws_session_chat_task(target_session_key)
+        cancelled = await cancel_ws_session_chat_task(
+            target_session_key,
+            user_id=registry_user_id,
+        )
         if not cancelled:
             # Compatibility fallback for direct/unit invocations.
             cancelled = await self._cancel_current_task_for_cleanup()
@@ -846,7 +892,11 @@ class WebSocketHandler:
             )
         finally:
             self._current_task = None
-            clear_ws_session_chat_task(self._default_session_key, task=task)
+            clear_ws_session_chat_task(
+                self._default_session_key,
+                user_id=self._resolve_registry_user_id(),
+                task=task,
+            )
 
         return True
 

--- a/spoon_bot/gateway/websocket/handler.py
+++ b/spoon_bot/gateway/websocket/handler.py
@@ -624,8 +624,9 @@ class WebSocketHandler:
             conn = manager.get_connection(self.connection_id)
         except RuntimeError:
             conn = None
-        if conn and isinstance(conn.user_id, str) and conn.user_id.strip():
-            user_id = conn.user_id.strip()
+        conn_user_id = getattr(conn, "user_id", None) if conn else None
+        if isinstance(conn_user_id, str) and conn_user_id.strip():
+            user_id = conn_user_id.strip()
         return user_id
 
     def _request_current_task_cancel(self) -> None:

--- a/spoon_bot/gateway/websocket/handler.py
+++ b/spoon_bot/gateway/websocket/handler.py
@@ -26,6 +26,7 @@ from spoon_bot.gateway.app import (
     get_connection_manager,
     get_config,
     get_agent_execution_lock,
+    get_ws_session_chat_lock,
     get_ws_session_chat_task_id,
     get_session_execution_lock,
     has_active_ws_session_chat_task,
@@ -369,67 +370,72 @@ async def websocket_endpoint(
                     if message.method in ("agent.chat", ClientMethod.CHAT_SEND.value):
                         _req = message  # capture for closure
                         session_key = handler._resolve_effective_session_key(_req.params)
-
-                        # New chat for the same session should replace any stale/disconnected run.
                         registry_user_id = handler._resolve_registry_user_id()
-                        had_active_task = has_active_ws_session_chat_task(
+                        session_chat_lock = get_ws_session_chat_lock(
                             session_key,
                             user_id=registry_user_id,
                         )
-                        cancelled = await cancel_ws_session_chat_task(
-                            session_key,
-                            user_id=registry_user_id,
-                        )
-                        if had_active_task and not cancelled and has_active_ws_session_chat_task(
-                            session_key,
-                            user_id=registry_user_id,
-                        ):
-                            await manager.send_message(
-                                conn_id,
-                                WSError(
-                                    id=_req.id,
-                                    code="TASK_BUSY",
-                                    message=(
-                                        "A previous chat task for this session is still shutting down. "
-                                        "Send chat.cancel and retry shortly."
-                                    ),
-                                ),
-                            )
-                            continue
 
-                        async def _run_chat(
-                            req: WSRequest = _req,
-                            bound_session_key: str = session_key,
-                            bound_user_id: str = registry_user_id,
-                        ) -> None:
-                            try:
-                                result = await handler._handle_chat(req.params)
-                                await manager.send_message(
-                                    conn_id, WSResponse(id=req.id, result=result),
-                                )
-                            except Exception as exc:
-                                logger.error(f"Chat error: {exc}")
+                        async with session_chat_lock:
+                            # New chat for the same session should replace any stale/disconnected run.
+                            had_active_task = has_active_ws_session_chat_task(
+                                session_key,
+                                user_id=registry_user_id,
+                            )
+                            cancelled = await cancel_ws_session_chat_task(
+                                session_key,
+                                user_id=registry_user_id,
+                            )
+                            if had_active_task and not cancelled and has_active_ws_session_chat_task(
+                                session_key,
+                                user_id=registry_user_id,
+                            ):
                                 await manager.send_message(
                                     conn_id,
-                                    WSError(id=req.id, code="HANDLER_ERROR", message=str(exc)),
+                                    WSError(
+                                        id=_req.id,
+                                        code="TASK_BUSY",
+                                        message=(
+                                            "A previous chat task for this session is still shutting down. "
+                                            "Send chat.cancel and retry shortly."
+                                        ),
+                                    ),
                                 )
-                            finally:
-                                handler._current_task = None
-                                clear_ws_session_chat_task(
-                                    bound_session_key,
-                                    user_id=bound_user_id,
-                                    task=asyncio.current_task(),
-                                )
+                                continue
 
-                        chat_task = asyncio.create_task(_run_chat())
-                        handler._current_task = chat_task
-                        register_ws_session_chat_task(
-                            session_key,
-                            chat_task,
-                            user_id=registry_user_id,
-                            cancel_cb=handler._request_current_task_cancel,
-                            task_id_cb=handler._current_task_id_for_cancel,
-                        )
+                            async def _run_chat(
+                                req: WSRequest = _req,
+                                bound_session_key: str = session_key,
+                                bound_user_id: str = registry_user_id,
+                            ) -> None:
+                                try:
+                                    result = await handler._handle_chat(req.params)
+                                    await manager.send_message(
+                                        conn_id, WSResponse(id=req.id, result=result),
+                                    )
+                                except Exception as exc:
+                                    logger.error(f"Chat error: {exc}")
+                                    await manager.send_message(
+                                        conn_id,
+                                        WSError(id=req.id, code="HANDLER_ERROR", message=str(exc)),
+                                    )
+                                finally:
+                                    handler._current_task = None
+                                    clear_ws_session_chat_task(
+                                        bound_session_key,
+                                        user_id=bound_user_id,
+                                        task=asyncio.current_task(),
+                                    )
+
+                            chat_task = asyncio.create_task(_run_chat())
+                            handler._current_task = chat_task
+                            register_ws_session_chat_task(
+                                session_key,
+                                chat_task,
+                                user_id=registry_user_id,
+                                cancel_cb=handler._request_current_task_cancel,
+                                task_id_cb=handler._current_task_id_for_cancel,
+                            )
 
                     elif message.method in _CONCURRENT_METHODS:
                         task = asyncio.create_task(
@@ -854,16 +860,21 @@ class WebSocketHandler:
         self._cancel_requested = True
         target_session_key = self._resolve_effective_session_key(params)
         registry_user_id = self._resolve_registry_user_id()
-        task_id = (
-            get_ws_session_chat_task_id(target_session_key, user_id=registry_user_id)
-            or self._current_task_id
-        )
-
-        # Prefer session-level cancellation so reconnects can stop stale tasks.
-        cancelled = await cancel_ws_session_chat_task(
+        session_chat_lock = get_ws_session_chat_lock(
             target_session_key,
             user_id=registry_user_id,
         )
+        async with session_chat_lock:
+            task_id = (
+                get_ws_session_chat_task_id(target_session_key, user_id=registry_user_id)
+                or self._current_task_id
+            )
+
+            # Prefer session-level cancellation so reconnects can stop stale tasks.
+            cancelled = await cancel_ws_session_chat_task(
+                target_session_key,
+                user_id=registry_user_id,
+            )
         if not cancelled:
             # Compatibility fallback for direct/unit invocations.
             cancelled = await self._cancel_current_task_for_cleanup()

--- a/spoon_bot/gateway/websocket/handler.py
+++ b/spoon_bot/gateway/websocket/handler.py
@@ -20,12 +20,17 @@ from fastapi import WebSocket, WebSocketDisconnect, Query
 from loguru import logger
 
 from spoon_bot.gateway.app import (
+    cancel_ws_session_chat_task,
+    clear_ws_session_chat_task,
     get_agent,
     get_connection_manager,
     get_config,
     get_agent_execution_lock,
+    get_ws_session_chat_task_id,
     get_session_execution_lock,
+    has_active_ws_session_chat_task,
     is_auth_required,
+    register_ws_session_chat_task,
 )
 from spoon_bot.gateway.auth.jwt import verify_token
 from spoon_bot.gateway.auth.api_key import verify_api_key
@@ -363,8 +368,26 @@ async def websocket_endpoint(
                     # loop stays free to process cancel / status requests.
                     if message.method in ("agent.chat", ClientMethod.CHAT_SEND.value):
                         _req = message  # capture for closure
+                        session_key = handler._resolve_effective_session_key(_req.params)
 
-                        async def _run_chat(req: WSRequest = _req) -> None:
+                        # New chat for the same session should replace any stale/disconnected run.
+                        had_active_task = has_active_ws_session_chat_task(session_key)
+                        cancelled = await cancel_ws_session_chat_task(session_key)
+                        if had_active_task and not cancelled and has_active_ws_session_chat_task(session_key):
+                            await manager.send_message(
+                                conn_id,
+                                WSError(
+                                    id=_req.id,
+                                    code="TASK_BUSY",
+                                    message=(
+                                        "A previous chat task for this session is still shutting down. "
+                                        "Send chat.cancel and retry shortly."
+                                    ),
+                                ),
+                            )
+                            continue
+
+                        async def _run_chat(req: WSRequest = _req, bound_session_key: str = session_key) -> None:
                             try:
                                 result = await handler._handle_chat(req.params)
                                 await manager.send_message(
@@ -378,8 +401,16 @@ async def websocket_endpoint(
                                 )
                             finally:
                                 handler._current_task = None
+                                clear_ws_session_chat_task(bound_session_key, task=asyncio.current_task())
 
-                        handler._current_task = asyncio.create_task(_run_chat())
+                        chat_task = asyncio.create_task(_run_chat())
+                        handler._current_task = chat_task
+                        register_ws_session_chat_task(
+                            session_key,
+                            chat_task,
+                            cancel_cb=handler._request_current_task_cancel,
+                            task_id_cb=handler._current_task_id_for_cancel,
+                        )
 
                     elif message.method in _CONCURRENT_METHODS:
                         task = asyncio.create_task(
@@ -536,6 +567,33 @@ class WebSocketHandler:
 
     # ========== Chat ==========
 
+    def _resolve_effective_session_key(self, params: dict[str, Any]) -> str:
+        """Resolve the session key for a request using connection binding fallback."""
+        bound_session_key = self._default_session_key
+        try:
+            manager = get_connection_manager()
+            conn = manager.get_connection(self.connection_id)
+        except RuntimeError:
+            conn = None
+
+        if conn:
+            bound_session_key = conn.session_key
+
+        session_key = params.get("session_key", bound_session_key)
+        if not isinstance(session_key, str) or not session_key.strip():
+            session_key = bound_session_key
+        return session_key.strip()
+
+    def _request_current_task_cancel(self) -> None:
+        """Signal cancellation for the current task owned by this handler."""
+        self._cancel_requested = True
+        task = self._current_task
+        if task is not None and not task.done():
+            task.cancel()
+
+    def _current_task_id_for_cancel(self) -> str | None:
+        return self._current_task_id
+
     async def _handle_chat(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle chat.send / agent.chat — serialized to prevent state races."""
         async with self._chat_lock:
@@ -547,7 +605,6 @@ class WebSocketHandler:
         manager = get_connection_manager()
         config = get_config()
         conn = manager.get_connection(self.connection_id)
-        bound_session_key = conn.session_key if conn else self._default_session_key
         if not conn:
             logger.info(
                 f"WS connection {self.connection_id} is no longer live; "
@@ -561,10 +618,7 @@ class WebSocketHandler:
         if not message:
             raise ValueError("Message or attachments are required")
 
-        session_key = params.get("session_key", bound_session_key)
-        # Validate session_key type
-        if not isinstance(session_key, str) or not session_key.strip():
-            session_key = bound_session_key
+        session_key = self._resolve_effective_session_key(params)
         self._default_session_key = session_key
 
         stream = params.get("stream", False)
@@ -759,10 +813,14 @@ class WebSocketHandler:
     async def _handle_cancel(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle cancel request (#13) — cancels both stream and non-stream."""
         self._cancel_requested = True
-        task_id = self._current_task_id
+        target_session_key = self._resolve_effective_session_key(params)
+        task_id = get_ws_session_chat_task_id(target_session_key) or self._current_task_id
 
-        # Also cancel the asyncio task if running (#13)
-        cancelled = await self._cancel_current_task_for_cleanup()
+        # Prefer session-level cancellation so reconnects can stop stale tasks.
+        cancelled = await cancel_ws_session_chat_task(target_session_key)
+        if not cancelled:
+            # Compatibility fallback for direct/unit invocations.
+            cancelled = await self._cancel_current_task_for_cleanup()
 
         return {"cancelled": True, "task_id": task_id, "task_interrupted": cancelled}
 
@@ -776,7 +834,7 @@ class WebSocketHandler:
             self._current_task = None
             return False
 
-        task.cancel()
+        self._request_current_task_cancel()
         try:
             await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
         except asyncio.CancelledError:
@@ -788,6 +846,7 @@ class WebSocketHandler:
             )
         finally:
             self._current_task = None
+            clear_ws_session_chat_task(self._default_session_key, task=task)
 
         return True
 

--- a/spoon_bot/gateway/websocket/handler.py
+++ b/spoon_bot/gateway/websocket/handler.py
@@ -333,7 +333,7 @@ async def websocket_endpoint(
 
     # Connect
     conn_id = await manager.connect(websocket, user_id, session_key)
-    handler = WebSocketHandler(conn_id)
+    handler = WebSocketHandler(conn_id, session_key)
 
     try:
         # Send connection success event
@@ -406,9 +406,6 @@ async def websocket_endpoint(
     except Exception as e:
         logger.error(f"WebSocket error for {conn_id}: {e}")
     finally:
-        cancelled = await handler._cancel_current_task_for_cleanup()
-        if cancelled:
-            logger.info(f"Cancelled background WS chat task on disconnect: {conn_id}")
         await handler._cleanup_resources()
         await manager.disconnect(conn_id)
 
@@ -424,6 +421,7 @@ class WebSocketHandler:
     def __init__(self, connection_id: str, session_id: str | None = None):
         self.connection_id = connection_id
         self.session_id = session_id or connection_id
+        self._default_session_key = session_id or "default"
         self._cancel_requested = False
         self._current_task_id: str | None = None
         self._current_task: asyncio.Task | None = None
@@ -549,9 +547,12 @@ class WebSocketHandler:
         manager = get_connection_manager()
         config = get_config()
         conn = manager.get_connection(self.connection_id)
-
+        bound_session_key = conn.session_key if conn else self._default_session_key
         if not conn:
-            raise ValueError("Connection not found")
+            logger.info(
+                f"WS connection {self.connection_id} is no longer live; "
+                "continuing chat task without WebSocket delivery"
+            )
 
         attachments = _validate_attachment_paths(_normalize_attachment_refs(params.get("attachments")))
         media = _string_list_from_any(params.get("media"))
@@ -560,10 +561,11 @@ class WebSocketHandler:
         if not message:
             raise ValueError("Message or attachments are required")
 
-        session_key = params.get("session_key", conn.session_key)
+        session_key = params.get("session_key", bound_session_key)
         # Validate session_key type
         if not isinstance(session_key, str) or not session_key.strip():
-            session_key = conn.session_key
+            session_key = bound_session_key
+        self._default_session_key = session_key
 
         stream = params.get("stream", False)
         thinking = params.get("thinking", False)
@@ -946,6 +948,7 @@ class WebSocketHandler:
             raise ValueError("session_key must be a non-empty string")
 
         conn.session_key = new_session
+        self._default_session_key = new_session
         return {"session_key": new_session, "switched": True}
 
     async def _handle_session_list(self, params: dict[str, Any]) -> dict[str, Any]:

--- a/spoon_bot/toolkit/adapter.py
+++ b/spoon_bot/toolkit/adapter.py
@@ -130,6 +130,31 @@ class ToolkitToolWrapper(Tool):
             job.finished_at = time.time()
         return job
 
+    def _attach_background_job_lifecycle(self, job: _BackgroundToolkitJob) -> None:
+        """Keep background job status in sync without requiring polling actions."""
+
+        def _on_done(done_task: asyncio.Task[Any]) -> None:
+            if job.status != "running":
+                return
+            try:
+                result = done_task.result()
+                job.result = str(result) if result is not None else "Success"
+                job.status = "completed"
+            except asyncio.CancelledError:
+                job.error = "Cancellation requested"
+                job.status = "cancelled"
+            except Exception as exc:  # noqa: BLE001
+                job.error = str(exc)
+                job.status = "failed"
+            finally:
+                job.finished_at = time.time()
+                self._prune_completed_jobs(owner_key=job.owner_key)
+
+        if job.task.done():
+            _on_done(job.task)
+            return
+        job.task.add_done_callback(_on_done)
+
     @staticmethod
     def _is_terminal_status(status: str) -> bool:
         return status in {"completed", "failed", "cancelled", "terminated"}
@@ -241,6 +266,7 @@ class ToolkitToolWrapper(Tool):
                     owner_key=owner_key,
                 )
                 _TOOLKIT_BACKGROUND_JOBS[job.job_id] = job
+                self._attach_background_job_lifecycle(job)
                 self._prune_completed_jobs(owner_key=owner_key)
                 logger.warning(
                     f"Toolkit tool {self.name} exceeded foreground wait budget "

--- a/spoon_bot/toolkit/adapter.py
+++ b/spoon_bot/toolkit/adapter.py
@@ -3,26 +3,41 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
+from uuid import uuid4
 
 from loguru import logger
 
 from spoon_bot.agent.tools.base import Tool
-from spoon_bot.exceptions import ToolExecutionError, ToolTimeoutError
-
 if TYPE_CHECKING:
     pass
+
+
+@dataclass
+class _BackgroundToolkitJob:
+    job_id: str
+    tool_name: str
+    task: asyncio.Task[Any]
+    status: str = "running"
+    result: str | None = None
+    error: str | None = None
+
+
+_TOOLKIT_BACKGROUND_JOBS: dict[str, _BackgroundToolkitJob] = {}
 
 
 class ToolkitToolWrapper(Tool):
     """Wrapper that adapts spoon-toolkit tools to spoon-bot Tool interface."""
 
-    def __init__(self, toolkit_tool: Any, timeout_seconds: float = 30.0):
+    def __init__(self, toolkit_tool: Any, timeout_seconds: float = 3600.0):
         """
         Initialize wrapper.
 
         Args:
             toolkit_tool: Instance from spoon-toolkits.
+            timeout_seconds: Foreground wait budget before the tool is left running
+                in the background.
         """
         self._tool = toolkit_tool
         self._timeout_seconds = timeout_seconds
@@ -33,23 +48,133 @@ class ToolkitToolWrapper(Tool):
 
     @property
     def description(self) -> str:
-        return getattr(self._tool, "description", "No description")
+        base = getattr(self._tool, "description", "No description")
+        return (
+            f"{base} Background actions are also supported: execute, list_jobs, "
+            "job_status, job_output, terminate_job."
+        )
 
     @property
     def parameters(self) -> dict[str, Any]:
         # Try to get parameters from tool
+        base_schema: dict[str, Any]
         if hasattr(self._tool, "parameters"):
-            return self._tool.parameters
+            base_schema = dict(self._tool.parameters)
         elif hasattr(self._tool, "input_schema"):
-            return self._tool.input_schema
+            base_schema = dict(self._tool.input_schema)
         elif hasattr(self._tool, "args_schema"):
             # Pydantic schema
             schema = self._tool.args_schema
             if hasattr(schema, "model_json_schema"):
-                return schema.model_json_schema()
+                base_schema = schema.model_json_schema()
             elif hasattr(schema, "schema"):
-                return schema.schema()
-        return {"type": "object", "properties": {}}
+                base_schema = schema.schema()
+            else:
+                base_schema = {"type": "object", "properties": {}}
+        else:
+            base_schema = {"type": "object", "properties": {}}
+
+        properties = dict(base_schema.get("properties", {}))
+        properties.update({
+            "action": {
+                "type": "string",
+                "enum": ["execute", "list_jobs", "job_status", "job_output", "terminate_job"],
+                "description": "Tool action. Defaults to execute.",
+                "default": "execute",
+            },
+            "job_id": {
+                "type": "string",
+                "description": "Background toolkit job ID for status/output/terminate actions",
+            },
+        })
+        return {
+            "type": "object",
+            "properties": properties,
+        }
+
+    async def _invoke_tool(self, call_kwargs: dict[str, Any]) -> Any:
+        if hasattr(self._tool, "arun"):
+            return await self._tool.arun(**call_kwargs)
+        if hasattr(self._tool, "execute"):
+            if asyncio.iscoroutinefunction(self._tool.execute):
+                return await self._tool.execute(**call_kwargs)
+            return await asyncio.to_thread(self._tool.execute, **call_kwargs)
+        if hasattr(self._tool, "run"):
+            return await asyncio.to_thread(self._tool.run, **call_kwargs)
+        if callable(self._tool):
+            return await asyncio.to_thread(self._tool, **call_kwargs)
+        raise TypeError(f"Tool '{self.name}' is not callable")
+
+    async def _refresh_job(self, job: _BackgroundToolkitJob) -> _BackgroundToolkitJob:
+        if job.status != "running":
+            return job
+        if not job.task.done():
+            return job
+        try:
+            result = await asyncio.shield(job.task)
+            job.result = str(result) if result is not None else "Success"
+            job.status = "completed"
+        except asyncio.CancelledError:
+            job.error = "Cancellation requested"
+            job.status = "cancelled"
+        except Exception as exc:
+            job.error = str(exc)
+            job.status = "failed"
+        return job
+
+    async def _handle_background_action(self, action: str, job_id: str | None) -> str:
+        if action == "list_jobs":
+            matching_jobs = [job for job in _TOOLKIT_BACKGROUND_JOBS.values() if job.tool_name == self.name]
+            if not matching_jobs:
+                return f"No background jobs for toolkit tool '{self.name}'"
+            lines = [f"Background jobs for toolkit tool '{self.name}':"]
+            for job in matching_jobs:
+                await self._refresh_job(job)
+                lines.append(f"[{job.job_id}] {job.status}")
+            return "\n".join(lines)
+
+        if not job_id:
+            return "Error: 'job_id' is required for this action"
+
+        job = _TOOLKIT_BACKGROUND_JOBS.get(job_id)
+        if job is None or job.tool_name != self.name:
+            return f"Error: Background toolkit job not found: {job_id}"
+
+        await self._refresh_job(job)
+
+        if action == "job_status":
+            details = job.result if job.result is not None else (job.error or "No output yet")
+            return f"job_id: {job.job_id}\nstatus: {job.status}\noutput:\n{details}"
+
+        if action == "job_output":
+            if job.result is not None:
+                return job.result
+            if job.error is not None:
+                return f"Error: {job.error}"
+            return f"Background toolkit job {job.job_id} is still running; no final output yet"
+
+        if action == "terminate_job":
+            if job.task.done():
+                await self._refresh_job(job)
+                return f"Background toolkit job {job.job_id} already finished with status={job.status}"
+            job.task.cancel()
+            try:
+                await asyncio.wait_for(asyncio.shield(job.task), timeout=5.0)
+            except asyncio.CancelledError:
+                pass
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"Toolkit job {job.job_id} did not stop promptly after cancellation request"
+                )
+            await self._refresh_job(job)
+            if job.status == "running":
+                return (
+                    f"Termination requested for toolkit job {job.job_id}, but the underlying work is still running. "
+                    "This tool type does not expose incremental output or guaranteed hard-kill support."
+                )
+            return f"Background toolkit job {job.job_id} stopped with status={job.status}"
+
+        return f"Error: Unknown action '{action}'"
 
     async def execute(self, **kwargs: Any) -> str:
         """Execute the toolkit tool.
@@ -58,50 +183,35 @@ class ToolkitToolWrapper(Tool):
             Tool execution result as string.
             In case of error, returns a user-friendly error message.
         """
+        action = kwargs.pop("action", "execute")
+        job_id = kwargs.pop("job_id", None)
+
+        if action != "execute":
+            return await self._handle_background_action(action, job_id)
+
         try:
-            # Check if tool has async execute
-            if hasattr(self._tool, "arun"):
-                result = await asyncio.wait_for(
-                    self._tool.arun(**kwargs),
-                    timeout=self._timeout_seconds,
+            bg_task = asyncio.create_task(self._invoke_tool(kwargs))
+            try:
+                result = await asyncio.wait_for(asyncio.shield(bg_task), timeout=self._timeout_seconds)
+                return str(result) if result is not None else "Success"
+            except asyncio.TimeoutError:
+                job = _BackgroundToolkitJob(
+                    job_id=f"tk_{uuid4().hex[:10]}",
+                    tool_name=self.name,
+                    task=bg_task,
                 )
-            elif hasattr(self._tool, "execute"):
-                if asyncio.iscoroutinefunction(self._tool.execute):
-                    result = await asyncio.wait_for(
-                        self._tool.execute(**kwargs),
-                        timeout=self._timeout_seconds,
-                    )
-                else:
-                    # Run sync function in executor to avoid blocking
-                    result = await asyncio.wait_for(
-                        asyncio.get_event_loop().run_in_executor(
-                            None, lambda: self._tool.execute(**kwargs)
-                        ),
-                        timeout=self._timeout_seconds,
-                    )
-            elif hasattr(self._tool, "run"):
-                # Run sync function in executor to avoid blocking
-                result = await asyncio.wait_for(
-                    asyncio.get_event_loop().run_in_executor(
-                        None, lambda: self._tool.run(**kwargs)
-                    ),
-                    timeout=self._timeout_seconds,
+                _TOOLKIT_BACKGROUND_JOBS[job.job_id] = job
+                logger.warning(
+                    f"Toolkit tool {self.name} exceeded foreground wait budget "
+                    f"({self._timeout_seconds:g}s) and was left running in the background as {job.job_id}"
                 )
-            elif callable(self._tool):
-                result = await asyncio.wait_for(
-                    asyncio.get_event_loop().run_in_executor(
-                        None, lambda: self._tool(**kwargs)
-                    ),
-                    timeout=self._timeout_seconds,
+                return (
+                    f"Toolkit tool '{self.name}' exceeded the foreground wait budget "
+                    f"({self._timeout_seconds:g}s) and is still running in the background.\n"
+                    f"job_id: {job.job_id}\n"
+                    "Use action='job_status' to inspect it, action='job_output' to fetch the final result when ready, "
+                    "or action='terminate_job' to request cancellation."
                 )
-            else:
-                return f"Error: Tool '{self.name}' is not callable"
-
-            return str(result) if result is not None else "Success"
-
-        except asyncio.TimeoutError as e:
-            logger.error(f"Toolkit tool {self.name} timed out: {e}")
-            return f"Error: Tool '{self.name}' timed out after {self._timeout_seconds:g} seconds"
         except asyncio.CancelledError:
             logger.warning(f"Toolkit tool {self.name} was cancelled")
             return f"Error: Tool '{self.name}' was cancelled"

--- a/spoon_bot/toolkit/adapter.py
+++ b/spoon_bot/toolkit/adapter.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from typing import Any, TYPE_CHECKING
 from uuid import uuid4
 
 from loguru import logger
 
 from spoon_bot.agent.tools.base import Tool
+from spoon_bot.agent.tools.execution_context import get_tool_owner
 if TYPE_CHECKING:
     pass
 
@@ -19,9 +21,12 @@ class _BackgroundToolkitJob:
     job_id: str
     tool_name: str
     task: asyncio.Task[Any]
+    owner_key: str = "default"
     status: str = "running"
     result: str | None = None
     error: str | None = None
+    created_at: float = field(default_factory=time.time)
+    finished_at: float | None = None
 
 
 _TOOLKIT_BACKGROUND_JOBS: dict[str, _BackgroundToolkitJob] = {}
@@ -114,17 +119,47 @@ class ToolkitToolWrapper(Tool):
             result = await asyncio.shield(job.task)
             job.result = str(result) if result is not None else "Success"
             job.status = "completed"
+            job.finished_at = time.time()
         except asyncio.CancelledError:
             job.error = "Cancellation requested"
             job.status = "cancelled"
+            job.finished_at = time.time()
         except Exception as exc:
             job.error = str(exc)
             job.status = "failed"
+            job.finished_at = time.time()
         return job
 
+    @staticmethod
+    def _is_terminal_status(status: str) -> bool:
+        return status in {"completed", "failed", "cancelled", "terminated"}
+
+    def _prune_completed_jobs(
+        self,
+        *,
+        owner_key: str,
+        keep_completed: int = 20,
+    ) -> None:
+        completed = [
+            job
+            for job in _TOOLKIT_BACKGROUND_JOBS.values()
+            if job.owner_key == owner_key
+            and job.tool_name == self.name
+            and self._is_terminal_status(job.status)
+        ]
+        completed.sort(key=lambda j: j.finished_at or j.created_at, reverse=True)
+        for stale_job in completed[keep_completed:]:
+            _TOOLKIT_BACKGROUND_JOBS.pop(stale_job.job_id, None)
+
     async def _handle_background_action(self, action: str, job_id: str | None) -> str:
+        owner_key = get_tool_owner()
+        self._prune_completed_jobs(owner_key=owner_key)
+
         if action == "list_jobs":
-            matching_jobs = [job for job in _TOOLKIT_BACKGROUND_JOBS.values() if job.tool_name == self.name]
+            matching_jobs = [
+                job for job in _TOOLKIT_BACKGROUND_JOBS.values()
+                if job.tool_name == self.name and job.owner_key == owner_key
+            ]
             if not matching_jobs:
                 return f"No background jobs for toolkit tool '{self.name}'"
             lines = [f"Background jobs for toolkit tool '{self.name}':"]
@@ -137,7 +172,7 @@ class ToolkitToolWrapper(Tool):
             return "Error: 'job_id' is required for this action"
 
         job = _TOOLKIT_BACKGROUND_JOBS.get(job_id)
-        if job is None or job.tool_name != self.name:
+        if job is None or job.tool_name != self.name or job.owner_key != owner_key:
             return f"Error: Background toolkit job not found: {job_id}"
 
         await self._refresh_job(job)
@@ -172,6 +207,9 @@ class ToolkitToolWrapper(Tool):
                     f"Termination requested for toolkit job {job.job_id}, but the underlying work is still running. "
                     "This tool type does not expose incremental output or guaranteed hard-kill support."
                 )
+            if job.status == "cancelled":
+                job.status = "terminated"
+                job.finished_at = time.time()
             return f"Background toolkit job {job.job_id} stopped with status={job.status}"
 
         return f"Error: Unknown action '{action}'"
@@ -190,6 +228,7 @@ class ToolkitToolWrapper(Tool):
             return await self._handle_background_action(action, job_id)
 
         try:
+            owner_key = get_tool_owner()
             bg_task = asyncio.create_task(self._invoke_tool(kwargs))
             try:
                 result = await asyncio.wait_for(asyncio.shield(bg_task), timeout=self._timeout_seconds)
@@ -199,8 +238,10 @@ class ToolkitToolWrapper(Tool):
                     job_id=f"tk_{uuid4().hex[:10]}",
                     tool_name=self.name,
                     task=bg_task,
+                    owner_key=owner_key,
                 )
                 _TOOLKIT_BACKGROUND_JOBS[job.job_id] = job
+                self._prune_completed_jobs(owner_key=owner_key)
                 logger.warning(
                     f"Toolkit tool {self.name} exceeded foreground wait budget "
                     f"({self._timeout_seconds:g}s) and was left running in the background as {job.job_id}"

--- a/tests/test_gateway_tracing.py
+++ b/tests/test_gateway_tracing.py
@@ -1133,6 +1133,30 @@ class TestToolkitAdapterTimeout:
 
         assert "not found" in denied.lower()
 
+    @pytest.mark.asyncio
+    async def test_toolkit_background_job_auto_marks_terminal_without_polling(self):
+        from spoon_bot.toolkit import adapter as adapter_module
+        from spoon_bot.toolkit.adapter import ToolkitToolWrapper
+
+        class _SlowAsyncTool:
+            name = "slow_auto_terminal"
+            description = "slow tool"
+
+            async def execute(self, **kwargs):
+                await asyncio.sleep(0.05)
+                return "done"
+
+        tool = ToolkitToolWrapper(_SlowAsyncTool(), timeout_seconds=0.01)
+        background = await tool.execute()
+        job_id = background.split("job_id:", 1)[1].splitlines()[0].strip()
+
+        await asyncio.sleep(0.12)
+        job = adapter_module._TOOLKIT_BACKGROUND_JOBS.get(job_id)
+        assert job is not None
+        assert job.status == "completed"
+        assert job.finished_at is not None
+        adapter_module._TOOLKIT_BACKGROUND_JOBS.pop(job_id, None)
+
 
 class TestToolOwnerKey:
     def test_owner_key_includes_user_and_session(self):

--- a/tests/test_gateway_tracing.py
+++ b/tests/test_gateway_tracing.py
@@ -978,3 +978,26 @@ class TestToolkitAdapterTimeout:
         await asyncio.sleep(0.15)
         result = await tool.execute(action="job_output", job_id=job_id)
         assert result == "done"
+
+    @pytest.mark.asyncio
+    async def test_toolkit_background_jobs_are_scoped_by_owner(self):
+        from spoon_bot.agent.tools.execution_context import bind_tool_owner
+        from spoon_bot.toolkit.adapter import ToolkitToolWrapper
+
+        class _SlowAsyncTool:
+            name = "slow_async_owner"
+            description = "slow tool"
+
+            async def execute(self, **kwargs):
+                await asyncio.sleep(0.15)
+                return "done"
+
+        tool = ToolkitToolWrapper(_SlowAsyncTool(), timeout_seconds=0.01)
+        with bind_tool_owner("owner-a"):
+            background = await tool.execute()
+            job_id = background.split("job_id:", 1)[1].splitlines()[0].strip()
+
+        with bind_tool_owner("owner-b"):
+            denied = await tool.execute(action="job_status", job_id=job_id)
+
+        assert "not found" in denied.lower()

--- a/tests/test_gateway_tracing.py
+++ b/tests/test_gateway_tracing.py
@@ -320,7 +320,9 @@ class TestBudgetConfig:
     def test_defaults(self):
         from spoon_bot.gateway.config import BudgetConfig
         b = BudgetConfig()
-        assert b.request_timeout_ms > 0 and b.tool_timeout_ms > 0
+        assert b.request_timeout_ms == 0
+        assert b.tool_timeout_ms > 0
+        assert b.stream_timeout_ms == 0
 
     def test_custom_values(self):
         from spoon_bot.gateway.config import BudgetConfig
@@ -563,6 +565,61 @@ class TestWsCancellationPropagation:
         cancelled = await handler._cancel_current_task_for_cleanup(timeout=0.2)
         assert cancelled is True
         assert handler._current_task is None
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_continues_after_connection_is_gone(self):
+        from spoon_bot.gateway.websocket.handler import WebSocketHandler
+
+        class _DisconnectedManager(_FakeManager):
+            def get_connection(self, conn_id):
+                return None
+
+            async def send_message(self, conn_id, message):
+                return False
+
+        fm = _DisconnectedManager()
+
+        with patch("spoon_bot.gateway.websocket.handler.get_agent", return_value=_make_mock_agent()):
+            handler = WebSocketHandler("conn_test", "persisted-session")
+            with patch("spoon_bot.gateway.websocket.handler.get_connection_manager", return_value=fm):
+                with patch("spoon_bot.gateway.websocket.handler.get_config") as mc:
+                    from spoon_bot.gateway.config import GatewayConfig
+                    mc.return_value = GatewayConfig()
+                    result = await handler._handle_chat({"message": "hi", "stream": True})
+
+        assert result["success"] is True
+        assert result["content"] == "Hello world"
+        assert result["session_key"] == "persisted-session"
+        assert fm.sent_messages == []
+
+    @pytest.mark.asyncio
+    async def test_websocket_disconnect_does_not_cancel_background_chat(self):
+        from fastapi import WebSocketDisconnect
+        from spoon_bot.gateway.config import GatewayConfig
+        from spoon_bot.gateway.websocket import handler as ws_handler_module
+
+        fake_ws = MagicMock()
+        fake_ws.client = None
+        fake_ws.receive_json = AsyncMock(side_effect=WebSocketDisconnect())
+
+        fake_manager = MagicMock()
+        fake_manager.connect = AsyncMock(return_value="conn_test")
+        fake_manager.send_message = AsyncMock(return_value=True)
+        fake_manager.disconnect = AsyncMock()
+
+        fake_handler = MagicMock()
+        fake_handler._cleanup_resources = AsyncMock()
+        fake_handler._cancel_current_task_for_cleanup = AsyncMock(return_value=True)
+
+        with patch.object(ws_handler_module, "get_config", return_value=GatewayConfig()):
+            with patch.object(ws_handler_module, "get_connection_manager", return_value=fake_manager):
+                with patch.object(ws_handler_module, "is_auth_required", return_value=False):
+                    with patch.object(ws_handler_module, "WebSocketHandler", return_value=fake_handler):
+                        await ws_handler_module.websocket_endpoint(fake_ws)
+
+        fake_handler._cancel_current_task_for_cleanup.assert_not_awaited()
+        fake_handler._cleanup_resources.assert_awaited_once()
+        fake_manager.disconnect.assert_awaited_once_with("conn_test")
 
 
 class TestWsTimeoutErrorCodes:
@@ -888,7 +945,7 @@ class TestRestCancellation:
 
 class TestToolkitAdapterTimeout:
     @pytest.mark.asyncio
-    async def test_toolkit_wrapper_enforces_timeout(self):
+    async def test_toolkit_wrapper_moves_to_background_after_timeout(self):
         from spoon_bot.toolkit.adapter import ToolkitToolWrapper
 
         class _SlowAsyncTool:
@@ -900,5 +957,24 @@ class TestToolkitAdapterTimeout:
 
         tool = ToolkitToolWrapper(_SlowAsyncTool(), timeout_seconds=0.05)
         result = await tool.execute()
-        assert "timed out" in result.lower()
-        assert "0.05" in result
+        assert "background" in result.lower()
+        assert "job_id:" in result
+
+    @pytest.mark.asyncio
+    async def test_toolkit_background_job_returns_result_when_ready(self):
+        from spoon_bot.toolkit.adapter import ToolkitToolWrapper
+
+        class _SlowAsyncTool:
+            name = "slow_async_result"
+            description = "slow tool"
+
+            async def execute(self, **kwargs):
+                await asyncio.sleep(0.1)
+                return "done"
+
+        tool = ToolkitToolWrapper(_SlowAsyncTool(), timeout_seconds=0.01)
+        background = await tool.execute()
+        job_id = background.split("job_id:", 1)[1].splitlines()[0].strip()
+        await asyncio.sleep(0.15)
+        result = await tool.execute(action="job_output", job_id=job_id)
+        assert result == "done"

--- a/tests/test_gateway_tracing.py
+++ b/tests/test_gateway_tracing.py
@@ -699,9 +699,15 @@ class TestWsCancellationPropagation:
                             "cancel_ws_session_chat_task",
                             new=AsyncMock(return_value=True),
                         ) as cancel_task:
-                            await ws_handler_module.websocket_endpoint(fake_ws)
+                            with patch.object(
+                                ws_handler_module,
+                                "get_ws_session_chat_lock",
+                                return_value=asyncio.Lock(),
+                            ) as get_replace_lock:
+                                await ws_handler_module.websocket_endpoint(fake_ws)
 
         cancel_task.assert_awaited_once_with("active-session", user_id="anonymous")
+        get_replace_lock.assert_called_once_with("active-session", user_id="anonymous")
 
     @pytest.mark.asyncio
     async def test_websocket_disconnect_does_not_cancel_background_chat(self):
@@ -731,6 +737,20 @@ class TestWsCancellationPropagation:
         fake_handler._cancel_current_task_for_cleanup.assert_not_awaited()
         fake_handler._cleanup_resources.assert_awaited_once()
         fake_manager.disconnect.assert_awaited_once_with("conn_test")
+
+    def test_ws_session_chat_lock_is_scoped_by_user_and_session(self):
+        from spoon_bot.gateway import app as app_module
+        from spoon_bot.gateway.app import get_ws_session_chat_lock
+
+        app_module._ws_session_chat_locks = {}
+        lock_a = get_ws_session_chat_lock("default", user_id="alice")
+        lock_a_again = get_ws_session_chat_lock("default", user_id="alice")
+        lock_b = get_ws_session_chat_lock("default", user_id="bob")
+        lock_other_session = get_ws_session_chat_lock("other", user_id="alice")
+
+        assert lock_a is lock_a_again
+        assert lock_a is not lock_b
+        assert lock_a is not lock_other_session
 
 
 class TestWsTimeoutErrorCodes:

--- a/tests/test_gateway_tracing.py
+++ b/tests/test_gateway_tracing.py
@@ -593,6 +593,84 @@ class TestWsCancellationPropagation:
         assert fm.sent_messages == []
 
     @pytest.mark.asyncio
+    async def test_reconnect_cancel_can_interrupt_previous_session_task(self):
+        from spoon_bot.gateway import app as app_module
+        from spoon_bot.gateway.app import clear_ws_session_chat_task, register_ws_session_chat_task
+        from spoon_bot.gateway.websocket.handler import WebSocketHandler
+
+        app_module._ws_session_chat_tasks = {}
+        session_key = "resume-session"
+        with patch("spoon_bot.gateway.websocket.handler.get_agent", return_value=_make_mock_agent()):
+            previous_handler = WebSocketHandler("conn_old", session_key)
+            previous_handler._current_task_id = "task_old_session"
+            previous_handler._current_task = asyncio.create_task(asyncio.sleep(100))
+            register_ws_session_chat_task(
+                session_key,
+                previous_handler._current_task,
+                cancel_cb=previous_handler._request_current_task_cancel,
+                task_id_cb=previous_handler._current_task_id_for_cancel,
+            )
+
+            try:
+                reconnect_handler = WebSocketHandler("conn_new", session_key)
+                result = await reconnect_handler._handle_cancel({"session_key": session_key})
+                assert result["cancelled"] is True
+                assert result["task_interrupted"] is True
+                assert result["task_id"] == "task_old_session"
+                await asyncio.sleep(0)
+                assert previous_handler._cancel_requested is True
+                assert previous_handler._current_task.cancelled()
+            finally:
+                clear_ws_session_chat_task(session_key)
+
+    @pytest.mark.asyncio
+    async def test_chat_send_cancels_existing_session_task_before_start(self):
+        from fastapi import WebSocketDisconnect
+        from spoon_bot.gateway.config import GatewayConfig
+        from spoon_bot.gateway.websocket import handler as ws_handler_module
+
+        fake_ws = MagicMock()
+        fake_ws.client = None
+        fake_ws.receive_json = AsyncMock(side_effect=[
+            {
+                "type": "request",
+                "id": "req_chat",
+                "method": "chat.send",
+                "params": {"message": "hello", "session_key": "active-session"},
+            },
+            WebSocketDisconnect(),
+        ])
+
+        fake_manager = MagicMock()
+        fake_manager.connect = AsyncMock(return_value="conn_test")
+        fake_manager.send_message = AsyncMock(return_value=True)
+        fake_manager.disconnect = AsyncMock()
+
+        fake_handler = MagicMock()
+        fake_handler._cleanup_resources = AsyncMock()
+        fake_handler._dispatch_concurrent_request = AsyncMock()
+        fake_handler.handle_request = AsyncMock()
+        fake_handler._handle_chat = AsyncMock(return_value={"success": True})
+        fake_handler._resolve_effective_session_key = MagicMock(return_value="active-session")
+        fake_handler._request_current_task_cancel = MagicMock()
+        fake_handler._current_task_id_for_cancel = MagicMock(return_value=None)
+        fake_handler._current_task = None
+        fake_handler._concurrent_tasks = set()
+
+        with patch.object(ws_handler_module, "get_config", return_value=GatewayConfig()):
+            with patch.object(ws_handler_module, "get_connection_manager", return_value=fake_manager):
+                with patch.object(ws_handler_module, "is_auth_required", return_value=False):
+                    with patch.object(ws_handler_module, "WebSocketHandler", return_value=fake_handler):
+                        with patch.object(
+                            ws_handler_module,
+                            "cancel_ws_session_chat_task",
+                            new=AsyncMock(return_value=True),
+                        ) as cancel_task:
+                            await ws_handler_module.websocket_endpoint(fake_ws)
+
+        cancel_task.assert_awaited_once_with("active-session")
+
+    @pytest.mark.asyncio
     async def test_websocket_disconnect_does_not_cancel_background_chat(self):
         from fastapi import WebSocketDisconnect
         from spoon_bot.gateway.config import GatewayConfig

--- a/tests/test_gateway_tracing.py
+++ b/tests/test_gateway_tracing.py
@@ -601,18 +601,19 @@ class TestWsCancellationPropagation:
         app_module._ws_session_chat_tasks = {}
         session_key = "resume-session"
         with patch("spoon_bot.gateway.websocket.handler.get_agent", return_value=_make_mock_agent()):
-            previous_handler = WebSocketHandler("conn_old", session_key)
+            previous_handler = WebSocketHandler("conn_old", session_key, user_id="user-a")
             previous_handler._current_task_id = "task_old_session"
             previous_handler._current_task = asyncio.create_task(asyncio.sleep(100))
             register_ws_session_chat_task(
                 session_key,
                 previous_handler._current_task,
+                user_id="user-a",
                 cancel_cb=previous_handler._request_current_task_cancel,
                 task_id_cb=previous_handler._current_task_id_for_cancel,
             )
 
             try:
-                reconnect_handler = WebSocketHandler("conn_new", session_key)
+                reconnect_handler = WebSocketHandler("conn_new", session_key, user_id="user-a")
                 result = await reconnect_handler._handle_cancel({"session_key": session_key})
                 assert result["cancelled"] is True
                 assert result["task_interrupted"] is True
@@ -621,7 +622,38 @@ class TestWsCancellationPropagation:
                 assert previous_handler._cancel_requested is True
                 assert previous_handler._current_task.cancelled()
             finally:
-                clear_ws_session_chat_task(session_key)
+                clear_ws_session_chat_task(session_key, user_id="user-a")
+
+    @pytest.mark.asyncio
+    async def test_reconnect_cancel_does_not_interrupt_other_user_task(self):
+        from spoon_bot.gateway import app as app_module
+        from spoon_bot.gateway.app import clear_ws_session_chat_task, register_ws_session_chat_task
+        from spoon_bot.gateway.websocket.handler import WebSocketHandler
+
+        app_module._ws_session_chat_tasks = {}
+        session_key = "default"
+        with patch("spoon_bot.gateway.websocket.handler.get_agent", return_value=_make_mock_agent()):
+            owner_handler = WebSocketHandler("conn_owner", session_key, user_id="user-a")
+            owner_handler._current_task_id = "task_user_a"
+            owner_handler._current_task = asyncio.create_task(asyncio.sleep(100))
+            register_ws_session_chat_task(
+                session_key,
+                owner_handler._current_task,
+                user_id="user-a",
+                cancel_cb=owner_handler._request_current_task_cancel,
+                task_id_cb=owner_handler._current_task_id_for_cancel,
+            )
+
+            attacker_handler = WebSocketHandler("conn_other", session_key, user_id="user-b")
+            result = await attacker_handler._handle_cancel({"session_key": session_key})
+            assert result["cancelled"] is True
+            assert result["task_interrupted"] is False
+            await asyncio.sleep(0)
+            assert owner_handler._current_task.cancelled() is False
+
+            owner_handler._current_task.cancel()
+            await asyncio.gather(owner_handler._current_task, return_exceptions=True)
+            clear_ws_session_chat_task(session_key, user_id="user-a")
 
     @pytest.mark.asyncio
     async def test_chat_send_cancels_existing_session_task_before_start(self):
@@ -652,6 +684,7 @@ class TestWsCancellationPropagation:
         fake_handler.handle_request = AsyncMock()
         fake_handler._handle_chat = AsyncMock(return_value={"success": True})
         fake_handler._resolve_effective_session_key = MagicMock(return_value="active-session")
+        fake_handler._resolve_registry_user_id = MagicMock(return_value="anonymous")
         fake_handler._request_current_task_cancel = MagicMock()
         fake_handler._current_task_id_for_cancel = MagicMock(return_value=None)
         fake_handler._current_task = None
@@ -668,7 +701,7 @@ class TestWsCancellationPropagation:
                         ) as cancel_task:
                             await ws_handler_module.websocket_endpoint(fake_ws)
 
-        cancel_task.assert_awaited_once_with("active-session")
+        cancel_task.assert_awaited_once_with("active-session", user_id="anonymous")
 
     @pytest.mark.asyncio
     async def test_websocket_disconnect_does_not_cancel_background_chat(self):
@@ -1079,3 +1112,22 @@ class TestToolkitAdapterTimeout:
             denied = await tool.execute(action="job_status", job_id=job_id)
 
         assert "not found" in denied.lower()
+
+
+class TestToolOwnerKey:
+    def test_owner_key_includes_user_and_session(self):
+        from spoon_bot.agent.tools.execution_context import build_tool_owner_key
+
+        a = build_tool_owner_key("alice", "default")
+        b = build_tool_owner_key("bob", "default")
+        assert a == "user:alice|session:default"
+        assert b == "user:bob|session:default"
+        assert a != b
+
+    def test_agent_loop_owner_key_is_user_scoped(self):
+        from spoon_bot.agent.loop import AgentLoop
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop.user_id = "alice"
+        loop.session_key = "default"
+        assert loop._current_tool_owner_key() == "user:alice|session:default"

--- a/tests/test_stream_thinking_fix.py
+++ b/tests/test_stream_thinking_fix.py
@@ -1,21 +1,49 @@
 """
-Tests for streaming thinking fix and stream timeout improvements.
+Tests for streaming thinking behavior and resilient long-running streams.
 
 Covers:
   - thinking parameter forwarded to _run_and_signal() in stream mode
-  - stream timeout uses 600s for thinking, 300s otherwise
-  - stream timeout emits error event instead of silent break
+  - stream loop no longer enforces a local deadline
+  - delayed chunks still arrive without tripping a local stream timeout
   - ConnectionManager.send_message retries before disconnecting
 """
 
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+
+def _make_mock_stream_agent(run_impl) -> tuple[object, asyncio.Queue, asyncio.Event]:
+    from spoon_bot.agent.loop import AgentLoop
+
+    oq: asyncio.Queue = asyncio.Queue()
+    td = asyncio.Event()
+
+    agent = MagicMock(spec=AgentLoop)
+    agent._initialized = True
+    agent._agent = MagicMock()
+    agent._agent.output_queue = oq
+    agent._agent.task_done = td
+    agent._agent.run = run_impl
+    agent._agent.state = "idle"
+    agent._agent.add_message = AsyncMock()
+    agent._session = MagicMock()
+    agent._session.add_message = MagicMock()
+    agent.sessions = MagicMock()
+    agent.sessions.save = MagicMock()
+    agent.memory = MagicMock()
+    agent.memory.get_memory_context = MagicMock(return_value=None)
+    agent.context = MagicMock()
+    agent._prepare_request_context = AsyncMock()
+    agent._build_runtime_message_content = MagicMock(return_value="test")
+    agent._build_step_prompt = MagicMock(return_value="prompt")
+    agent._install_anti_loop_tracker = MagicMock()
+    agent._restore_agent_think = MagicMock()
+    agent._callable_accepts_kwarg = AgentLoop._callable_accepts_kwarg
+    return agent, oq, td
 
 
 # ============================================================
@@ -39,30 +67,7 @@ class TestStreamThinkingParam:
             result.content = "done"
             return result
 
-        oq: asyncio.Queue = asyncio.Queue()
-        td = asyncio.Event()
-
-        agent = MagicMock(spec=AgentLoop)
-        agent._initialized = True
-        agent._agent = MagicMock()
-        agent._agent.output_queue = oq
-        agent._agent.task_done = td
-        agent._agent.run = mock_run
-        agent._agent.state = "idle"
-        agent._agent.add_message = AsyncMock()
-        agent._session = MagicMock()
-        agent._session.add_message = MagicMock()
-        agent.sessions = MagicMock()
-        agent.sessions.save = MagicMock()
-        agent.memory = MagicMock()
-        agent.memory.get_memory_context = MagicMock(return_value=None)
-        agent.context = MagicMock()
-        agent._prepare_request_context = AsyncMock()
-        agent._build_runtime_message_content = MagicMock(return_value="test")
-        agent._build_step_prompt = MagicMock(return_value="prompt")
-        agent._install_anti_loop_tracker = MagicMock()
-        agent._restore_agent_think = MagicMock()
-        agent._callable_accepts_kwarg = AgentLoop._callable_accepts_kwarg
+        agent, _, _ = _make_mock_stream_agent(mock_run)
 
         chunks = []
         async for chunk in AgentLoop.stream(agent, message="test", thinking=True):
@@ -84,30 +89,7 @@ class TestStreamThinkingParam:
             result.content = "done"
             return result
 
-        oq: asyncio.Queue = asyncio.Queue()
-        td = asyncio.Event()
-
-        agent = MagicMock(spec=AgentLoop)
-        agent._initialized = True
-        agent._agent = MagicMock()
-        agent._agent.output_queue = oq
-        agent._agent.task_done = td
-        agent._agent.run = mock_run
-        agent._agent.state = "idle"
-        agent._agent.add_message = AsyncMock()
-        agent._session = MagicMock()
-        agent._session.add_message = MagicMock()
-        agent.sessions = MagicMock()
-        agent.sessions.save = MagicMock()
-        agent.memory = MagicMock()
-        agent.memory.get_memory_context = MagicMock(return_value=None)
-        agent.context = MagicMock()
-        agent._prepare_request_context = AsyncMock()
-        agent._build_runtime_message_content = MagicMock(return_value="test")
-        agent._build_step_prompt = MagicMock(return_value="prompt")
-        agent._install_anti_loop_tracker = MagicMock()
-        agent._restore_agent_think = MagicMock()
-        agent._callable_accepts_kwarg = AgentLoop._callable_accepts_kwarg
+        agent, _, _ = _make_mock_stream_agent(mock_run)
 
         chunks = []
         async for chunk in AgentLoop.stream(agent, message="test", thinking=False):
@@ -118,169 +100,38 @@ class TestStreamThinkingParam:
 
 
 # ============================================================
-# Stream timeout configuration
+# Stream wait behavior
 # ============================================================
 
 
-class TestStreamTimeoutConfig:
-    """Verify that stream timeout is properly configured based on thinking flag."""
+class TestStreamWaitBehavior:
+    """Verify that stream() waits for completion instead of timing out locally."""
 
     @pytest.mark.asyncio
-    async def test_thinking_mode_uses_longer_timeout(self):
-        """With thinking=True, stream_timeout should be 600s."""
-        from spoon_bot.agent.loop import AgentLoop
-
-        timeout_captured: list[float] = []
-
-        orig_time = asyncio.get_event_loop().time
-
-        async def mock_run(**kwargs):
-            result = MagicMock()
-            result.content = "done"
-            return result
-
-        oq: asyncio.Queue = asyncio.Queue()
-        td = asyncio.Event()
-
-        agent = MagicMock(spec=AgentLoop)
-        agent._initialized = True
-        agent._agent = MagicMock()
-        agent._agent.output_queue = oq
-        agent._agent.task_done = td
-        agent._agent.run = mock_run
-        agent._agent.state = "idle"
-        agent._agent.add_message = AsyncMock()
-        agent._session = MagicMock()
-        agent._session.add_message = MagicMock()
-        agent.sessions = MagicMock()
-        agent.sessions.save = MagicMock()
-        agent.memory = MagicMock()
-        agent.memory.get_memory_context = MagicMock(return_value=None)
-        agent.context = MagicMock()
-        agent._prepare_request_context = AsyncMock()
-        agent._build_runtime_message_content = MagicMock(return_value="test")
-        agent._build_step_prompt = MagicMock(return_value="prompt")
-        agent._install_anti_loop_tracker = MagicMock()
-        agent._restore_agent_think = MagicMock()
-        agent._callable_accepts_kwarg = AgentLoop._callable_accepts_kwarg
-
-        chunks = []
-        async for chunk in AgentLoop.stream(agent, message="test", thinking=True):
-            chunks.append(chunk)
-
-        done_chunks = [c for c in chunks if c["type"] == "done"]
-        assert len(done_chunks) == 1
-
-    @pytest.mark.asyncio
-    async def test_non_thinking_mode_uses_default_timeout(self):
-        """With thinking=False, stream_timeout should be 300s (not the old 120s)."""
+    async def test_stream_waits_for_delayed_chunk_without_timeout(self):
+        """A delayed chunk should still be delivered without a synthetic timeout error."""
         from spoon_bot.agent.loop import AgentLoop
 
         async def mock_run(**kwargs):
+            await asyncio.sleep(0.05)
+            await oq.put({"type": "content", "delta": "late chunk", "metadata": {}})
             result = MagicMock()
-            result.content = "done"
+            result.content = "late chunk"
             return result
 
-        oq: asyncio.Queue = asyncio.Queue()
-        td = asyncio.Event()
-
-        agent = MagicMock(spec=AgentLoop)
-        agent._initialized = True
-        agent._agent = MagicMock()
-        agent._agent.output_queue = oq
-        agent._agent.task_done = td
-        agent._agent.run = mock_run
-        agent._agent.state = "idle"
-        agent._agent.add_message = AsyncMock()
-        agent._session = MagicMock()
-        agent._session.add_message = MagicMock()
-        agent.sessions = MagicMock()
-        agent.sessions.save = MagicMock()
-        agent.memory = MagicMock()
-        agent.memory.get_memory_context = MagicMock(return_value=None)
-        agent.context = MagicMock()
-        agent._prepare_request_context = AsyncMock()
-        agent._build_runtime_message_content = MagicMock(return_value="test")
-        agent._build_step_prompt = MagicMock(return_value="prompt")
-        agent._install_anti_loop_tracker = MagicMock()
-        agent._restore_agent_think = MagicMock()
-        agent._callable_accepts_kwarg = AgentLoop._callable_accepts_kwarg
+        agent, oq, _ = _make_mock_stream_agent(mock_run)
 
         chunks = []
-        async for chunk in AgentLoop.stream(agent, message="test", thinking=False):
+        async for chunk in AgentLoop.stream(agent, message="test"):
             chunks.append(chunk)
 
+        assert [c for c in chunks if c["type"] == "error"] == []
+        content_chunks = [c for c in chunks if c["type"] == "content"]
         done_chunks = [c for c in chunks if c["type"] == "done"]
+        assert len(content_chunks) == 1
+        assert content_chunks[0]["delta"] == "late chunk"
         assert len(done_chunks) == 1
-
-
-# ============================================================
-# Stream timeout emits error (not silent break)
-# ============================================================
-
-
-class TestStreamTimeoutError:
-    """Verify that stream timeout emits an error event."""
-
-    @pytest.mark.asyncio
-    async def test_timeout_emits_error_chunk(self):
-        """When stream deadline is reached, an error chunk should be emitted."""
-        from spoon_bot.agent.loop import AgentLoop
-
-        oq: asyncio.Queue = asyncio.Queue()
-        td = asyncio.Event()
-
-        async def slow_run(**kwargs):
-            await asyncio.sleep(100)
-            result = MagicMock()
-            result.content = "never"
-            return result
-
-        agent = MagicMock(spec=AgentLoop)
-        agent._initialized = True
-        agent._agent = MagicMock()
-        agent._agent.output_queue = oq
-        agent._agent.task_done = td
-        agent._agent.run = slow_run
-        agent._agent.state = "idle"
-        agent._agent.add_message = AsyncMock()
-        agent._session = MagicMock()
-        agent._session.add_message = MagicMock()
-        agent.sessions = MagicMock()
-        agent.sessions.save = MagicMock()
-        agent.memory = MagicMock()
-        agent.memory.get_memory_context = MagicMock(return_value=None)
-        agent.context = MagicMock()
-        agent._prepare_request_context = AsyncMock()
-        agent._build_runtime_message_content = MagicMock(return_value="test")
-        agent._build_step_prompt = MagicMock(return_value="prompt")
-        agent._install_anti_loop_tracker = MagicMock()
-        agent._restore_agent_think = MagicMock()
-        agent._callable_accepts_kwarg = AgentLoop._callable_accepts_kwarg
-
-        with patch("spoon_bot.agent.loop.asyncio.get_event_loop") as mock_loop:
-            call_count = 0
-
-            def fake_time():
-                nonlocal call_count
-                call_count += 1
-                if call_count <= 2:
-                    return 1000.0
-                return 2000.0
-
-            mock_event_loop = MagicMock()
-            mock_event_loop.time = fake_time
-            mock_loop.return_value = mock_event_loop
-
-            chunks = []
-            async for chunk in AgentLoop.stream(agent, message="test"):
-                chunks.append(chunk)
-                if chunk.get("type") == "error":
-                    break
-
-            error_chunks = [c for c in chunks if c["type"] == "error"]
-            assert len(error_chunks) >= 1
-            assert "STREAM_TIMEOUT" in error_chunks[0]["metadata"].get("error_code", "")
+        assert done_chunks[0]["metadata"]["content"] == "late chunk"
 
 
 # ============================================================

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -1151,6 +1151,57 @@ class TestAgentLoopProcessWithThinking:
         assert thinking == "I need to think about this..."
 
     @pytest.mark.asyncio
+    async def test_process_with_thinking_binds_tool_owner(self):
+        """process_with_thinking() should bind tool owner context for run()."""
+        from contextlib import contextmanager
+        from spoon_bot.agent.loop import AgentLoop
+
+        result = MagicMock()
+        result.content = "ok"
+        result.thinking_content = None
+
+        mock_inner_agent = MagicMock()
+        mock_inner_agent.run = AsyncMock(return_value=result)
+        mock_inner_agent.add_message = AsyncMock()
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = mock_inner_agent
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._auto_commit = False
+        agent._git = None
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._looks_like_duplicate_thinking = AgentLoop._looks_like_duplicate_thinking.__get__(agent, AgentLoop)
+        agent._normalize_comparable_text = AgentLoop._normalize_comparable_text
+        agent._latest_reasoning_excerpt = None
+        agent._current_tool_owner_key = MagicMock(return_value="user:alice|session:default")
+
+        owners: list[str] = []
+
+        @contextmanager
+        def _capture_owner(owner):
+            owners.append(str(owner))
+            yield owner
+
+        with patch("spoon_bot.agent.loop.bind_tool_owner", side_effect=_capture_owner):
+            response, thinking = await AgentLoop.process_with_thinking(agent, message="test")
+
+        assert response == "ok"
+        assert thinking is None
+        assert owners == ["user:alice|session:default"]
+
+    @pytest.mark.asyncio
     async def test_thinking_fallback_attributes(self):
         """Should try multiple attributes for thinking content."""
         from spoon_bot.agent.loop import AgentLoop

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -78,6 +78,91 @@ class TestShellTool:
         # Should be truncated
         assert "truncated" in result.lower() or len(result) <= 100
 
+    @pytest.mark.asyncio
+    async def test_command_moves_to_background_after_timeout(self, shell_tool):
+        """Timed-out commands should stay alive as background jobs instead of erroring out."""
+        from spoon_bot.agent.tools.shell import _BackgroundShellJob, _SHELL_BACKGROUND_JOBS
+
+        shell_tool.timeout = 0.01
+
+        class _FakeProcess:
+            returncode = None
+
+            async def wait(self):
+                await asyncio.sleep(1)
+
+            def terminate(self):
+                self.returncode = -15
+
+            def kill(self):
+                self.returncode = -9
+
+        stdout_task = asyncio.create_task(asyncio.sleep(1))
+        stderr_task = asyncio.create_task(asyncio.sleep(1))
+        job = _BackgroundShellJob(
+            job_id="sh_testjob",
+            command="echo hello",
+            cwd=os.getcwd(),
+            process=_FakeProcess(),
+            stdout_task=stdout_task,
+            stderr_task=stderr_task,
+            buffer_limit=1000,
+            stdout_text="still running",
+        )
+
+        async def _fake_start_background_job(*args, **kwargs):
+            _SHELL_BACKGROUND_JOBS[job.job_id] = job
+            return job
+
+        with patch.object(shell_tool, "_start_background_job", AsyncMock(side_effect=_fake_start_background_job)):
+            result = await shell_tool.execute("echo hello")
+
+        assert "background" in result.lower()
+        assert "sh_testjob" in result
+        assert _SHELL_BACKGROUND_JOBS["sh_testjob"] is job
+        stdout_task.cancel()
+        stderr_task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_background_job_status_and_terminate_actions(self, shell_tool):
+        """Shell background jobs should expose status and terminate actions."""
+        from spoon_bot.agent.tools.shell import _BackgroundShellJob, _SHELL_BACKGROUND_JOBS
+
+        class _FakeProcess:
+            def __init__(self):
+                self.returncode = None
+
+            async def wait(self):
+                self.returncode = -15
+                return self.returncode
+
+            def terminate(self):
+                self.returncode = -15
+
+            def kill(self):
+                self.returncode = -9
+
+        stdout_task = asyncio.create_task(asyncio.sleep(0))
+        stderr_task = asyncio.create_task(asyncio.sleep(0))
+        job = _BackgroundShellJob(
+            job_id="sh_statusjob",
+            command="echo hello",
+            cwd=os.getcwd(),
+            process=_FakeProcess(),
+            stdout_task=stdout_task,
+            stderr_task=stderr_task,
+            buffer_limit=1000,
+            stdout_text="line one",
+        )
+        _SHELL_BACKGROUND_JOBS[job.job_id] = job
+
+        status = await shell_tool.execute(action="job_status", job_id=job.job_id)
+        assert "job_id: sh_statusjob" in status
+        assert "line one" in status
+
+        terminated = await shell_tool.execute(action="terminate_job", job_id=job.job_id)
+        assert "Terminated background shell job sh_statusjob" in terminated
+
     def test_windows_shell_uses_user_home_env(self, monkeypatch):
         """Windows bash execution should preserve the user's home path."""
         from spoon_bot.agent.tools.shell import ShellTool

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -163,6 +163,97 @@ class TestShellTool:
         terminated = await shell_tool.execute(action="terminate_job", job_id=job.job_id)
         assert "Terminated background shell job sh_statusjob" in terminated
 
+    @pytest.mark.asyncio
+    async def test_background_jobs_are_scoped_by_owner(self, shell_tool):
+        """Shell background job actions should only expose caller-owned jobs."""
+        from spoon_bot.agent.tools.execution_context import bind_tool_owner
+        from spoon_bot.agent.tools.shell import _BackgroundShellJob, _SHELL_BACKGROUND_JOBS
+
+        class _FakeProcess:
+            returncode = None
+
+            async def wait(self):
+                return None
+
+            def terminate(self):
+                self.returncode = -15
+
+            def kill(self):
+                self.returncode = -9
+
+        _SHELL_BACKGROUND_JOBS.clear()
+        owner_a_job = _BackgroundShellJob(
+            job_id="sh_owner_a",
+            command="echo owner-a",
+            cwd=os.getcwd(),
+            process=_FakeProcess(),
+            stdout_task=asyncio.create_task(asyncio.sleep(0)),
+            stderr_task=asyncio.create_task(asyncio.sleep(0)),
+            buffer_limit=1000,
+            stdout_text="owner-a output",
+            owner_key="owner-a",
+        )
+        owner_b_job = _BackgroundShellJob(
+            job_id="sh_owner_b",
+            command="echo owner-b",
+            cwd=os.getcwd(),
+            process=_FakeProcess(),
+            stdout_task=asyncio.create_task(asyncio.sleep(0)),
+            stderr_task=asyncio.create_task(asyncio.sleep(0)),
+            buffer_limit=1000,
+            stdout_text="owner-b output",
+            owner_key="owner-b",
+        )
+        _SHELL_BACKGROUND_JOBS[owner_a_job.job_id] = owner_a_job
+        _SHELL_BACKGROUND_JOBS[owner_b_job.job_id] = owner_b_job
+
+        with bind_tool_owner("owner-a"):
+            listed = await shell_tool.execute(action="list_jobs")
+            denied = await shell_tool.execute(action="job_status", job_id=owner_b_job.job_id)
+
+        assert "sh_owner_a" in listed
+        assert "sh_owner_b" not in listed
+        assert "not found" in denied.lower()
+
+    @pytest.mark.asyncio
+    async def test_foreground_completion_evicts_job_from_registry(self, shell_tool):
+        """Completed foreground shell runs should not remain in global job registry."""
+        from spoon_bot.agent.tools.shell import _BackgroundShellJob, _SHELL_BACKGROUND_JOBS
+
+        class _FakeProcess:
+            returncode = 0
+
+            async def wait(self):
+                return 0
+
+            def terminate(self):
+                self.returncode = -15
+
+            def kill(self):
+                self.returncode = -9
+
+        _SHELL_BACKGROUND_JOBS.clear()
+        job = _BackgroundShellJob(
+            job_id="sh_foreground_done",
+            command="echo done",
+            cwd=os.getcwd(),
+            process=_FakeProcess(),
+            stdout_task=asyncio.create_task(asyncio.sleep(0)),
+            stderr_task=asyncio.create_task(asyncio.sleep(0)),
+            buffer_limit=1000,
+            stdout_text="done",
+        )
+
+        async def _fake_start_background_job(*args, **kwargs):
+            _SHELL_BACKGROUND_JOBS[job.job_id] = job
+            return job
+
+        with patch.object(shell_tool, "_start_background_job", AsyncMock(side_effect=_fake_start_background_job)):
+            result = await shell_tool.execute("echo done")
+
+        assert "done" in result.lower()
+        assert job.job_id not in _SHELL_BACKGROUND_JOBS
+
     def test_windows_shell_uses_user_home_env(self, monkeypatch):
         """Windows bash execution should preserve the user's home path."""
         from spoon_bot.agent.tools.shell import ShellTool


### PR DESCRIPTION
## Summary
- remove gateway request/stream hard timeouts by default so requests can run indefinitely
- keep chat tasks alive after WebSocket disconnect and only stop them on explicit cancel
- move long-running shell and toolkit executions into inspectable background jobs after a 60 minute foreground budget

## Details
- set `request_timeout_ms` and `stream_timeout_ms` defaults to `0`
- remove the local stream deadline in `AgentLoop.stream()`
- stop cancelling the active task in the websocket disconnect cleanup path
- add session fallback so a disconnected WS can lose delivery without losing the running task
- extend `shell` with `list_jobs`, `job_status`, `job_output`, and `terminate_job`
- extend toolkit wrappers with the same background job controls
- keep shell/toolkit foreground wait at 60 minutes before backgrounding

## Testing
- `uv run python -m pytest tests/test_tools.py tests/test_gateway_tracing.py::TestBudgetConfig::test_defaults tests/test_gateway_tracing.py::TestToolkitAdapterTimeout tests/test_gateway_tracing.py::TestWsCancellationPropagation::test_stream_chat_continues_after_connection_is_gone tests/test_gateway_tracing.py::TestWsCancellationPropagation::test_websocket_disconnect_does_not_cancel_background_chat tests/test_gateway_ws_bugs.py::TestWSCancelNonStream::test_cancel_returns_task_interrupted tests/test_stream_thinking_fix.py -q`

## Notes
- toolkit termination for sync thread-backed tools remains best-effort; cancellation is requested but a hard kill is not guaranteed without deeper process isolation