### PR TITLE
fix: preserve content streaming and thinking kwargs

### DIFF
--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2144,6 +2144,28 @@ class AgentLoop:
         """Collapse whitespace so duplicate text can be compared reliably."""
         return " ".join(str(text or "").split())
 
+    @staticmethod
+    def _resolve_stream_fallback_delta(
+        streamed_text: str | None,
+        final_text: str | None,
+    ) -> tuple[str, str]:
+        """Return merged final content plus the missing delta to emit."""
+        streamed = str(streamed_text or "")
+        final = str(final_text or "")
+        if not streamed or not final:
+            return final, final
+
+        prefix_candidates = [streamed]
+        trimmed_streamed = streamed.rstrip()
+        if trimmed_streamed and trimmed_streamed != streamed:
+            prefix_candidates.append(trimmed_streamed)
+
+        for prefix in prefix_candidates:
+            if prefix and final.startswith(prefix):
+                return final, final[len(prefix):]
+
+        return streamed + final, final
+
     def _looks_like_duplicate_thinking(
         self,
         thinking_text: str | None,
@@ -2627,17 +2649,22 @@ class AgentLoop:
                     "Stream produced no content chunks; "
                     "falling back to run() result text."
                 )
+                fallback_delta = run_result_text
                 if full_content and fallback_after_tool_only_preamble:
-                    full_content += run_result_text
+                    full_content, fallback_delta = AgentLoop._resolve_stream_fallback_delta(
+                        full_content,
+                        run_result_text,
+                    )
                     fallback_reason = "run_result_after_tool_preamble"
                 else:
                     full_content = run_result_text
                     fallback_reason = "run_result_no_chunks"
-                yield {
-                    "type": "content",
-                    "delta": run_result_text,
-                    "metadata": {"fallback": fallback_reason},
-                }
+                if fallback_delta:
+                    yield {
+                        "type": "content",
+                        "delta": fallback_delta,
+                        "metadata": {"fallback": fallback_reason},
+                    }
 
             # Emit done
             stream_completed = True
@@ -2888,15 +2915,29 @@ class AgentLoop:
             prompt += env_section
         return prompt
 
+    def _current_llm_provider(self) -> str:
+        """Return the active provider name for prompt-selection decisions."""
+        provider = getattr(self, "provider", None)
+        if isinstance(provider, str) and provider.strip():
+            return provider.strip().lower()
+        chatbot_provider = getattr(getattr(self, "_chatbot", None), "llm_provider", None)
+        if isinstance(chatbot_provider, str) and chatbot_provider.strip():
+            return chatbot_provider.strip().lower()
+        return ""
+
+    def _should_use_lightweight_thinking_prompt(self) -> bool:
+        """Only OpenRouter reasoning runs need the lightweight prompt workaround."""
+        return self._current_llm_provider() == "openrouter"
+
     def _select_next_step_prompt(self, message: str, *, thinking: bool) -> str:
         """Choose the per-step prompt shape for the current request.
 
         OpenRouter-backed reasoning models stop emitting streaming reasoning
         tokens when we inject the heavier runtime step prompt as an extra user
-        turn. When thinking is enabled, prefer the lightweight default prompt
-        so visible reasoning remains available while preserving normal tool use.
+        turn. Keep that workaround scoped to OpenRouter so other providers
+        retain the contextual user/workspace/env sections from _build_step_prompt().
         """
-        if thinking:
+        if thinking and self._should_use_lightweight_thinking_prompt():
             return self.DEFAULT_NEXT_STEP_PROMPT
         return self._build_step_prompt(message)
 

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2361,7 +2361,7 @@ class AgentLoop:
         if isinstance(runtime_message, str):
             message = runtime_message
 
-        _base_prompt = self._build_step_prompt(message)
+        _base_prompt = self._select_next_step_prompt(message, thinking=thinking)
         self._agent.next_step_prompt = _base_prompt
         self._install_anti_loop_tracker(_base_prompt)
 
@@ -2728,7 +2728,7 @@ class AgentLoop:
         if isinstance(runtime_message, str):
             message = runtime_message
 
-        _base_prompt = self._build_step_prompt(message)
+        _base_prompt = self._select_next_step_prompt(message, thinking=True)
         self._agent.next_step_prompt = _base_prompt
         self._install_anti_loop_tracker(_base_prompt)
         await self._agent.add_message("user", runtime_message)
@@ -2887,6 +2887,18 @@ class AgentLoop:
         if env_section:
             prompt += env_section
         return prompt
