### PR TITLE
Fix: add tool result in stream

### DIFF
--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2444,6 +2444,14 @@ class AgentLoop:
                 elif isinstance(chunk, str):
                     delta = chunk
 
+                if chunk_type == "tool_result":
+                    yield {
+                        "type": chunk_type,
+                        "delta": delta,
+                        "metadata": metadata,
+                    }
+                    continue
+
                 if delta:
                     metadata_phase = metadata.get("phase") if isinstance(metadata, dict) else None
                     explicit_pre_tool_phase = (

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2076,6 +2076,96 @@ class AgentLoop:
         result = re.sub(r'\n{3,}', '\n\n', result)  # Replace 3+ newlines with 2
         return result.strip()
 
+    @staticmethod
+    def _stream_message_attr(message: Any, key: str, default: Any = None) -> Any:
+        """Read a message field from either dict or object runtime payloads."""
+        if isinstance(message, dict):
+            return message.get(key, default)
+        return getattr(message, key, default)
+
+    @staticmethod
+    def _stream_message_role(message: Any) -> str:
+        """Normalize runtime message roles to plain strings."""
+        role = AgentLoop._stream_message_attr(message, "role", "")
+        return role.value if hasattr(role, "value") else str(role or "")
+
+    @staticmethod
+    def _stringify_stream_payload(payload: Any) -> str:
+        """Serialize structured tool payloads for websocket metadata."""
+        if payload is None:
+            return ""
+        if isinstance(payload, str):
+            return payload
+        if isinstance(payload, (dict, list)):
+            try:
+                return json.dumps(payload, ensure_ascii=False)
+            except Exception:
+                return str(payload)
+        return str(payload)
+
+    def _get_runtime_memory_messages(self) -> list[Any]:
+        """Return runtime memory messages exposed by the active inner agent."""
+        if not hasattr(self._agent, "memory") or self._agent.memory is None:
+            return []
+
+        memory = self._agent.memory
+        if hasattr(memory, "get_messages"):
+            try:
+                messages = memory.get_messages()
+                if isinstance(messages, list):
+                    return messages
+            except Exception as exc:
+                logger.debug(f"Failed to read runtime memory via get_messages(): {exc}")
+
+        messages = getattr(memory, "messages", None)
+        return messages if isinstance(messages, list) else []
+
+    def _collect_stream_tool_result_events(
+        self,
+        start_index: int,
+        emitted_tool_result_ids: set[str],
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Collect newly-added tool result messages from runtime memory."""
+        messages = AgentLoop._get_runtime_memory_messages(self)
+        if start_index < 0 or start_index > len(messages):
+            start_index = 0
+
+        events: list[dict[str, Any]] = []
+        for msg in messages[start_index:]:
+            if AgentLoop._stream_message_role(msg) != "tool":
+                continue
+
+            tool_call_id = (
+                AgentLoop._stream_message_attr(msg, "tool_call_id", "")
+                or AgentLoop._stream_message_attr(msg, "id", "")
+            )
+            if tool_call_id and tool_call_id in emitted_tool_result_ids:
+                continue
+
+            result_payload = AgentLoop._stream_message_attr(msg, "text_content", None)
+            if result_payload in (None, ""):
+                result_payload = AgentLoop._stream_message_attr(msg, "content", "")
+            serialized_result = AgentLoop._stringify_stream_payload(result_payload)
+            tool_name = AgentLoop._stream_message_attr(msg, "name", "")
+
+            metadata: dict[str, Any] = {
+                "name": tool_name,
+                "result": serialized_result,
+                "content": serialized_result,
+            }
+            if tool_call_id:
+                metadata["id"] = tool_call_id
+                metadata["tool_call_id"] = tool_call_id
+                emitted_tool_result_ids.add(tool_call_id)
+
+            events.append({
+                "type": "tool_result",
+                "delta": "",
+                "metadata": metadata,
+            })
+
+        return events, len(messages)
+
 
     async def stream(
         self,
@@ -2151,6 +2241,8 @@ class AgentLoop:
                     break
 
             await self._agent.add_message("user", runtime_message)
+            stream_tool_result_index = len(AgentLoop._get_runtime_memory_messages(self))
+            emitted_tool_result_ids: set[str] = set()
 
             # 2. Start run() in background
             run_result_text = ""
@@ -2197,6 +2289,16 @@ class AgentLoop:
 
             logger.debug(f"Entering stream loop: td={td.is_set()}, qempty={oq.empty()}, qsize={oq.qsize()}")
             while not (td.is_set() and oq.empty()):
+                tool_result_events, stream_tool_result_index = (
+                    AgentLoop._collect_stream_tool_result_events(
+                        self,
+                        stream_tool_result_index,
+                        emitted_tool_result_ids,
+                    )
+                )
+                for event in tool_result_events:
+                    yield event
+
                 # tracked_reasoning is inferred from assistant output logs and is
                 # not a reliable API thinking source. Clear it so it does not leak
                 # duplicated final content into WS/REST responses.
@@ -2305,6 +2407,28 @@ class AgentLoop:
                     dict_type = chunk.get("type")
                     if dict_type == "thinking":
                         chunk_type = "thinking"
+                    elif dict_type == "tool_result":
+                        chunk_type = "tool_result"
+                        tool_result = (
+                            chunk.get("result")
+                            or chunk.get("content")
+                            or chunk.get("response")
+                            or chunk.get("output")
+                        )
+                        serialized_result = AgentLoop._stringify_stream_payload(tool_result)
+                        if serialized_result:
+                            metadata.setdefault("result", serialized_result)
+                            metadata.setdefault("content", serialized_result)
+                        tool_call_id = (
+                            chunk.get("tool_call_id")
+                            or chunk.get("id")
+                            or metadata.get("tool_call_id")
+                            or metadata.get("id")
+                        )
+                        if tool_call_id:
+                            metadata.setdefault("tool_call_id", tool_call_id)
+                            metadata.setdefault("id", tool_call_id)
+                            emitted_tool_result_ids.add(tool_call_id)
                     elif dict_type == "content":
                         chunk_type = "content"
                     # Support both "content" and "delta" keys (#10)
@@ -2358,6 +2482,15 @@ class AgentLoop:
                 pass
 
             self._drain_reasoning_chunks()
+            tool_result_events, stream_tool_result_index = (
+                AgentLoop._collect_stream_tool_result_events(
+                    self,
+                    stream_tool_result_index,
+                    emitted_tool_result_ids,
+                )
+            )
+            for event in tool_result_events:
+                yield event
 
             if pending_pre_tool_chunks:
                 for pending_chunk in pending_pre_tool_chunks:

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -684,6 +684,128 @@ class TestAgentLoopStream:
         assert done_chunks[0]["metadata"]["content"] == "Done."
 
     @pytest.mark.asyncio
+    async def test_stream_passes_through_structured_tool_result_chunks(self):
+        """Explicit tool_result chunks should be preserved for downstream UIs."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "shell"
+        tool_call.function.arguments = '{"command":"pwd"}'
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"tool_calls": [tool_call]})
+            await agent._agent.output_queue.put(
+                {
+                    "type": "tool_result",
+                    "metadata": {
+                        "id": "call_1",
+                        "name": "shell",
+                    },
+                    "result": {
+                        "stdout": "/workspace",
+                    },
+                }
+            )
+            await agent._agent.output_queue.put({"content": "Done."})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.memory = MagicMock()
+        agent._agent.memory.messages = []
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="placeholder")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder"):
+            chunks.append(chunk)
+
+        emitted = [c for c in chunks if c["type"] in {"tool_call", "tool_result", "content"}]
+        assert [c["type"] for c in emitted] == ["tool_call", "tool_result", "content"]
+        assert emitted[1]["metadata"]["id"] == "call_1"
+        assert emitted[1]["metadata"]["name"] == "shell"
+        assert emitted[1]["metadata"]["result"] == '{"stdout": "/workspace"}'
+
+    @pytest.mark.asyncio
+    async def test_stream_backfills_tool_result_from_runtime_memory(self):
+        """Tool results stored only in runtime memory should still be emitted."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "shell"
+        tool_call.function.arguments = '{"command":"pwd"}'
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"tool_calls": [tool_call]})
+            agent._agent.memory.messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "name": "shell",
+                    "content": "/workspace",
+                }
+            )
+            await agent._agent.output_queue.put({"content": "Done."})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.memory = MagicMock()
+        agent._agent.memory.messages = []
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="placeholder")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder"):
+            chunks.append(chunk)
+
+        emitted = [c for c in chunks if c["type"] in {"tool_call", "tool_result", "content"}]
+        assert [c["type"] for c in emitted] == ["tool_call", "tool_result", "content"]
+        assert emitted[1]["metadata"]["id"] == "call_1"
+        assert emitted[1]["metadata"]["name"] == "shell"
+        assert emitted[1]["metadata"]["result"] == "/workspace"
+
+    @pytest.mark.asyncio
     async def test_stream_uses_explicit_thinking_chunk_without_prompt_heuristic(self):
         """Explicit thinking chunks from core should drive pre-tool thinking display."""
         from spoon_bot.agent.loop import AgentLoop


### PR DESCRIPTION
- Add streaming `tool_result` emission for explicit runtime chunks

- Backfill `tool_result` events from runtime memory `role=tool` messages when queue output is missing

- Add regression coverage for both paths