### PR TITLE
Fix skill installs for repo-root and nested skill repos

### DIFF
--- a/tests/test_skill_marketplace.py
+++ b/tests/test_skill_marketplace.py
@@ -105,17 +105,18 @@ async def test_install_root_skill_repo_writes_into_workspace_skills_directory(
 
 
 def test_git_clone_command_uses_full_clone_for_root_skill_repo(skill_manager_module):
+    destination = Path("C:/tmp/repo")
     cmd = skill_manager_module._build_git_clone_command(
         "https://github.com/Agent-Cypher-Lab/joker-game-agent.git",
         "main",
-        Path("C:/tmp/repo"),
+        destination,
         "",
     )
 
     assert "--sparse" not in cmd
     assert cmd[-2:] == [
         "https://github.com/Agent-Cypher-Lab/joker-game-agent.git",
-        "C:\\tmp\\repo",
+        str(destination),
     ]
 
 

--- a/tests/test_skill_marketplace.py
+++ b/tests/test_skill_marketplace.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def skill_manager_module(monkeypatch: pytest.MonkeyPatch):
+    class BaseTool:
+        pass
+
+    spoon_ai_pkg = types.ModuleType("spoon_ai")
+    tools_pkg = types.ModuleType("spoon_ai.tools")
+    base_pkg = types.ModuleType("spoon_ai.tools.base")
+    base_pkg.BaseTool = BaseTool
+    spoon_ai_pkg.tools = tools_pkg
+    tools_pkg.base = base_pkg
+
+    monkeypatch.setitem(sys.modules, "spoon_ai", spoon_ai_pkg)
+    monkeypatch.setitem(sys.modules, "spoon_ai.tools", tools_pkg)
+    monkeypatch.setitem(sys.modules, "spoon_ai.tools.base", base_pkg)
+
+    repo_root = Path(__file__).resolve().parent.parent
+    tools_path = repo_root / "workspace" / "skills" / "skill-manager" / "tools.py"
+    spec = importlib.util.spec_from_file_location(
+        "skill_manager_tools_under_test",
+        tools_path,
+    )
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_install_skill_writes_into_workspace_skills_directory(
+    skill_manager_module,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("SPOON_BOT_WORKSPACE_PATH", str(tmp_path))
+    recorded_targets: list[Path] = []
+
+    async def fake_download(owner, repo, branch, subpath, target):
+        recorded_targets.append(target)
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "SKILL.md").write_text("# skill", encoding="utf-8")
+        return 1
+
+    monkeypatch.setattr(skill_manager_module, "_download_skill_files", fake_download)
+
+    tool = skill_manager_module.SkillMarketplaceTool()
+    result = await tool.execute(
+        action="install_skill",
+        url="openclaw/skills/skills/demo/wallet",
+    )
+
+    installed_dir = tmp_path / "skills" / "wallet"
+    assert "SUCCESS" in result
+    assert recorded_targets == [installed_dir]
+    assert installed_dir.exists()
+    assert (installed_dir / "SKILL.md").exists()
+    assert not (tmp_path / "wallet").exists()
+
+
+@pytest.mark.asyncio
+async def test_install_root_skill_repo_writes_into_workspace_skills_directory(
+    skill_manager_module,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("SPOON_BOT_WORKSPACE_PATH", str(tmp_path))
+    recorded_calls: list[tuple[str, str, str, str, Path]] = []
+
+    async def fake_download(owner, repo, branch, subpath, target):
+        recorded_calls.append((owner, repo, branch, subpath, target))
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "SKILL.md").write_text("# joker", encoding="utf-8")
+        (target / "README.md").write_text("# readme", encoding="utf-8")
+        return 2
+
+    monkeypatch.setattr(skill_manager_module, "_download_skill_files", fake_download)
+
+    tool = skill_manager_module.SkillMarketplaceTool()
+    result = await tool.execute(
+        action="install_skill",
+        url="https://github.com/Agent-Cypher-Lab/joker-game-agent",
+    )
+
+    installed_dir = tmp_path / "skills" / "joker-game-agent"
+    assert "SUCCESS" in result
+    assert recorded_calls == [
+        ("Agent-Cypher-Lab", "joker-game-agent", "main", "", installed_dir)
+    ]
+    assert installed_dir.exists()
+    assert (installed_dir / "SKILL.md").exists()
+    assert not (tmp_path / "SKILL.md").exists()
+    assert not (tmp_path / "README.md").exists()
+
+
+def test_git_clone_command_uses_full_clone_for_root_skill_repo(skill_manager_module):
+    cmd = skill_manager_module._build_git_clone_command(
+        "https://github.com/Agent-Cypher-Lab/joker-game-agent.git",
+        "main",
+        Path("C:/tmp/repo"),
+        "",
+    )
+
+    assert "--sparse" not in cmd
+    assert cmd[-2:] == [
+        "https://github.com/Agent-Cypher-Lab/joker-game-agent.git",
+        "C:\\tmp\\repo",
+    ]
+
+
+def test_git_clone_command_uses_sparse_clone_for_nested_skill(skill_manager_module):
+    cmd = skill_manager_module._build_git_clone_command(
+        "https://github.com/openclaw/skills.git",
+        "main",
+        Path("C:/tmp/repo"),
+        "skills/demo/wallet",
+    )
+
+    assert "--sparse" in cmd

--- a/workspace/skills/skill-manager/tools.py
+++ b/workspace/skills/skill-manager/tools.py
@@ -33,6 +33,33 @@ def _get_workspace() -> Path:
     return Path.home() / ".spoon-bot" / "workspace"
 
 
+def _normalize_subpath(raw: str) -> str:
+    """Normalize a remote skill path into a stable POSIX-like form."""
+    subpath = raw.strip().replace("\\", "/").strip("/")
+    while "//" in subpath:
+        subpath = subpath.replace("//", "/")
+    return subpath
+
+
+def _validate_subpath(raw: str, *, allow_empty: bool = False) -> str:
+    """Validate a remote skill path and optionally allow repo root installs."""
+    subpath = _normalize_subpath(raw)
+    if not subpath:
+        if allow_empty:
+            return ""
+        raise ValueError("Invalid skill path")
+
+    parts = [p for p in subpath.split("/") if p]
+    if not parts:
+        raise ValueError("Invalid skill path")
+    if any(p in {".", ".."} for p in parts):
+        raise ValueError("Invalid skill path: path traversal is not allowed")
+    if any(p.startswith(".") for p in parts):
+        raise ValueError("Invalid skill path: hidden segments are not allowed")
+
+    return "/".join(parts)
+
+
 def _parse_github_url(url: str) -> tuple[str, str, str, str]:
     """Parse a GitHub URL -> (owner, repo, branch, subpath)."""
     m = _GITHUB_URL_RE.match(url.strip())
@@ -55,6 +82,22 @@ def _github_headers() -> dict[str, str]:
     return headers
 
 
+def _build_git_clone_command(clone_url: str, branch: str, destination: Path, subpath: str) -> list[str]:
+    """Build the git clone command for either repo-root or nested skill installs."""
+    cmd = [
+        "git",
+        "clone",
+        "--depth=1",
+        "--filter=blob:none",
+        "--branch",
+        branch,
+    ]
+    if subpath:
+        cmd.append("--sparse")
+    cmd.extend([clone_url, str(destination)])
+    return cmd
+
+
 async def _download_via_git(
     owner: str, repo: str, branch: str, subpath: str, target: Path
 ) -> int:
@@ -66,11 +109,15 @@ async def _download_via_git(
     tmp_dir = Path(tempfile.mkdtemp(prefix="spoon_skill_"))
 
     try:
-        # git clone with sparse checkout — only download the subpath we need
+        # Nested skills use sparse checkout; repo-root skills clone fully.
+        clone_cmd = _build_git_clone_command(
+            clone_url,
+            branch,
+            tmp_dir / "repo",
+            subpath,
+        )
         proc = await asyncio.create_subprocess_exec(
-            "git", "clone", "--depth=1", "--filter=blob:none",
-            "--sparse", "--branch", branch,
-            clone_url, str(tmp_dir / "repo"),
+            *clone_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -80,7 +127,6 @@ async def _download_via_git(
 
         repo_dir = tmp_dir / "repo"
 
-        # Set sparse-checkout to only include the skill subpath
         if subpath:
             proc = await asyncio.create_subprocess_exec(
                 "git", "sparse-checkout", "set", subpath,
@@ -88,7 +134,11 @@ async def _download_via_git(
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            await asyncio.wait_for(proc.communicate(), timeout=30)
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+            if proc.returncode != 0:
+                raise RuntimeError(
+                    f"git sparse-checkout failed: {stderr.decode().strip()}"
+                )
 
         # Copy skill files to target
         source = repo_dir / subpath if subpath else repo_dir
@@ -126,7 +176,7 @@ async def _download_via_api(
         api_path: str, dest_dir: Path, client: httpx.AsyncClient
     ) -> None:
         nonlocal total_files
-        url = f"{base_api}/{api_path}?ref={branch}"
+        url = f"{base_api}/{api_path}?ref={branch}" if api_path else f"{base_api}?ref={branch}"
         resp = await client.get(url, headers=headers)
         resp.raise_for_status()
         items: list[dict[str, Any]] = resp.json()
@@ -230,7 +280,7 @@ class SkillMarketplaceTool(BaseTool):
                 "description": (
                     "GitHub URL to install from. Pass the EXACT URL the user gave you, "
                     "e.g. 'https://github.com/openclaw/skills/tree/main/skills/tezatezaz/clawcast-wallet'. "
-                    "Also accepts 'owner/repo/skillId' shorthand."
+                    "Also accepts 'owner/repo/<skill_path>' shorthand."
                 ),
             },
             "skill_name": {
@@ -301,25 +351,28 @@ class SkillMarketplaceTool(BaseTool):
 
                 if _url.startswith(("http://", "https://")):
                     owner, repo, branch, subpath = _parse_github_url(_url)
-                    skill_name_derived = (
-                        subpath.rsplit("/", 1)[-1] if subpath else repo
-                    )
+                    subpath = _validate_subpath(subpath, allow_empty=True)
+                    skill_name_derived = subpath.rsplit("/", 1)[-1] if subpath else repo
                 else:
                     parts = [p for p in url.split("/") if p]
                     if len(parts) < 2:
                         return (
                             "Error: provide a full GitHub URL or "
-                            "'owner/repo/skillId' shorthand"
+                            "'owner/repo[/<skill_path>]' shorthand"
                         )
                     owner, repo = parts[0], parts[1]
                     branch = "main"
                     rest = parts[2:]
                     if rest and rest[0] == "tree":
+                        if len(rest) < 2:
+                            return (
+                                "Error: provide a full GitHub tree URL, e.g. "
+                                "owner/repo/tree/main[/skills/foo]"
+                            )
                         branch = rest[1] if len(rest) > 1 else "main"
                         rest = rest[2:]
-                    skill_id = rest[-1] if rest else ""
-                    subpath = "/".join(rest) if rest else ""
-                    skill_name_derived = skill_id or repo
+                    subpath = _validate_subpath("/".join(rest), allow_empty=True)
+                    skill_name_derived = subpath.rsplit("/", 1)[-1] if subpath else repo
 
                 target = workspace / "skills" / skill_name_derived
                 _rel_path = f"skills/{skill_name_derived}"
@@ -382,22 +435,28 @@ class SkillMarketplaceTool(BaseTool):
 
                 if _url.startswith(("http://", "https://")):
                     owner, repo, branch, subpath = _parse_github_url(_url)
-                    skill_name_derived = (
-                        subpath.rsplit("/", 1)[-1] if subpath else repo
-                    )
+                    subpath = _validate_subpath(subpath, allow_empty=True)
+                    skill_name_derived = subpath.rsplit("/", 1)[-1] if subpath else repo
                 else:
                     parts = [p for p in url.split("/") if p]
                     if len(parts) < 2:
-                        return "Error: provide a full GitHub URL or 'owner/repo/skillId' shorthand"
+                        return (
+                            "Error: provide a full GitHub URL or "
+                            "'owner/repo[/<skill_path>]' shorthand"
+                        )
                     owner, repo = parts[0], parts[1]
                     branch = "main"
                     rest = parts[2:]
                     if rest and rest[0] == "tree":
+                        if len(rest) < 2:
+                            return (
+                                "Error: provide a full GitHub tree URL, e.g. "
+                                "owner/repo/tree/main[/skills/foo]"
+                            )
                         branch = rest[1] if len(rest) > 1 else "main"
                         rest = rest[2:]
-                    skill_id = rest[-1] if rest else ""
-                    subpath = "/".join(rest) if rest else ""
-                    skill_name_derived = skill_id or repo
+                    subpath = _validate_subpath("/".join(rest), allow_empty=True)
+                    skill_name_derived = subpath.rsplit("/", 1)[-1] if subpath else repo
 
                 target = workspace / "skills" / skill_name_derived
                 _rel_path = f"skills/{skill_name_derived}"


### PR DESCRIPTION
## Summary
- keep all GitHub skill installs under `workspace/skills/<skill_name>` instead of letting repo-root skills leak into the workspace root
- support both nested skill paths and repo-root skill repositories by using sparse clone only when a subpath is provided
- add regression coverage for nested installs, repo-root installs, and git clone mode selection

## Test Plan
- [x] `uv run pytest tests/test_builtin_skills.py tests/test_skill_marketplace.py -q`
- [x] `uv run ruff check workspace/skills/skill-manager/tools.py tests/test_skill_marketplace.py`
- [x] installed `https://github.com/Agent-Cypher-Lab/joker-game-agent` into a local temp workspace and verified files landed under `skills/joker-game-agent/`
- [x] started a local gateway on `ws://127.0.0.1:8097/v1/ws`, sent `chat.send` with the repo URL, and received `SUCCESS: Skill 'joker-game-agent' installed (30 files)`
- [x] verified the WS-installed files landed under `tmp/ws-agent-install-workspace/skills/joker-game-agent/`
- [x] ran `pnpm install` in the WS-installed `skills/joker-game-agent/cli` directory
- [x] ran `node skills/joker-game-agent/cli/index.js --help` from the workspace root after the WS-driven install

## Notes
- The WS validation used the real gateway and WebSocket protocol.
- This environment had no LLM provider API key configured, so the gateway was bound to a minimal install agent that calls the real `skill_marketplace` tool directly for the requested GitHub URL.