+
+    def _select_next_step_prompt(self, message: str, *, thinking: bool) -> str:
+        """Choose the per-step prompt shape for the current request.
+
+        OpenRouter-backed reasoning models stop emitting streaming reasoning
+        tokens when we inject the heavier runtime step prompt as an extra user
+        turn. When thinking is enabled, prefer the lightweight default prompt
+        so visible reasoning remains available while preserving normal tool use.
+        """
+        if thinking:
+            return self.DEFAULT_NEXT_STEP_PROMPT
+        return self._build_step_prompt(message)
 
     def _extract_env_for_prompt(self) -> str:
         """Extract env vars from .env.local for the step prompt.

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2008,7 +2008,7 @@ class AgentLoop:
             if evicted:
                 logger.info(f"Evicted {evicted} duplicate tool results from context")
 
-        async def _tracked_think() -> bool:
+        async def _tracked_think(*args: Any, **kwargs: Any) -> bool:
             _evict_duplicate_tool_results()
             agent_loop._compress_runtime_context()
 
@@ -2048,7 +2048,7 @@ class AgentLoop:
                 agent.next_step_prompt = desired_next_step_prompt
 
             try:
-                result = await original_think()
+                result = await original_think(*args, **kwargs)
             finally:
                 agent.next_step_prompt = desired_next_step_prompt
 
@@ -2347,8 +2347,6 @@ class AgentLoop:
         stream_completed = False
         stream_cancelled = False
         bg_task: asyncio.Task[None] | None = None
-        pending_pre_tool_chunks: list[dict[str, Any]] = []
-        buffering_pre_tool_segment = thinking
 
         # Trim and inject persisted history into runtime memory
         await self._prepare_request_context()
@@ -2494,15 +2492,6 @@ class AgentLoop:
                         continue
 
                     if "tool_calls" in chunk and chunk["tool_calls"]:
-                        if thinking and pending_pre_tool_chunks:
-                            for pending_chunk in pending_pre_tool_chunks:
-                                yield {
-                                    "type": "thinking",
-                                    "delta": pending_chunk["delta"],
-                                    "metadata": pending_chunk["metadata"],
-                                }
-                            pending_pre_tool_chunks = []
-                        buffering_pre_tool_segment = thinking
                         for tc in chunk["tool_calls"]:
                             # tc may be a ToolCall pydantic object or a dict
                             if isinstance(tc, dict):
@@ -2592,13 +2581,6 @@ class AgentLoop:
                                 "source": metadata.get("source", "phase_think"),
                             },
                         }
-                    elif chunk_type == "content" and buffering_pre_tool_segment:
-                        pending_pre_tool_chunks.append(
-                            {
-                                "delta": delta,
-                                "metadata": dict(metadata),
-                            }
-                        )
                     else:
                         event = {"type": chunk_type, "delta": delta, "metadata": metadata}
                         if chunk_type == "content":
@@ -2623,16 +2605,6 @@ class AgentLoop:
             )
             for event in tool_result_events:
                 yield event
-
-            if pending_pre_tool_chunks:
-                for pending_chunk in pending_pre_tool_chunks:
-                    full_content += pending_chunk["delta"]
-                    yield {
-                        "type": "content",
-                        "delta": pending_chunk["delta"],
-                        "metadata": pending_chunk["metadata"],
-                    }
-                pending_pre_tool_chunks = []
 
             # Fallback: if run() completed but no stream chunks were emitted,
             # use final run result as one content chunk to avoid empty output.

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2455,6 +2455,36 @@ class AgentLoop:
             td = self._agent.task_done
             logger.debug(f"output_queue type={type(oq).__name__}, task_done type={type(td).__name__}")
             chunk_count = 0
+            stream_segment_index = -1
+            current_stream_segment_type: str | None = None
+
+            def _decorate_stream_event(event: dict[str, Any]) -> dict[str, Any]:
+                nonlocal stream_segment_index, current_stream_segment_type
+
+                event_type = str(event.get("type") or "")
+                if event_type not in {"thinking", "content", "tool_call", "tool_result"}:
+                    return event
+
+                metadata = dict(event.get("metadata") or {})
+                starts_new_segment = (
+                    event_type in {"tool_call", "tool_result"}
+                    or current_stream_segment_type != event_type
+                )
+                if starts_new_segment:
+                    stream_segment_index += 1
+                metadata.setdefault("segment_index", stream_segment_index)
+                metadata.setdefault("segment_start", starts_new_segment)
+                metadata.setdefault("segment_type", event_type)
+
+                if event_type in {"tool_call", "tool_result"}:
+                    current_stream_segment_type = None
+                else:
+                    current_stream_segment_type = event_type
+
+                return {
+                    **event,
+                    "metadata": metadata,
+                }
 
             logger.debug(f"Entering stream loop: td={td.is_set()}, qempty={oq.empty()}, qsize={oq.qsize()}")
             while not (td.is_set() and oq.empty()):
@@ -2466,7 +2496,7 @@ class AgentLoop:
                     )
                 )
                 for event in tool_result_events:
-                    yield event
+                    yield _decorate_stream_event(event)
 
                 # tracked_reasoning is inferred from assistant output logs and is
                 # not a reliable API thinking source. Clear it so it does not leak
@@ -2535,7 +2565,7 @@ class AgentLoop:
                                 fn_obj = getattr(tc, "function", None)
                                 fn_name = getattr(fn_obj, "name", "") if fn_obj else ""
                                 fn_args = getattr(fn_obj, "arguments", "") if fn_obj else ""
-                            yield {
+                            yield _decorate_stream_event({
                                 "type": "tool_call",
                                 "delta": "",
                                 "metadata": {
@@ -2543,7 +2573,7 @@ class AgentLoop:
                                     "name": fn_name,
                                     "arguments": fn_args,
                                 },
-                            }
+                            })
                         continue
                     chunk_metadata = chunk.get("metadata")
                     if isinstance(chunk_metadata, dict):
@@ -2589,11 +2619,11 @@ class AgentLoop:
                     delta = chunk
 
                 if chunk_type == "tool_result":
-                    yield {
+                    yield _decorate_stream_event({
                         "type": chunk_type,
                         "delta": delta,
                         "metadata": metadata,
-                    }
+                    })
                     continue
 
                 if delta:
@@ -2604,21 +2634,21 @@ class AgentLoop:
                         and metadata_phase == "think"
                     )
                     if chunk_type == "content" and explicit_pre_tool_phase:
-                        yield {
+                        yield _decorate_stream_event({
                             "type": "thinking",
                             "delta": delta,
                             "metadata": {
                                 **metadata,
                                 "source": metadata.get("source", "phase_think"),
                             },
-                        }
+                        })
                     else:
                         event = {"type": chunk_type, "delta": delta, "metadata": metadata}
                         if chunk_type == "content":
                             if saw_tool_call:
                                 saw_content_after_tool_call = True
                             full_content += delta
-                        yield event
+                        yield _decorate_stream_event(event)
 
             logger.debug(f"Stream loop exited: td={td.is_set()}, qempty={oq.empty()}, chunks_received={chunk_count}, full_content_len={len(full_content)}")
 
@@ -2637,7 +2667,7 @@ class AgentLoop:
                 )
             )
             for event in tool_result_events:
-                yield event
+                yield _decorate_stream_event(event)
 
             fallback_after_tool_only_preamble = (
                 saw_tool_call
@@ -2666,11 +2696,11 @@ class AgentLoop:
                     full_content = run_result_text
                     fallback_reason = "run_result_no_chunks"
                 if fallback_delta:
-                    yield {
+                    yield _decorate_stream_event({
                         "type": "content",
                         "delta": fallback_delta,
                         "metadata": {"fallback": fallback_reason},
-                    }
+                    })
 
             # Emit done
             stream_completed = True

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2386,21 +2386,21 @@ class AgentLoop:
         if isinstance(runtime_message, str):
             message = runtime_message
 
-        _base_prompt = self._select_next_step_prompt(message, thinking=thinking)
-        original_system_prompt, original_base_system_prompt = (
-            AgentLoop._apply_request_context_to_system_prompt(self, message, thinking=thinking)
-        )
-        self._agent.next_step_prompt = _base_prompt
-        self._install_anti_loop_tracker(_base_prompt)
-
-        # ------------------------------------------------------------------
-        # Streaming uses the spoon-core run+stream pattern:
-        #   1. Clear task_done + drain output_queue
-        #   2. Start run(message) in background — sets task_done on finish
-        #   3. Read chunks from output_queue until task_done AND queue empty
-        # ------------------------------------------------------------------
-
         try:
+            _base_prompt = self._select_next_step_prompt(message, thinking=thinking)
+            original_system_prompt, original_base_system_prompt = (
+                AgentLoop._apply_request_context_to_system_prompt(self, message, thinking=thinking)
+            )
+            self._agent.next_step_prompt = _base_prompt
+            self._install_anti_loop_tracker(_base_prompt)
+
+            # ------------------------------------------------------------------
+            # Streaming uses the spoon-core run+stream pattern:
+            #   1. Clear task_done + drain output_queue
+            #   2. Start run(message) in background — sets task_done on finish
+            #   3. Read chunks from output_queue until task_done AND queue empty
+            # ------------------------------------------------------------------
+
             # 1. Reset streaming state
             self._agent.task_done.clear()
             while not self._agent.output_queue.empty():
@@ -2768,16 +2768,16 @@ class AgentLoop:
         if isinstance(runtime_message, str):
             message = runtime_message
 
-        _base_prompt = self._select_next_step_prompt(message, thinking=True)
-        original_system_prompt, original_base_system_prompt = (
-            AgentLoop._apply_request_context_to_system_prompt(self, message, thinking=True)
-        )
-        self._agent.next_step_prompt = _base_prompt
-        self._install_anti_loop_tracker(_base_prompt)
-        await self._agent.add_message("user", runtime_message)
-
-        # Run agent with thinking enabled
         try:
+            _base_prompt = self._select_next_step_prompt(message, thinking=True)
+            original_system_prompt, original_base_system_prompt = (
+                AgentLoop._apply_request_context_to_system_prompt(self, message, thinking=True)
+            )
+            self._agent.next_step_prompt = _base_prompt
+            self._install_anti_loop_tracker(_base_prompt)
+            await self._agent.add_message("user", runtime_message)
+
+            # Run agent with thinking enabled
             run_kwargs: dict[str, Any] = {}
             if self._callable_accepts_kwarg(self._agent.run, "thinking"):
                 run_kwargs["thinking"] = True

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -117,6 +117,7 @@ _ATTACHMENT_ONLY_PLACEHOLDER = (
     "The user attached files without extra text. Inspect the files and answer based on their contents."
 )
 _SANDBOX_WORKSPACE_ROOT = "/workspace"
+_MISSING = object()
 _WALLET_REQUIRED_TOOLS: frozenset[str] = frozenset({
     "balance_check",
     "transfer",
@@ -2371,6 +2372,8 @@ class AgentLoop:
         stream_completed = False
         stream_cancelled = False
         bg_task: asyncio.Task[None] | None = None
+        original_system_prompt: str | None = None
+        original_base_system_prompt: object = _MISSING
 
         # Trim and inject persisted history into runtime memory
         await self._prepare_request_context()
@@ -2384,6 +2387,9 @@ class AgentLoop:
             message = runtime_message
 
         _base_prompt = self._select_next_step_prompt(message, thinking=thinking)
+        original_system_prompt, original_base_system_prompt = (
+            AgentLoop._apply_request_context_to_system_prompt(self, message, thinking=thinking)
+        )
         self._agent.next_step_prompt = _base_prompt
         self._install_anti_loop_tracker(_base_prompt)
 
@@ -2681,6 +2687,11 @@ class AgentLoop:
             yield {"type": "done", "delta": "", "metadata": {"error": str(e)}}
         finally:
             self._restore_agent_think()
+            AgentLoop._restore_request_context_system_prompt(
+                self,
+                original_system_prompt,
+                original_base_system_prompt,
+            )
             if bg_task is not None and not bg_task.done():
                 bg_task.cancel()
                 try:
@@ -2735,6 +2746,8 @@ class AgentLoop:
 
         logger.info(f"Processing message (with thinking): {message[:100]}...")
         self._reset_reasoning_capture()
+        original_system_prompt: str | None = None
+        original_base_system_prompt: object = _MISSING
 
         # Refresh memory context
         try:
@@ -2756,6 +2769,9 @@ class AgentLoop:
             message = runtime_message
 
         _base_prompt = self._select_next_step_prompt(message, thinking=True)
+        original_system_prompt, original_base_system_prompt = (
+            AgentLoop._apply_request_context_to_system_prompt(self, message, thinking=True)
+        )
         self._agent.next_step_prompt = _base_prompt
         self._install_anti_loop_tracker(_base_prompt)
         await self._agent.add_message("user", runtime_message)
@@ -2789,6 +2805,11 @@ class AgentLoop:
             raise
         finally:
             self._restore_agent_think()
+            AgentLoop._restore_request_context_system_prompt(
+                self,
+                original_system_prompt,
+                original_base_system_prompt,
+            )
 
         # Save to session
         try:
@@ -2915,29 +2936,76 @@ class AgentLoop:
             prompt += env_section
         return prompt
 
-    def _current_llm_provider(self) -> str:
-        """Return the active provider name for prompt-selection decisions."""
-        provider = getattr(self, "provider", None)
-        if isinstance(provider, str) and provider.strip():
-            return provider.strip().lower()
-        chatbot_provider = getattr(getattr(self, "_chatbot", None), "llm_provider", None)
-        if isinstance(chatbot_provider, str) and chatbot_provider.strip():
-            return chatbot_provider.strip().lower()
-        return ""
+    def _build_request_context_prompt(self, message: str) -> str:
+        """Build the compact request context block used for thinking runs."""
+        _truncated = message[:300] + ("…" if len(message) > 300 else "")
+        _ws = self._workspace_posix_path()
+        prompt = (
+            f"[USER REQUEST]: {_truncated}\n"
+            f"[WORKSPACE]: {_ws}/\n"
+        )
+        env_section = self._extract_env_for_prompt()
+        if env_section:
+            prompt += env_section
+        return prompt
 
-    def _should_use_lightweight_thinking_prompt(self) -> bool:
-        """Only OpenRouter reasoning runs need the lightweight prompt workaround."""
-        return self._current_llm_provider() == "openrouter"
+    def _apply_request_context_to_system_prompt(
+        self,
+        message: str,
+        *,
+        thinking: bool,
+    ) -> tuple[str | None, object]:
+        """Temporarily append active request context to the agent system prompt."""
+        if not thinking or not getattr(self, "_agent", None):
+            return None, _MISSING
+
+        current_prompt = getattr(self._agent, "system_prompt", None)
+        if not isinstance(current_prompt, str) or not current_prompt:
+            return None, _MISSING
+
+        request_context = self._build_request_context_prompt(message)
+        augmented_prompt = (
+            f"{current_prompt}\n\n"
+            f"## Active Request Context\n"
+            f"{request_context}"
+        )
+        self._agent.system_prompt = augmented_prompt
+
+        original_base_prompt = _MISSING
+        if hasattr(self._agent, "_original_system_prompt"):
+            original_base_prompt = getattr(self._agent, "_original_system_prompt")
+            if isinstance(original_base_prompt, str) and original_base_prompt:
+                self._agent._original_system_prompt = (
+                    f"{original_base_prompt}\n\n"
+                    f"## Active Request Context\n"
+                    f"{request_context}"
+                )
+
+        return current_prompt, original_base_prompt
+
+    def _restore_request_context_system_prompt(
+        self,
+        original_prompt: str | None,
+        original_base_prompt: object,
+    ) -> None:
+        """Restore the agent system prompt after a thinking run completes."""
+        if not getattr(self, "_agent", None):
+            return
+        if original_prompt is not None:
+            self._agent.system_prompt = original_prompt
+        if original_base_prompt is not _MISSING and hasattr(self._agent, "_original_system_prompt"):
+            self._agent._original_system_prompt = original_base_prompt
 
     def _select_next_step_prompt(self, message: str, *, thinking: bool) -> str:
         """Choose the per-step prompt shape for the current request.
 
-        OpenRouter-backed reasoning models stop emitting streaming reasoning
-        tokens when we inject the heavier runtime step prompt as an extra user
-        turn. Keep that workaround scoped to OpenRouter so other providers
-        retain the contextual user/workspace/env sections from _build_step_prompt().
+        Thinking runs keep a lightweight per-step prompt across all providers.
+        The active request context is injected into the system prompt instead,
+        so runtime pruning still preserves user/workspace/env guidance without
+        reintroducing the heavier synthetic user-turn prompt that suppresses
+        streamed reasoning on some providers.
         """
-        if thinking and self._should_use_lightweight_thinking_prompt():
+        if thinking:
             return self.DEFAULT_NEXT_STEP_PROMPT
         return self._build_step_prompt(message)
 

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2344,6 +2344,8 @@ class AgentLoop:
             logger.warning(f"Failed to load memory context: {e}")
 
         full_content = ""
+        saw_tool_call = False
+        saw_content_after_tool_call = False
         stream_completed = False
         stream_cancelled = False
         bg_task: asyncio.Task[None] | None = None
@@ -2492,6 +2494,7 @@ class AgentLoop:
                         continue
 
                     if "tool_calls" in chunk and chunk["tool_calls"]:
+                        saw_tool_call = True
                         for tc in chunk["tool_calls"]:
                             # tc may be a ToolCall pydantic object or a dict
                             if isinstance(tc, dict):
@@ -2584,6 +2587,8 @@ class AgentLoop:
                     else:
                         event = {"type": chunk_type, "delta": delta, "metadata": metadata}
                         if chunk_type == "content":
+                            if saw_tool_call:
+                                saw_content_after_tool_call = True
                             full_content += delta
                         yield event
 
@@ -2606,18 +2611,32 @@ class AgentLoop:
             for event in tool_result_events:
                 yield event
 
+            fallback_after_tool_only_preamble = (
+                saw_tool_call
+                and not saw_content_after_tool_call
+                and bool(run_result_text)
+                and self._normalize_comparable_text(full_content)
+                != self._normalize_comparable_text(run_result_text)
+            )
+
             # Fallback: if run() completed but no stream chunks were emitted,
-            # use final run result as one content chunk to avoid empty output.
-            if not full_content and run_result_text:
+            # or only a pre-tool preamble was emitted, use the final run result
+            # to avoid ending the stream without the actual answer text.
+            if run_result_text and (not full_content or fallback_after_tool_only_preamble):
                 logger.warning(
                     "Stream produced no content chunks; "
                     "falling back to run() result text."
                 )
-                full_content = run_result_text
+                if full_content and fallback_after_tool_only_preamble:
+                    full_content += run_result_text
+                    fallback_reason = "run_result_after_tool_preamble"
+                else:
+                    full_content = run_result_text
+                    fallback_reason = "run_result_no_chunks"
                 yield {
                     "type": "content",
                     "delta": run_result_text,
-                    "metadata": {"fallback": "run_result_no_chunks"},
+                    "metadata": {"fallback": fallback_reason},
                 }
 
             # Emit done

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -81,7 +81,13 @@ from spoon_bot.agent.tools.filesystem import (
     ListDirTool,
 )
 from spoon_bot.agent.tools.grep import GrepTool
-from spoon_bot.agent.tools.execution_context import bind_tool_owner, build_tool_owner_key
+from spoon_bot.agent.tools.execution_context import (
+    bind_tool_owner,
+    build_tool_owner_key,
+    capture_tool_outputs,
+    consume_captured_tool_output,
+    normalize_tool_arguments,
+)
 from spoon_bot.agent.tools.self_config import (
     ActivateToolTool,
     SelfConfigTool,
@@ -2267,6 +2273,41 @@ class AgentLoop:
                 return str(payload)
         return str(payload)
 
+    @staticmethod
+    def _tool_call_arguments_key(arguments: Any) -> str:
+        """Normalize tool-call arguments for captured-output matching."""
+        return normalize_tool_arguments(arguments)
+
+    @staticmethod
+    def _merge_stream_tool_result_metadata(
+        metadata: dict[str, Any],
+        *,
+        streamed_result: str,
+        captured_output: Any | None,
+    ) -> dict[str, Any]:
+        """Prefer captured full tool output while retaining model-visible summary."""
+        merged = dict(metadata)
+        summary_result = streamed_result
+        full_result = streamed_result
+
+        if captured_output is not None:
+            captured_summary = getattr(captured_output, "summary_output", "") or summary_result
+            captured_full = getattr(captured_output, "full_output", "") or captured_summary
+            summary_result = captured_summary
+            full_result = captured_full
+
+        if full_result:
+            merged["result"] = full_result
+            merged["content"] = full_result
+            merged["full_result"] = full_result
+            merged["full_content"] = full_result
+        if summary_result:
+            merged.setdefault("model_result", summary_result)
+            merged.setdefault("model_content", summary_result)
+        if full_result and summary_result and full_result != summary_result:
+            merged["result_truncated_for_model"] = True
+        return merged
+
     def _get_runtime_memory_messages(self) -> list[Any]:
         """Return runtime memory messages exposed by the active inner agent."""
         if not hasattr(self._agent, "memory") or self._agent.memory is None:
@@ -2288,6 +2329,9 @@ class AgentLoop:
         self,
         start_index: int,
         emitted_tool_result_ids: set[str],
+        *,
+        tool_output_capture_scope: str | None,
+        tool_call_arguments_by_id: dict[str, str],
     ) -> tuple[list[dict[str, Any]], int]:
         """Collect newly-added tool result messages from runtime memory."""
         messages = AgentLoop._get_runtime_memory_messages(self)
@@ -2295,15 +2339,20 @@ class AgentLoop:
             start_index = 0
 
         events: list[dict[str, Any]] = []
-        for msg in messages[start_index:]:
+        next_index = start_index
+        for index, msg in enumerate(messages[start_index:], start=start_index):
             if AgentLoop._stream_message_role(msg) != "tool":
+                next_index = index + 1
                 continue
 
             tool_call_id = (
                 AgentLoop._stream_message_attr(msg, "tool_call_id", "")
                 or AgentLoop._stream_message_attr(msg, "id", "")
             )
+            if tool_call_id and tool_call_id not in tool_call_arguments_by_id:
+                break
             if tool_call_id and tool_call_id in emitted_tool_result_ids:
+                next_index = index + 1
                 continue
 
             result_payload = AgentLoop._stream_message_attr(msg, "text_content", None)
@@ -2311,24 +2360,31 @@ class AgentLoop:
                 result_payload = AgentLoop._stream_message_attr(msg, "content", "")
             serialized_result = AgentLoop._stringify_stream_payload(result_payload)
             tool_name = AgentLoop._stream_message_attr(msg, "name", "")
+            captured_output = consume_captured_tool_output(
+                tool_output_capture_scope,
+                tool_name=tool_name,
+                arguments=tool_call_arguments_by_id.get(tool_call_id, ""),
+            )
 
-            metadata: dict[str, Any] = {
-                "name": tool_name,
-                "result": serialized_result,
-                "content": serialized_result,
-            }
+            metadata: dict[str, Any] = {"name": tool_name}
             if tool_call_id:
                 metadata["id"] = tool_call_id
                 metadata["tool_call_id"] = tool_call_id
                 emitted_tool_result_ids.add(tool_call_id)
+            metadata = AgentLoop._merge_stream_tool_result_metadata(
+                metadata,
+                streamed_result=serialized_result,
+                captured_output=captured_output,
+            )
 
             events.append({
                 "type": "tool_result",
                 "delta": "",
                 "metadata": metadata,
             })
+            next_index = index + 1
 
-        return events, len(messages)
+        return events, next_index
 
 
     async def stream(
@@ -2374,6 +2430,8 @@ class AgentLoop:
         bg_task: asyncio.Task[None] | None = None
         original_system_prompt: str | None = None
         original_base_system_prompt: object = _MISSING
+        tool_output_capture_scope: str | None = None
+        capture_manager = None
 
         # Trim and inject persisted history into runtime memory
         await self._prepare_request_context()
@@ -2387,6 +2445,8 @@ class AgentLoop:
             message = runtime_message
 
         try:
+            capture_manager = capture_tool_outputs()
+            tool_output_capture_scope = capture_manager.__enter__()
             _base_prompt = self._select_next_step_prompt(message, thinking=thinking)
             original_system_prompt, original_base_system_prompt = (
                 AgentLoop._apply_request_context_to_system_prompt(self, message, thinking=thinking)
@@ -2412,6 +2472,7 @@ class AgentLoop:
             await self._agent.add_message("user", runtime_message)
             stream_tool_result_index = len(AgentLoop._get_runtime_memory_messages(self))
             emitted_tool_result_ids: set[str] = set()
+            tool_call_arguments_by_id: dict[str, str] = {}
 
             # 2. Start run() in background
             run_result_text = ""
@@ -2493,6 +2554,8 @@ class AgentLoop:
                         self,
                         stream_tool_result_index,
                         emitted_tool_result_ids,
+                        tool_output_capture_scope=tool_output_capture_scope,
+                        tool_call_arguments_by_id=tool_call_arguments_by_id,
                     )
                 )
                 for event in tool_result_events:
@@ -2565,6 +2628,8 @@ class AgentLoop:
                                 fn_obj = getattr(tc, "function", None)
                                 fn_name = getattr(fn_obj, "name", "") if fn_obj else ""
                                 fn_args = getattr(fn_obj, "arguments", "") if fn_obj else ""
+                            if tc_id:
+                                tool_call_arguments_by_id[tc_id] = AgentLoop._tool_call_arguments_key(fn_args)
                             yield _decorate_stream_event({
                                 "type": "tool_call",
                                 "delta": "",
@@ -2583,6 +2648,11 @@ class AgentLoop:
                         chunk_type = "thinking"
                     elif dict_type == "tool_result":
                         chunk_type = "tool_result"
+                        tool_name = (
+                            chunk.get("name")
+                            or metadata.get("name")
+                            or ""
+                        )
                         tool_result = (
                             chunk.get("result")
                             or chunk.get("content")
@@ -2590,19 +2660,28 @@ class AgentLoop:
                             or chunk.get("output")
                         )
                         serialized_result = AgentLoop._stringify_stream_payload(tool_result)
-                        if serialized_result:
-                            metadata.setdefault("result", serialized_result)
-                            metadata.setdefault("content", serialized_result)
                         tool_call_id = (
                             chunk.get("tool_call_id")
                             or chunk.get("id")
                             or metadata.get("tool_call_id")
                             or metadata.get("id")
                         )
+                        captured_output = consume_captured_tool_output(
+                            tool_output_capture_scope,
+                            tool_name=tool_name,
+                            arguments=tool_call_arguments_by_id.get(tool_call_id, ""),
+                        )
+                        if tool_name:
+                            metadata.setdefault("name", tool_name)
                         if tool_call_id:
                             metadata.setdefault("tool_call_id", tool_call_id)
                             metadata.setdefault("id", tool_call_id)
                             emitted_tool_result_ids.add(tool_call_id)
+                        metadata = AgentLoop._merge_stream_tool_result_metadata(
+                            metadata,
+                            streamed_result=serialized_result,
+                            captured_output=captured_output,
+                        )
                     elif dict_type == "content":
                         chunk_type = "content"
                     # Support both "content" and "delta" keys (#10)
@@ -2664,6 +2743,8 @@ class AgentLoop:
                     self,
                     stream_tool_result_index,
                     emitted_tool_result_ids,
+                    tool_output_capture_scope=tool_output_capture_scope,
+                    tool_call_arguments_by_id=tool_call_arguments_by_id,
                 )
             )
             for event in tool_result_events:
@@ -2716,6 +2797,8 @@ class AgentLoop:
             yield {"type": "error", "delta": str(e), "metadata": {"error": str(e)}}
             yield {"type": "done", "delta": "", "metadata": {"error": str(e)}}
         finally:
+            if capture_manager is not None:
+                capture_manager.__exit__(None, None, None)
             self._restore_agent_think()
             AgentLoop._restore_request_context_system_prompt(
                 self,

--- a/spoon_bot/agent/tools/base.py
+++ b/spoon_bot/agent/tools/base.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, TypedDict
 
+from spoon_bot.agent.tools.execution_context import bind_tool_invocation, finalize_tool_invocation
+
 try:
     from typing import NotRequired
 except ImportError:
@@ -132,7 +134,12 @@ class Tool(ABC):
 
         This allows the tool to be used as: `result = await tool(arg=value)`
         """
-        return await self.execute(**kwargs)
+        with bind_tool_invocation(self.name, kwargs):
+            try:
+                result = await self.execute(**kwargs)
+            finally:
+                finalize_tool_invocation(locals().get("result"))
+        return result
 
     @abstractmethod
     async def execute(self, **kwargs: Any) -> str:

--- a/spoon_bot/agent/tools/document.py
+++ b/spoon_bot/agent/tools/document.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from spoon_bot.agent.tools.base import Tool, ToolParameterSchema
+from spoon_bot.agent.tools.execution_context import capture_tool_output
 
 
 class DocumentParseTool(Tool):
@@ -179,8 +180,10 @@ class DocumentParseTool(Tool):
             ]
             result_parts.extend(warnings)
 
+            full_text_result = None
             if extract_text:
-                joined_text = "\n\n".join(text_blocks)
+                full_text_result = "\n\n".join(text_blocks)
+                joined_text = full_text_result
                 if len(joined_text) > 50_000:
                     joined_text = joined_text[:50_000] + "\n\n[Truncated at 50KB]"
                 result_parts.append("\n# Text\n" + (joined_text or "No text extracted"))
@@ -193,6 +196,25 @@ class DocumentParseTool(Tool):
                 images_text = "\n".join(image_paths) if image_paths else "No images extracted"
                 result_parts.append("\n# Images\n" + images_text)
 
-            return "\n".join(result_parts)
+            summary_result = "\n".join(result_parts)
+            if full_text_result is None:
+                capture_tool_output(summary_result, summary_result)
+                return summary_result
+
+            full_parts = [
+                f"Parsed: {pdf_path.name}",
+                f"Pages processed: {len(selected_pages)}/{page_count}",
+            ]
+            full_parts.extend(warnings)
+            full_parts.append("\n# Text\n" + (full_text_result or "No text extracted"))
+            if extract_tables:
+                joined_tables = "\n\n".join(table_blocks)
+                full_parts.append("\n# Tables\n" + (joined_tables or "No tables found"))
+            if extract_images:
+                images_text = "\n".join(image_paths) if image_paths else "No images extracted"
+                full_parts.append("\n# Images\n" + images_text)
+            full_result = "\n".join(full_parts)
+            capture_tool_output(summary_result, full_result)
+            return summary_result
         finally:
             doc.close()

--- a/spoon_bot/agent/tools/execution_context.py
+++ b/spoon_bot/agent/tools/execution_context.py
@@ -1,13 +1,44 @@
-"""Task-local execution context for tool ownership scoping."""
+"""Task-local execution context for tool ownership scoping and stream capture."""
 
 from __future__ import annotations
 
+import json
+from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Iterator
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, Iterator
+from uuid import uuid4
 
 
 _TOOL_OWNER: ContextVar[str] = ContextVar("tool_owner", default="default")
+_TOOL_OUTPUT_CAPTURE_SCOPE: ContextVar[str | None] = ContextVar(
+    "tool_output_capture_scope",
+    default=None,
+)
+_CURRENT_TOOL_INVOCATION: ContextVar[str | None] = ContextVar(
+    "current_tool_invocation",
+    default=None,
+)
+
+
+@dataclass
+class CapturedToolOutput:
+    """Full tool output captured for websocket streaming."""
+
+    scope_id: str
+    owner: str
+    tool_name: str
+    arguments_key: str
+    summary_output: str = ""
+    full_output: str = ""
+
+
+_TOOL_OUTPUT_LOCK = Lock()
+_ACTIVE_TOOL_INVOCATIONS: dict[str, CapturedToolOutput] = {}
+_COMPLETED_TOOL_OUTPUTS: dict[str, list[CapturedToolOutput]] = defaultdict(list)
+_MAX_CAPTURED_TOOL_OUTPUTS_PER_SCOPE = 256
 
 
 def normalize_tool_owner_user(user_id: str | None) -> str:
@@ -49,3 +80,163 @@ def bind_tool_owner(owner: str | None) -> Iterator[str]:
         yield normalized
     finally:
         _TOOL_OWNER.reset(token)
+
+
+def stringify_tool_output(payload: Any) -> str:
+    """Serialize tool output to a plain string for websocket metadata."""
+    if payload is None:
+        return ""
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, (dict, list)):
+        try:
+            return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        except Exception:
+            return str(payload)
+    return str(payload)
+
+
+def normalize_tool_arguments(arguments: Any) -> str:
+    """Normalize tool arguments so captured output can be matched later."""
+    if arguments is None:
+        return ""
+    if isinstance(arguments, str):
+        text = arguments.strip()
+        if not text:
+            return ""
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            return text
+        return normalize_tool_arguments(parsed)
+    if isinstance(arguments, (dict, list)):
+        try:
+            return json.dumps(arguments, ensure_ascii=False, sort_keys=True)
+        except Exception:
+            return str(arguments)
+    return str(arguments)
+
+
+@contextmanager
+def capture_tool_outputs() -> Iterator[str]:
+    """Enable per-request tool output capture for websocket streaming."""
+    scope_id = uuid4().hex
+    token = _TOOL_OUTPUT_CAPTURE_SCOPE.set(scope_id)
+    try:
+        yield scope_id
+    finally:
+        _TOOL_OUTPUT_CAPTURE_SCOPE.reset(token)
+        clear_captured_tool_outputs(scope_id)
+
+
+@contextmanager
+def bind_tool_invocation(tool_name: str, arguments: Any) -> Iterator[str | None]:
+    """Bind the current tool invocation so tools can publish full output."""
+    scope_id = _TOOL_OUTPUT_CAPTURE_SCOPE.get()
+    if not scope_id:
+        yield None
+        return
+
+    invocation_id = uuid4().hex
+    capture = CapturedToolOutput(
+        scope_id=scope_id,
+        owner=get_tool_owner(),
+        tool_name=str(tool_name or ""),
+        arguments_key=normalize_tool_arguments(arguments),
+    )
+    with _TOOL_OUTPUT_LOCK:
+        _ACTIVE_TOOL_INVOCATIONS[invocation_id] = capture
+    token = _CURRENT_TOOL_INVOCATION.set(invocation_id)
+    try:
+        yield invocation_id
+    finally:
+        _CURRENT_TOOL_INVOCATION.reset(token)
+
+
+def capture_tool_output(summary_output: Any, full_output: Any | None = None) -> None:
+    """Record summary/full tool output for the current invocation."""
+    invocation_id = _CURRENT_TOOL_INVOCATION.get()
+    if not invocation_id:
+        return
+
+    summary_text = stringify_tool_output(summary_output)
+    full_text = stringify_tool_output(full_output if full_output is not None else summary_output)
+
+    with _TOOL_OUTPUT_LOCK:
+        capture = _ACTIVE_TOOL_INVOCATIONS.get(invocation_id)
+        if capture is None:
+            return
+        capture.summary_output = summary_text
+        capture.full_output = full_text
+
+
+def finalize_tool_invocation(default_output: Any | None = None) -> None:
+    """Move the current invocation capture into the completed queue."""
+    invocation_id = _CURRENT_TOOL_INVOCATION.get()
+    if not invocation_id:
+        return
+
+    with _TOOL_OUTPUT_LOCK:
+        capture = _ACTIVE_TOOL_INVOCATIONS.pop(invocation_id, None)
+        if capture is None:
+            return
+        if not capture.summary_output:
+            capture.summary_output = stringify_tool_output(default_output)
+        if not capture.full_output:
+            capture.full_output = capture.summary_output
+
+        bucket = _COMPLETED_TOOL_OUTPUTS[capture.scope_id]
+        bucket.append(capture)
+        if len(bucket) > _MAX_CAPTURED_TOOL_OUTPUTS_PER_SCOPE:
+            del bucket[:-_MAX_CAPTURED_TOOL_OUTPUTS_PER_SCOPE]
+
+
+def consume_captured_tool_output(
+    scope_id: str | None,
+    *,
+    tool_name: str | None = None,
+    arguments: Any = None,
+) -> CapturedToolOutput | None:
+    """Consume the next captured tool output for a streamed tool_result event."""
+    if not scope_id:
+        return None
+
+    arguments_key = normalize_tool_arguments(arguments)
+    with _TOOL_OUTPUT_LOCK:
+        bucket = _COMPLETED_TOOL_OUTPUTS.get(scope_id)
+        if not bucket:
+            return None
+
+        match_index: int | None = None
+        if tool_name and arguments_key:
+            for index, item in enumerate(bucket):
+                if item.tool_name == tool_name and item.arguments_key == arguments_key:
+                    match_index = index
+                    break
+        if match_index is None and tool_name:
+            for index, item in enumerate(bucket):
+                if item.tool_name == tool_name:
+                    match_index = index
+                    break
+        if match_index is None:
+            match_index = 0
+
+        capture = bucket.pop(match_index)
+        if not bucket:
+            _COMPLETED_TOOL_OUTPUTS.pop(scope_id, None)
+        return capture
+
+
+def clear_captured_tool_outputs(scope_id: str | None) -> None:
+    """Drop any captured tool outputs for a completed/aborted request."""
+    if not scope_id:
+        return
+    with _TOOL_OUTPUT_LOCK:
+        _COMPLETED_TOOL_OUTPUTS.pop(scope_id, None)
+        stale_invocations = [
+            invocation_id
+            for invocation_id, capture in _ACTIVE_TOOL_INVOCATIONS.items()
+            if capture.scope_id == scope_id
+        ]
+        for invocation_id in stale_invocations:
+            _ACTIVE_TOOL_INVOCATIONS.pop(invocation_id, None)

--- a/spoon_bot/agent/tools/filesystem.py
+++ b/spoon_bot/agent/tools/filesystem.py
@@ -11,6 +11,7 @@ import aiofiles
 import aiofiles.os
 
 from spoon_bot.agent.tools.base import Tool
+from spoon_bot.agent.tools.execution_context import capture_tool_output
 from spoon_bot.agent.tools.path_validator import (
     PathValidator,
     validate_read_path,
@@ -128,12 +129,15 @@ class ReadFileTool(Tool):
             else:
                 range_note = ""
 
-            total_size = len(content)
+            full_content = content
+            total_size = len(full_content)
             parts = file_path.parts
             is_skill_file = "skills" in parts
 
             if self._max_output and total_size > self._max_output:
-                content = content[:self._max_output] + f"\n... (truncated, {total_size - self._max_output} more chars)"
+                content = full_content[:self._max_output] + f"\n... (truncated, {total_size - self._max_output} more chars)"
+            else:
+                content = full_content
 
             # Use relative path to workspace for dedup, fallback to name
             try:
@@ -145,12 +149,18 @@ class ReadFileTool(Tool):
             except ValueError:
                 display_path = file_path.name
 
-            actual_size = len(content)
-            header = f"[file: {display_path} | {actual_size} chars{range_note}"
-            if is_skill_file:
-                header += " | skill-ref"
-            header += "]\n"
-            return header + content
+            def _build_result(body: str) -> str:
+                body_size = len(body)
+                header = f"[file: {display_path} | {body_size} chars{range_note}"
+                if is_skill_file:
+                    header += " | skill-ref"
+                header += "]\n"
+                return header + body
+
+            summary_result = _build_result(content)
+            full_result = _build_result(full_content)
+            capture_tool_output(summary_result, full_result)
+            return summary_result
 
         except PermissionError:
             return f"Error: Permission denied: {path}"

--- a/spoon_bot/agent/tools/grep.py
+++ b/spoon_bot/agent/tools/grep.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from spoon_bot.agent.tools.base import Tool
+from spoon_bot.agent.tools.execution_context import capture_tool_output
 
 
 class GrepTool(Tool):
@@ -129,9 +130,11 @@ class GrepTool(Tool):
             ws_str = str(self._workspace)
             output = output.replace(ws_str + os.sep, "").replace(ws_str + "/", "")
 
+        full_output = output
         if len(output) > self._max_output:
             output = output[: self._max_output] + f"\n... [truncated, {len(output) - self._max_output} more chars]"
 
+        capture_tool_output(output, full_output)
         return output
 
     @staticmethod

--- a/spoon_bot/agent/tools/registry.py
+++ b/spoon_bot/agent/tools/registry.py
@@ -7,6 +7,7 @@ from typing import Any
 from loguru import logger
 
 from spoon_bot.agent.tools.base import Tool, ToolSchema
+from spoon_bot.agent.tools.execution_context import bind_tool_invocation, finalize_tool_invocation
 
 
 # ---------------------------------------------------------------------------
@@ -328,16 +329,19 @@ class ToolRegistry:
                 logger.warning(f"Parameter validation failed for {name}: {error_msg}")
                 return f"Error: Invalid parameters for tool '{name}': {error_msg}"
 
-        try:
-            result = await tool.execute(**arguments)
-            return result
-        except TypeError as e:
-            # Handle missing or extra arguments
-            logger.error(f"Type error executing tool {name}: {e}")
-            return f"Error: Invalid arguments for tool '{name}': {str(e)}"
-        except Exception as e:
-            logger.error(f"Error executing tool {name}: {e}")
-            return f"Error executing tool {name}: {str(e)}"
+        with bind_tool_invocation(name, arguments):
+            try:
+                result = await tool.execute(**arguments)
+            except TypeError as e:
+                # Handle missing or extra arguments
+                logger.error(f"Type error executing tool {name}: {e}")
+                result = f"Error: Invalid arguments for tool '{name}': {str(e)}"
+            except Exception as e:
+                logger.error(f"Error executing tool {name}: {e}")
+                result = f"Error executing tool {name}: {str(e)}"
+            finally:
+                finalize_tool_invocation(locals().get("result"))
+        return result
 
     def list_tools(self) -> list[str]:
         """

--- a/spoon_bot/agent/tools/shell.py
+++ b/spoon_bot/agent/tools/shell.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 from loguru import logger
 
 from spoon_bot.agent.tools.base import Tool
-from spoon_bot.agent.tools.execution_context import get_tool_owner
+from spoon_bot.agent.tools.execution_context import capture_tool_output, get_tool_owner
 from spoon_bot.utils.rate_limit import (
     RateLimitConfig,
     get_rate_limiter,
@@ -733,6 +733,7 @@ class ShellTool(Tool):
         returncode: int | None,
         *,
         max_chars: int | None = None,
+        truncate: bool = True,
     ) -> str:
         output_parts = []
 
@@ -749,7 +750,7 @@ class ShellTool(Tool):
         result = self._mask_secrets(result)
 
         limit = max_chars or self.max_output
-        if len(result) > limit:
+        if truncate and limit and len(result) > limit:
             truncated = len(result) - limit
             result = result[:limit] + f"\n... (truncated, {truncated} more chars)"
 
@@ -979,12 +980,21 @@ class ShellTool(Tool):
             )
 
         if action == "job_output":
-            return self._build_output_result(
+            full_result = self._build_output_result(
+                job.stdout_text,
+                job.stderr_text,
+                job.returncode,
+                max_chars=tail_chars,
+                truncate=False,
+            )
+            result = self._build_output_result(
                 job.stdout_text,
                 job.stderr_text,
                 job.returncode,
                 max_chars=tail_chars,
             )
+            capture_tool_output(result, full_result)
+            return result
 
         if action == "terminate_job":
             if self._get_process_returncode(job.process) is None:
@@ -997,10 +1007,26 @@ class ShellTool(Tool):
             await self._refresh_background_job(job)
             job.status = "terminated"
             job.finished_at = time.time()
-            return (
-                f"Terminated background shell job {job.job_id}.\n"
-                f"{self._build_output_result(job.stdout_text, job.stderr_text, job.returncode, max_chars=tail_chars)}"
+            full_body = self._build_output_result(
+                job.stdout_text,
+                job.stderr_text,
+                job.returncode,
+                max_chars=tail_chars,
+                truncate=False,
             )
+            summary_body = self._build_output_result(
+                job.stdout_text,
+                job.stderr_text,
+                job.returncode,
+                max_chars=tail_chars,
+            )
+            result = (
+                f"Terminated background shell job {job.job_id}.\n"
+                f"{summary_body}"
+            )
+            full_result = f"Terminated background shell job {job.job_id}.\n{full_body}"
+            capture_tool_output(result, full_result)
+            return result
 
         return f"Error: Unknown action '{action}'"
 
@@ -1053,7 +1079,14 @@ class ShellTool(Tool):
             try:
                 await asyncio.wait_for(self._wait_for_process(job.process), timeout=self.timeout)
                 await self._refresh_background_job(job)
+                full_result = self._build_output_result(
+                    job.stdout_text,
+                    job.stderr_text,
+                    job.returncode,
+                    truncate=False,
+                )
                 result = self._build_output_result(job.stdout_text, job.stderr_text, job.returncode)
+                capture_tool_output(result, full_result)
                 _SHELL_BACKGROUND_JOBS.pop(job.job_id, None)
                 self._prune_background_jobs(owner_key=owner_key)
                 return result

--- a/spoon_bot/agent/tools/web.py
+++ b/spoon_bot/agent/tools/web.py
@@ -11,6 +11,7 @@ import httpx
 from loguru import logger
 
 from spoon_bot.agent.tools.base import Tool
+from spoon_bot.agent.tools.execution_context import capture_tool_output
 
 
 # Shared httpx client for connection pooling across web tools.
@@ -384,26 +385,32 @@ class WebFetchTool(Tool):
             resp.raise_for_status()
 
             content_type = resp.headers.get("content-type", "")
-            raw = resp.text
-
-            # Truncate very large responses
-            if len(raw) > self._max_content_size:
-                raw = raw[: self._max_content_size] + "\n\n[Content truncated]"
+            full_raw = resp.text
+            summary_raw = full_raw
+            if len(summary_raw) > self._max_content_size:
+                summary_raw = summary_raw[: self._max_content_size] + "\n\n[Content truncated]"
 
             # JSON response — return formatted
             if "json" in content_type:
                 try:
                     data = resp.json()
-                    return _json.dumps(data, ensure_ascii=False, indent=2)
+                    result = _json.dumps(data, ensure_ascii=False, indent=2)
+                    capture_tool_output(result, result)
+                    return result
                 except Exception:
-                    return raw
+                    capture_tool_output(summary_raw, full_raw)
+                    return summary_raw
 
             # HTML — try to extract readable text
             if "html" in content_type and extract_text:
-                return self._extract_text_from_html(raw, selector)
+                summary_result = self._extract_text_from_html(summary_raw, selector)
+                full_result = self._extract_text_from_html(full_raw, selector)
+                capture_tool_output(summary_result, full_result)
+                return summary_result
 
             # Plain text / other
-            return raw
+            capture_tool_output(summary_raw, full_raw)
+            return summary_raw
 
         except httpx.HTTPStatusError as exc:
             return f"Error: HTTP {exc.response.status_code} for {url}"

--- a/tests/test_stream_thinking_fix.py
+++ b/tests/test_stream_thinking_fix.py
@@ -163,6 +163,35 @@ class TestStreamWaitBehavior:
         assert len(done_chunks) == 1
         assert done_chunks[0]["metadata"]["content"] == "late chunk"
 
+    @pytest.mark.asyncio
+    async def test_stream_restores_system_prompt_when_add_message_fails(self):
+        """Temporary request context must be rolled back if stream setup fails."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        async def mock_run(**kwargs):
+            result = MagicMock()
+            result.content = "unused"
+            return result
+
+        agent, _, _ = _make_mock_stream_agent(mock_run)
+        agent._agent.system_prompt = "base system"
+        agent._agent._original_system_prompt = "base original"
+        agent._agent.add_message = AsyncMock(side_effect=RuntimeError("setup failed"))
+        agent._build_request_context_prompt = MagicMock(return_value="[USER REQUEST]: test")
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="test", thinking=True):
+            chunks.append(chunk)
+
+        error_chunks = [c for c in chunks if c["type"] == "error"]
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+        assert len(error_chunks) == 1
+        assert error_chunks[0]["metadata"]["error"] == "setup failed"
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["metadata"]["error"] == "setup failed"
+        assert agent._agent.system_prompt == "base system"
+        assert agent._agent._original_system_prompt == "base original"
+
 
 # ============================================================
 # ConnectionManager send_message retry

--- a/tests/test_stream_thinking_fix.py
+++ b/tests/test_stream_thinking_fix.py
@@ -98,6 +98,36 @@ class TestStreamThinkingParam:
         assert len(run_kwargs_captured) == 1
         assert "thinking" not in run_kwargs_captured[0]
 
+    @pytest.mark.asyncio
+    async def test_anti_loop_tracker_forwards_thinking_kwargs(self):
+        """The anti-loop think() wrapper must preserve provider-specific kwargs."""
+        from pathlib import Path
+
+        from spoon_bot.agent.loop import AgentLoop
+
+        captured_kwargs: list[dict] = []
+
+        async def base_think(**kwargs):
+            captured_kwargs.append(kwargs)
+            return True
+
+        loop = object.__new__(AgentLoop)
+        loop.workspace = Path(".")
+        loop._agent = type("FakeAgent", (), {})()
+        loop._agent.think = base_think
+        loop._agent.next_step_prompt = None
+        loop._agent.tool_calls = []
+        loop._agent.memory = MagicMock(messages=[])
+        loop._compress_runtime_context = MagicMock()
+        loop._capture_reasoning_text = MagicMock(return_value=None)
+
+        AgentLoop._install_anti_loop_tracker(loop, "prompt")
+
+        result = await loop._agent.think(thinking=True)
+
+        assert result is True
+        assert captured_kwargs == [{"thinking": True}]
+
 
 # ============================================================
 # Stream wait behavior

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -691,8 +691,8 @@ class TestAgentLoopStream:
         assert done_chunks[0]["metadata"]["content"] == "Answer"
 
     @pytest.mark.asyncio
-    async def test_stream_keeps_leading_content_streaming_when_tool_call_follows(self):
-        """Plain content should stay streamable even if a tool call appears later."""
+    async def test_stream_keeps_pre_tool_content_as_content(self):
+        """Plain content must remain content even if a tool call follows."""
         from spoon_bot.agent.loop import AgentLoop
 
         tool_call = MagicMock()
@@ -734,13 +734,129 @@ class TestAgentLoopStream:
         async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
             chunks.append(chunk)
 
-        emitted = [c for c in chunks if c["type"] in {"content", "tool_call"}]
+        emitted = [c for c in chunks if c["type"] in {"tool_call", "content"}]
         assert [c["type"] for c in emitted] == ["content", "tool_call", "content"]
         assert emitted[0]["delta"] == "Part A. "
+        assert emitted[0]["metadata"]["segment_type"] == "content"
         assert emitted[1]["metadata"]["name"] == "shell"
         assert emitted[2]["delta"] == "Part B."
         done_chunks = [c for c in chunks if c["type"] == "done"]
         assert done_chunks[0]["metadata"]["content"] == "Part A. Part B."
+
+    @pytest.mark.asyncio
+    async def test_stream_preserves_pre_tool_content_chunk_boundaries(self):
+        """Multiple pre-tool content chunks should stay split and ordered."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "read_file"
+        tool_call.function.arguments = '{"path":"README.md"}'
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"content": "First"})
+            await agent._agent.output_queue.put({"content": " second"})
+            await agent._agent.output_queue.put({"content": "."})
+            await agent._agent.output_queue.put({"tool_calls": [tool_call]})
+            await agent._agent.output_queue.put({"content": "Done."})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="placeholder")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
+            chunks.append(chunk)
+
+        emitted = [c for c in chunks if c["type"] in {"tool_call", "content"}]
+        assert [c["type"] for c in emitted] == [
+            "content",
+            "content",
+            "content",
+            "tool_call",
+            "content",
+        ]
+        assert [c["delta"] for c in emitted[:3]] == ["First", " second", "."]
+        assert len({c["metadata"]["segment_index"] for c in emitted[:3]}) == 1
+        assert emitted[3]["metadata"]["name"] == "read_file"
+        assert emitted[4]["delta"] == "Done."
+
+    @pytest.mark.asyncio
+    async def test_stream_marks_segment_boundaries_around_tool_calls(self):
+        """Segment metadata should let downstream UIs separate pre/post-tool content blocks."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "list_dir"
+        tool_call.function.arguments = '{"path":"."}'
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"content": "我将检查当前工作区。"})
+            await asyncio.sleep(0.12)
+            await agent._agent.output_queue.put({"tool_calls": [tool_call]})
+            await agent._agent.output_queue.put({"content": "检查完成。"})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="placeholder")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
+            chunks.append(chunk)
+
+        emitted = [c for c in chunks if c["type"] in {"content", "tool_call"}]
+        assert [c["type"] for c in emitted] == ["content", "tool_call", "content"]
+        assert emitted[0]["metadata"]["segment_start"] is True
+        assert emitted[1]["metadata"]["segment_start"] is True
+        assert emitted[2]["metadata"]["segment_start"] is True
+        assert emitted[0]["metadata"]["segment_index"] != emitted[1]["metadata"]["segment_index"]
+        assert emitted[1]["metadata"]["segment_index"] != emitted[2]["metadata"]["segment_index"]
+        assert emitted[0]["metadata"]["segment_type"] == "content"
+        assert emitted[1]["metadata"]["segment_type"] == "tool_call"
+        assert emitted[2]["metadata"]["segment_type"] == "content"
 
     @pytest.mark.asyncio
     async def test_stream_falls_back_to_run_result_after_pre_tool_content_without_final_chunk(self):
@@ -789,7 +905,7 @@ class TestAgentLoopStream:
         async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
             chunks.append(chunk)
 
-        emitted = [c for c in chunks if c["type"] in {"content", "tool_call"}]
+        emitted = [c for c in chunks if c["type"] in {"tool_call", "content"}]
         assert [c["type"] for c in emitted] == ["content", "tool_call", "content"]
         assert emitted[0]["delta"] == "Need tool first. "
         assert emitted[2]["delta"] == "Final answer."
@@ -844,7 +960,7 @@ class TestAgentLoopStream:
         async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
             chunks.append(chunk)
 
-        emitted = [c for c in chunks if c["type"] in {"content", "tool_call"}]
+        emitted = [c for c in chunks if c["type"] in {"tool_call", "content"}]
         assert [c["type"] for c in emitted] == ["content", "tool_call", "content"]
         assert emitted[0]["delta"] == "Need tool first. "
         assert emitted[2]["delta"] == "Final answer."
@@ -1229,7 +1345,10 @@ class TestAgentLoopStream:
         stream_iter = AgentLoop.stream(agent, message="test", thinking=True)
 
         first_chunk = await asyncio.wait_for(anext(stream_iter), timeout=0.2)
-        assert first_chunk == {"type": "content", "delta": "chunk-1 ", "metadata": {}}
+        assert first_chunk["type"] == "content"
+        assert first_chunk["delta"] == "chunk-1 "
+        assert first_chunk["metadata"]["segment_type"] == "content"
+        assert first_chunk["metadata"]["segment_start"] is True
 
         release_run.set()
         remaining_chunks = [chunk async for chunk in stream_iter]

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -632,8 +632,8 @@ class TestAgentLoopStream:
         assert done_chunks[0]["metadata"]["content"] == "Answer"
 
     @pytest.mark.asyncio
-    async def test_stream_buffers_leading_content_until_tool_call_then_emits_thinking(self):
-        """Leading streamed content should become thinking only after a real tool call arrives."""
+    async def test_stream_keeps_leading_content_streaming_when_tool_call_follows(self):
+        """Plain content should stay streamable even if a tool call appears later."""
         from spoon_bot.agent.loop import AgentLoop
 
         tool_call = MagicMock()
@@ -643,9 +643,9 @@ class TestAgentLoopStream:
         tool_call.function.arguments = '{"command":"pwd"}'
 
         async def mock_run(**kwargs):
-            await agent._agent.output_queue.put({"content": "Let me inspect the workspace first."})
+            await agent._agent.output_queue.put({"content": "Part A. "})
             await agent._agent.output_queue.put({"tool_calls": [tool_call]})
-            await agent._agent.output_queue.put({"content": "Done."})
+            await agent._agent.output_queue.put({"content": "Part B."})
 
         agent = MagicMock(spec=AgentLoop)
         agent._initialized = True
@@ -675,13 +675,13 @@ class TestAgentLoopStream:
         async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
             chunks.append(chunk)
 
-        emitted = [c for c in chunks if c["type"] in {"thinking", "tool_call", "content"}]
-        assert [c["type"] for c in emitted] == ["thinking", "tool_call", "content"]
-        assert emitted[0]["delta"] == "Let me inspect the workspace first."
+        emitted = [c for c in chunks if c["type"] in {"content", "tool_call"}]
+        assert [c["type"] for c in emitted] == ["content", "tool_call", "content"]
+        assert emitted[0]["delta"] == "Part A. "
         assert emitted[1]["metadata"]["name"] == "shell"
-        assert emitted[2]["delta"] == "Done."
+        assert emitted[2]["delta"] == "Part B."
         done_chunks = [c for c in chunks if c["type"] == "done"]
-        assert done_chunks[0]["metadata"]["content"] == "Done."
+        assert done_chunks[0]["metadata"]["content"] == "Part A. Part B."
 
     @pytest.mark.asyncio
     async def test_stream_passes_through_structured_tool_result_chunks(self):
@@ -1020,6 +1020,56 @@ class TestAgentLoopStream:
         done_chunks = [c for c in chunks if c["type"] == "done"]
         assert len(done_chunks) == 1
         assert done_chunks[0]["metadata"]["content"] == "直接给答案"
+
+    @pytest.mark.asyncio
+    async def test_stream_without_tool_call_emits_first_content_before_run_finishes(self):
+        """thinking=true should not buffer normal content until the very end."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        release_run = asyncio.Event()
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"content": "chunk-1 "})
+            await asyncio.wait_for(release_run.wait(), timeout=0.2)
+            await agent._agent.output_queue.put({"content": "chunk-2"})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+
+        stream_iter = AgentLoop.stream(agent, message="test", thinking=True)
+
+        first_chunk = await asyncio.wait_for(anext(stream_iter), timeout=0.2)
+        assert first_chunk == {"type": "content", "delta": "chunk-1 ", "metadata": {}}
+
+        release_run.set()
+        remaining_chunks = [chunk async for chunk in stream_iter]
+        content_chunks = [first_chunk, *[c for c in remaining_chunks if c["type"] == "content"]]
+        done_chunks = [c for c in remaining_chunks if c["type"] == "done"]
+
+        assert [c["delta"] for c in content_chunks] == ["chunk-1 ", "chunk-2"]
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["metadata"]["content"] == "chunk-1 chunk-2"
 
     @pytest.mark.asyncio
     async def test_stream_error_handling(self):

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -379,6 +379,34 @@ class TestAgentLoopStream:
         loop.sessions.save = MagicMock()
         return loop
 
+    def test_select_next_step_prompt_uses_lightweight_prompt_for_openrouter_thinking(self):
+        """OpenRouter thinking runs should keep the lightweight prompt workaround."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop.provider = "openrouter"
+        loop._chatbot = None
+        loop._build_step_prompt = MagicMock(return_value="context prompt")
+
+        prompt = AgentLoop._select_next_step_prompt(loop, "inspect workspace", thinking=True)
+
+        assert prompt == AgentLoop.DEFAULT_NEXT_STEP_PROMPT
+        loop._build_step_prompt.assert_not_called()
+
+    def test_select_next_step_prompt_keeps_context_for_other_providers(self):
+        """Non-OpenRouter thinking runs should retain the contextual step prompt."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop.provider = "anthropic"
+        loop._chatbot = None
+        loop._build_step_prompt = MagicMock(return_value="context prompt")
+
+        prompt = AgentLoop._select_next_step_prompt(loop, "inspect workspace", thinking=True)
+
+        assert prompt == "context prompt"
+        loop._build_step_prompt.assert_called_once_with("inspect workspace")
+
     @pytest.mark.asyncio
     async def test_stream_yields_typed_dicts(self):
         """stream() should yield dicts with type, delta, metadata keys."""
@@ -719,6 +747,61 @@ class TestAgentLoopStream:
         agent._prepare_request_context = AsyncMock()
         agent._build_runtime_message_content = MagicMock(return_value="placeholder")
         agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+        agent._normalize_comparable_text = AgentLoop._normalize_comparable_text
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
+            chunks.append(chunk)
+
+        emitted = [c for c in chunks if c["type"] in {"content", "tool_call"}]
+        assert [c["type"] for c in emitted] == ["content", "tool_call", "content"]
+        assert emitted[0]["delta"] == "Need tool first. "
+        assert emitted[2]["delta"] == "Final answer."
+        assert emitted[2]["metadata"]["fallback"] == "run_result_after_tool_preamble"
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+        assert done_chunks[0]["metadata"]["content"] == "Need tool first. Final answer."
+
+    @pytest.mark.asyncio
+    async def test_stream_fallback_after_tool_preamble_emits_only_missing_suffix(self):
+        """Fallback should not replay the already streamed preamble content."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "shell"
+        tool_call.function.arguments = '{"command":"pwd"}'
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"content": "Need tool first. "})
+            await agent._agent.output_queue.put({"tool_calls": [tool_call]})
+            result = MagicMock()
+            result.content = "Need tool first. Final answer."
+            return result
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="placeholder")
+        agent._select_next_step_prompt = MagicMock(return_value="prompt")
         agent._install_anti_loop_tracker = MagicMock()
         agent._restore_agent_think = MagicMock()
         agent._callable_accepts_kwarg = MagicMock(return_value=True)

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -1091,6 +1091,142 @@ class TestAgentLoopStream:
         assert emitted[1]["metadata"]["result"] == "/workspace"
 
     @pytest.mark.asyncio
+    async def test_stream_prefers_captured_full_tool_result_for_ws_metadata(self):
+        """WS tool_result metadata should expose full tool output, not the model-truncated summary."""
+        from spoon_bot.agent.loop import AgentLoop
+        from spoon_bot.agent.tools.execution_context import bind_tool_invocation, capture_tool_output, finalize_tool_invocation
+
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "shell"
+        tool_call.function.arguments = '{"command":"pwd"}'
+
+        summary_result = "/workspace\n... (truncated, 120 more chars)"
+        full_result = "/workspace\nalpha\nbeta\ngamma"
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"tool_calls": [tool_call]})
+            with bind_tool_invocation("shell", {"command": "pwd"}):
+                capture_tool_output(summary_result, full_result)
+                finalize_tool_invocation(summary_result)
+            await agent._agent.output_queue.put(
+                {
+                    "type": "tool_result",
+                    "metadata": {
+                        "id": "call_1",
+                        "name": "shell",
+                    },
+                    "result": summary_result,
+                }
+            )
+            await agent._agent.output_queue.put({"content": "Done."})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.memory = MagicMock()
+        agent._agent.memory.messages = []
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="placeholder")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+        agent._current_tool_owner_key = MagicMock(return_value="owner:test")
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder"):
+            chunks.append(chunk)
+
+        tool_result_chunk = next(c for c in chunks if c["type"] == "tool_result")
+        assert tool_result_chunk["metadata"]["result"] == full_result
+        assert tool_result_chunk["metadata"]["content"] == full_result
+        assert tool_result_chunk["metadata"]["full_result"] == full_result
+        assert tool_result_chunk["metadata"]["model_result"] == summary_result
+        assert tool_result_chunk["metadata"]["result_truncated_for_model"] is True
+
+    @pytest.mark.asyncio
+    async def test_stream_backfilled_tool_result_uses_captured_full_output(self):
+        """Runtime-memory tool results should also expose captured full output in WS metadata."""
+        from spoon_bot.agent.loop import AgentLoop
+        from spoon_bot.agent.tools.execution_context import bind_tool_invocation, capture_tool_output, finalize_tool_invocation
+
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "read_file"
+        tool_call.function.arguments = '{"path":"README.md"}'
+
+        summary_result = "[file: README.md | 40 chars]\nhello\n... (truncated, 100 more chars)"
+        full_result = "[file: README.md | 145 chars]\nhello\nworld\nfull text"
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"tool_calls": [tool_call]})
+            with bind_tool_invocation("read_file", {"path": "README.md"}):
+                capture_tool_output(summary_result, full_result)
+                finalize_tool_invocation(summary_result)
+            agent._agent.memory.messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "name": "read_file",
+                    "content": summary_result,
+                }
+            )
+            await agent._agent.output_queue.put({"content": "Done."})
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.memory = MagicMock()
+        agent._agent.memory.messages = []
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="placeholder")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+        agent._current_tool_owner_key = MagicMock(return_value="owner:test")
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder"):
+            chunks.append(chunk)
+
+        tool_result_chunk = next(c for c in chunks if c["type"] == "tool_result")
+        assert tool_result_chunk["metadata"]["result"] == full_result
+        assert tool_result_chunk["metadata"]["content"] == full_result
+        assert tool_result_chunk["metadata"]["model_result"] == summary_result
+
+    @pytest.mark.asyncio
     async def test_stream_uses_explicit_thinking_chunk_without_prompt_heuristic(self):
         """Explicit thinking chunks from core should drive pre-tool thinking display."""
         from spoon_bot.agent.loop import AgentLoop
@@ -1253,11 +1389,11 @@ class TestAgentLoopStream:
             chunks.append(chunk)
 
         emitted = [c for c in chunks if c["type"] in {"thinking", "content"}]
-        assert emitted[0] == {
-            "type": "thinking",
-            "delta": "Inspecting candidate commands.",
-            "metadata": {"phase": "think", "source": "provider"},
-        }
+        assert emitted[0]["type"] == "thinking"
+        assert emitted[0]["delta"] == "Inspecting candidate commands."
+        assert emitted[0]["metadata"]["phase"] == "think"
+        assert emitted[0]["metadata"]["source"] == "provider"
+        assert emitted[0]["metadata"]["segment_type"] == "thinking"
         assert emitted[1]["type"] == "content"
         assert emitted[1]["delta"] == "Final answer."
 

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -1734,6 +1734,42 @@ class TestAgentLoopProcessWithThinking:
         with pytest.raises(RuntimeError, match="LLM unavailable"):
             await AgentLoop.process_with_thinking(agent, message="test")
 
+    @pytest.mark.asyncio
+    async def test_process_with_thinking_restores_system_prompt_when_add_message_fails(self):
+        """Temporary request context must be rolled back if setup fails before run()."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        mock_inner_agent = MagicMock()
+        mock_inner_agent.system_prompt = "base system"
+        mock_inner_agent._original_system_prompt = "base original"
+        mock_inner_agent.run = AsyncMock()
+        mock_inner_agent.add_message = AsyncMock(side_effect=RuntimeError("setup failed"))
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = mock_inner_agent
+        agent._session = MagicMock()
+        agent.sessions = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._auto_commit = False
+        agent._git = None
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_request_context_prompt = MagicMock(return_value="[USER REQUEST]: test")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+
+        with pytest.raises(RuntimeError, match="setup failed"):
+            await AgentLoop.process_with_thinking(agent, message="test")
+
+        assert mock_inner_agent.system_prompt == "base system"
+        assert mock_inner_agent._original_system_prompt == "base original"
+
 
 # ============================================================
 # REST API endpoint tests

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -684,6 +684,61 @@ class TestAgentLoopStream:
         assert done_chunks[0]["metadata"]["content"] == "Part A. Part B."
 
     @pytest.mark.asyncio
+    async def test_stream_falls_back_to_run_result_after_pre_tool_content_without_final_chunk(self):
+        """A tool preamble should not suppress the final run() answer fallback."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "shell"
+        tool_call.function.arguments = '{"command":"pwd"}'
+
+        async def mock_run(**kwargs):
+            await agent._agent.output_queue.put({"content": "Need tool first. "})
+            await agent._agent.output_queue.put({"tool_calls": [tool_call]})
+            result = MagicMock()
+            result.content = "Final answer."
+            return result
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = MagicMock()
+        agent._agent.output_queue = asyncio.Queue()
+        agent._agent.task_done = asyncio.Event()
+        agent._agent.run = mock_run
+        agent._agent.add_message = AsyncMock()
+        agent._agent.state = "idle"
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.sessions.save = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(return_value="placeholder")
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._drain_reasoning_chunks = MagicMock(return_value=[])
+        agent._normalize_comparable_text = AgentLoop._normalize_comparable_text
+
+        chunks = []
+        async for chunk in AgentLoop.stream(agent, message="placeholder", thinking=True):
+            chunks.append(chunk)
+
+        emitted = [c for c in chunks if c["type"] in {"content", "tool_call"}]
+        assert [c["type"] for c in emitted] == ["content", "tool_call", "content"]
+        assert emitted[0]["delta"] == "Need tool first. "
+        assert emitted[2]["delta"] == "Final answer."
+        assert emitted[2]["metadata"]["fallback"] == "run_result_after_tool_preamble"
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+        assert done_chunks[0]["metadata"]["content"] == "Need tool first. Final answer."
+
+    @pytest.mark.asyncio
     async def test_stream_passes_through_structured_tool_result_chunks(self):
         """Explicit tool_result chunks should be preserved for downstream UIs."""
         from spoon_bot.agent.loop import AgentLoop

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -379,8 +379,8 @@ class TestAgentLoopStream:
         loop.sessions.save = MagicMock()
         return loop
 
-    def test_select_next_step_prompt_uses_lightweight_prompt_for_openrouter_thinking(self):
-        """OpenRouter thinking runs should keep the lightweight prompt workaround."""
+    def test_select_next_step_prompt_keeps_context_for_openrouter_thinking(self):
+        """Thinking mode should use the same lightweight next-step prompt on OpenRouter."""
         from spoon_bot.agent.loop import AgentLoop
 
         loop = AgentLoop.__new__(AgentLoop)
@@ -394,7 +394,7 @@ class TestAgentLoopStream:
         loop._build_step_prompt.assert_not_called()
 
     def test_select_next_step_prompt_keeps_context_for_other_providers(self):
-        """Non-OpenRouter thinking runs should retain the contextual step prompt."""
+        """Thinking mode should use the same lightweight next-step prompt for every provider."""
         from spoon_bot.agent.loop import AgentLoop
 
         loop = AgentLoop.__new__(AgentLoop)
@@ -404,8 +404,39 @@ class TestAgentLoopStream:
 
         prompt = AgentLoop._select_next_step_prompt(loop, "inspect workspace", thinking=True)
 
-        assert prompt == "context prompt"
-        loop._build_step_prompt.assert_called_once_with("inspect workspace")
+        assert prompt == AgentLoop.DEFAULT_NEXT_STEP_PROMPT
+        loop._build_step_prompt.assert_not_called()
+
+    def test_apply_request_context_to_system_prompt_augments_and_restores_prompts(self):
+        """Thinking runs should preserve request context via temporary system prompt augmentation."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop._agent = MagicMock()
+        loop._agent.system_prompt = "base system"
+        loop._agent._original_system_prompt = "base original"
+        loop._build_request_context_prompt = MagicMock(return_value="[USER REQUEST]: inspect workspace")
+
+        original_prompt, original_base_prompt = AgentLoop._apply_request_context_to_system_prompt(
+            loop,
+            "inspect workspace",
+            thinking=True,
+        )
+
+        assert original_prompt == "base system"
+        assert original_base_prompt == "base original"
+        assert "## Active Request Context" in loop._agent.system_prompt
+        assert "[USER REQUEST]: inspect workspace" in loop._agent.system_prompt
+        assert "## Active Request Context" in loop._agent._original_system_prompt
+
+        AgentLoop._restore_request_context_system_prompt(
+            loop,
+            original_prompt,
+            original_base_prompt,
+        )
+
+        assert loop._agent.system_prompt == "base system"
+        assert loop._agent._original_system_prompt == "base original"
 
     @pytest.mark.asyncio
     async def test_stream_yields_typed_dicts(self):

--- a/tests/test_tool_output_capture.py
+++ b/tests/test_tool_output_capture.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_read_file_tool_records_full_output_for_stream_capture(tmp_path: Path):
+    from spoon_bot.agent.tools.execution_context import (
+        bind_tool_invocation,
+        capture_tool_outputs,
+        consume_captured_tool_output,
+        finalize_tool_invocation,
+    )
+    from spoon_bot.agent.tools.filesystem import ReadFileTool
+
+    file_path = tmp_path / "long.txt"
+    file_path.write_text("A" * 120, encoding="utf-8")
+
+    tool = ReadFileTool(workspace=tmp_path, max_output=40)
+
+    with capture_tool_outputs() as scope_id:
+        with bind_tool_invocation("read_file", {"path": str(file_path)}):
+            result = await tool.execute(path=str(file_path))
+            finalize_tool_invocation(result)
+
+        captured = consume_captured_tool_output(
+            scope_id,
+            tool_name="read_file",
+            arguments={"path": str(file_path)},
+        )
+
+    assert captured is not None
+    assert "... (truncated," in result
+    assert "... (truncated," in captured.summary_output
+    assert "... (truncated," not in captured.full_output
+    assert "A" * 120 in captured.full_output
+
+
+@pytest.mark.asyncio
+async def test_capture_defaults_to_returned_result_when_tool_does_not_publish_full_output():
+    from spoon_bot.agent.tools.execution_context import (
+        bind_tool_invocation,
+        capture_tool_outputs,
+        consume_captured_tool_output,
+        finalize_tool_invocation,
+    )
+
+    with capture_tool_outputs() as scope_id:
+        with bind_tool_invocation("dummy_tool", {"x": 1}):
+            finalize_tool_invocation("plain result")
+
+        captured = consume_captured_tool_output(
+            scope_id,
+            tool_name="dummy_tool",
+            arguments={"x": 1},
+        )
+
+    assert captured is not None
+    assert captured.summary_output == "plain result"
+    assert captured.full_output == "plain result"


### PR DESCRIPTION
## Summary
- keep leading streamed content as normal `content` chunks even if a tool call appears later in the same response
- forward `*args, **kwargs` through the anti-loop `_tracked_think()` wrapper so `thinking=True` reaches real runtime calls
- add regressions for the content-first stream path and the thinking-kwargs passthrough

## Testing
- `python -m pytest tests/test_stream_thinking_fix.py tests/test_streaming_thinking.py::TestAgentLoopStream::test_stream_keeps_leading_content_streaming_when_tool_call_follows tests/test_streaming_thinking.py::TestAgentLoopStream::test_stream_without_tool_call_emits_first_content_before_run_finishes -q`

## Notes
- `tests/test_streaming_thinking.py::TestAgentLoopStream::test_stream_backfills_tool_result_from_runtime_memory` still fails on current `master` and is outside this PR's scope
- downstream stack validation also depends on the paired core/cypher_api changes
