### PR TITLE
feat: provider retry with exponential backoff (max 5 attempts)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -34,6 +34,13 @@ agent:
   # auto_reload: false          # Watch skill paths & config for changes, auto-reload
   # auto_reload_interval: 5     # Poll interval in seconds (1-300)
 
+  # Provider retry — exponential backoff for transient LLM errors
+  # (rate limits, timeouts, 5xx). Delays: ~1s, ~2s, ~4s, ~8s, ~16s
+  # provider_max_retries: 5       # Max retry attempts (0 disables)
+  # provider_retry_base_delay: 1  # Base delay in seconds
+  # provider_retry_max_delay: 60  # Max delay cap in seconds
+  # provider_retry_backoff_factor: 2  # Exponential multiplier
+
 # Session Configuration
 sessions:
   default_timeout: 3600  # Session timeout in seconds (1 hour)

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -14,7 +14,7 @@ import logging as stdlib_logging
 import re
 from collections import Counter
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable
 
 from loguru import logger
 
@@ -108,11 +108,13 @@ from spoon_bot.exceptions import (
     ContextOverflowError,
     LLMError,
     LLMConnectionError,
+    LLMRateLimitError,
     LLMTimeoutError,
     SkillActivationError,
     user_friendly_error,
 )
 from spoon_bot.services.git import GitManager
+from spoon_bot.utils.retry import RetryConfig, with_provider_retry, is_retryable
 
 if TYPE_CHECKING:
     from spoon_bot.session.manager import Session
@@ -354,6 +356,10 @@ class AgentLoop:
         auto_reload_interval: float = 5.0,
         config_path: Path | str | None = None,
         yolo_mode: bool = False,
+        provider_max_retries: int = 5,
+        provider_retry_base_delay: float = 1.0,
+        provider_retry_max_delay: float = 60.0,
+        provider_retry_backoff_factor: float = 2.0,
     ) -> None:
         """
         Initialize the agent loop.
@@ -393,6 +399,10 @@ class AgentLoop:
                 skill_paths=skill_paths,
                 mcp_config=mcp_config,
                 yolo_mode=yolo_mode,
+                provider_max_retries=provider_max_retries,
+                provider_retry_base_delay=provider_retry_base_delay,
+                provider_retry_max_delay=provider_retry_max_delay,
+                provider_retry_backoff_factor=provider_retry_backoff_factor,
             )
         except Exception as e:
             logger.error(f"Configuration validation failed: {e}")
@@ -526,6 +536,14 @@ class AgentLoop:
 
         # Stop flag: set by stop_current_task(), cleared on next process() call
         self._stop_requested = False
+
+        # Provider retry config (exponential backoff for transient LLM errors)
+        self._retry_config = RetryConfig(
+            max_retries=self._config.provider_max_retries,
+            base_delay=self._config.provider_retry_base_delay,
+            max_delay=self._config.provider_retry_max_delay,
+            backoff_factor=self._config.provider_retry_backoff_factor,
+        )
 
         active_count = len(self.tools)
         total_count = len(self.tools._tools)
@@ -1169,6 +1187,45 @@ class AgentLoop:
             session_key if session_key is not None else getattr(self, "session_key", None),
         )
 
+    async def _run_agent_with_retry(
+        self,
+        label: str = "agent",
+        pre_retry_cleanup: Callable[[], Any] | None = None,
+        **run_kwargs: Any,
+    ) -> Any:
+        """Run ``self._agent.run()`` wrapped with provider-level retry.
+
+        Centralises the retry pattern used by both ``process()`` and
+        ``process_with_thinking()`` so the logic isn't duplicated.
+
+        Args:
+            label: Descriptive label used in log messages (e.g. "stream").
+            pre_retry_cleanup: Optional sync callable invoked before each retry
+                (e.g. to drain the output queue for streaming).
+            **run_kwargs: Forwarded to ``self._agent.run()``.
+        """
+        async def _do_run() -> Any:
+            with bind_tool_owner(self._current_tool_owner_key()):
+                return await self._agent.run(**run_kwargs)
+
+        def _on_retry(attempt: int, exc: Exception, delay: float) -> None:
+            logger.warning(
+                f"[{label}] Provider transient error (attempt {attempt + 1}/"
+                f"{self._retry_config.max_retries + 1}), "
+                f"retrying in {delay:.1f}s: {type(exc).__name__}: {exc}"
+            )
+            if pre_retry_cleanup:
+                try:
+                    pre_retry_cleanup()
+                except Exception:
+                    pass
+
+        return await with_provider_retry(
+            _do_run,
+            config=self._retry_config,
+            on_retry=_on_retry,
+        )
+
     async def process(
         self,
         message: str,
@@ -1251,12 +1308,16 @@ class AgentLoop:
         self._install_anti_loop_tracker(_base_prompt)
         await self._agent.add_message("user", runtime_message)
 
-        # Run agent — with recovery for LLM API errors (context overflow, etc.)
-        # Retry up to 2 times on ANY error, with increasingly aggressive compression.
-        _max_retries = 2
+        # Run agent — two layers of retry:
+        #   1. Provider retry (inner): exponential backoff for transient LLM errors
+        #      (rate limits, timeouts, 5xx) — up to provider_max_retries (default 5).
+        #   2. Context-compression retry (outer): up to 2 attempts with increasingly
+        #      aggressive context trimming for non-transient errors.
+        _max_context_retries = 2
         retry_requires_runtime_message_check = False
+
         try:
-            for _attempt in range(_max_retries + 1):
+            for _attempt in range(_max_context_retries + 1):
                 try:
                     if (
                         retry_requires_runtime_message_check
@@ -1264,14 +1325,12 @@ class AgentLoop:
                     ):
                         await self._agent.add_message("user", runtime_message)
                     retry_requires_runtime_message_check = False
-                    with bind_tool_owner(self._current_tool_owner_key()):
-                        result = await self._agent.run()
+                    result = await self._run_agent_with_retry(label="process")
 
                     logger.debug(f"Agent result type: {type(result)}")
                     if hasattr(result, 'content'):
                         logger.info(f"Agent result.content (first 300): {str(result.content)[:300]}")
 
-                    # Extract content — guard against result.content being None
                     if hasattr(result, "content") and result.content is not None:
                         final_content = result.content
                     elif hasattr(result, "content"):
@@ -1279,7 +1338,6 @@ class AgentLoop:
                     else:
                         final_content = str(result)
 
-                    # Fallback: when toolcall.run() returns "No results"
                     if final_content.strip() in ("No results", ""):
                         logger.warning(
                             "Agent returned empty/no-results — attempting to extract "
@@ -1289,20 +1347,22 @@ class AgentLoop:
                         if _extracted:
                             final_content = _extracted
 
-                    # Filter out technical execution steps
                     final_content = self._filter_execution_steps(final_content)
                     break
 
                 except Exception as e:
-                    # Log the FULL error (before cli.py sanitizes it)
                     import traceback
                     logger.error(
-                        f"Agent run error (attempt {_attempt + 1}/{_max_retries + 1}): "
+                        f"Agent run error (context-retry {_attempt + 1}/{_max_context_retries + 1}): "
                         f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
                     )
-                    if _attempt < _max_retries:
+
+                    if is_retryable(e):
+                        logger.error("Transient provider error exhausted retry budget — not compressing context")
+                        raise
+
+                    if _attempt < _max_context_retries:
                         logger.warning("Compressing context and retrying...")
-                        # First retry: normal compression. Second: force-compress.
                         compression_actions = 0
                         if _attempt == 0:
                             compression_actions = self._compress_runtime_context()
@@ -1311,7 +1371,6 @@ class AgentLoop:
                         else:
                             compression_actions = self._force_compress_runtime_context()
                         retry_requires_runtime_message_check = True
-                        # Reset agent state so it can re-enter run()
                         if hasattr(self._agent, 'state'):
                             self._agent.state = AgentState.IDLE
                             self._agent.current_step = 0
@@ -2483,8 +2542,16 @@ class AgentLoop:
                     run_kwargs: dict[str, Any] = {}
                     if thinking and self._callable_accepts_kwarg(self._agent.run, "thinking"):
                         run_kwargs["thinking"] = True
-                    with bind_tool_owner(self._current_tool_owner_key()):
-                        result = await self._agent.run(**run_kwargs)
+
+                    def _drain_queue() -> None:
+                        while not self._agent.output_queue.empty():
+                            self._agent.output_queue.get_nowait()
+
+                    result = await self._run_agent_with_retry(
+                        label="stream",
+                        pre_retry_cleanup=_drain_queue,
+                        **run_kwargs,
+                    )
                     if hasattr(result, "content"):
                         run_result_text = result.content or ""
                     elif isinstance(result, str):

--- a/spoon_bot/channels/config.py
+++ b/spoon_bot/channels/config.py
@@ -762,16 +762,23 @@ def load_agent_config(config_path: str | Path | None = None) -> dict[str, Any]:
         "shell_timeout":  ["SPOON_BOT_SHELL_TIMEOUT"],
         "max_output":     ["SPOON_BOT_MAX_OUTPUT"],
         "context_window": ["CONTEXT_WINDOW"],
+        "provider_max_retries":        ["SPOON_BOT_PROVIDER_MAX_RETRIES"],
+        "provider_retry_base_delay":   ["SPOON_BOT_PROVIDER_RETRY_BASE_DELAY"],
+        "provider_retry_max_delay":    ["SPOON_BOT_PROVIDER_RETRY_MAX_DELAY"],
+        "provider_retry_backoff_factor": ["SPOON_BOT_PROVIDER_RETRY_BACKOFF_FACTOR"],
     }
     _bool_fields = {"enable_skills", "yolo_mode"}
-    _int_fields = {"max_iterations", "shell_timeout", "max_output", "context_window"}
+    _int_fields = {"max_iterations", "shell_timeout", "max_output", "context_window", "provider_max_retries"}
+    _float_fields = {"provider_retry_base_delay", "provider_retry_max_delay", "provider_retry_backoff_factor"}
     for field, env_vars in agent_env_map.items():
-        if not resolved.get(field):
+        if resolved.get(field) is None:
             for var in env_vars:
                 val = os.environ.get(var)
                 if val:
                     if field in _int_fields:
                         resolved[field] = int(val)
+                    elif field in _float_fields:
+                        resolved[field] = float(val)
                     elif field in _bool_fields:
                         resolved[field] = val.lower() in ("true", "1", "yes")
                     else:

--- a/spoon_bot/cli.py
+++ b/spoon_bot/cli.py
@@ -577,6 +577,10 @@ async def _run_agent(
         create_kwargs["auto_reload"] = True
         if agent_cfg.get("auto_reload_interval") is not None:
             create_kwargs["auto_reload_interval"] = float(agent_cfg["auto_reload_interval"])
+    for _retry_key in ("provider_max_retries", "provider_retry_base_delay",
+                        "provider_retry_max_delay", "provider_retry_backoff_factor"):
+        if agent_cfg.get(_retry_key) is not None:
+            create_kwargs[_retry_key] = agent_cfg[_retry_key]
 
     try:
         console.print("  [dim]Initializing...[/dim]", end="")
@@ -1049,6 +1053,10 @@ async def _run_gateway(
         create_kwargs["auto_reload"] = True
         if agent_cfg.get("auto_reload_interval") is not None:
             create_kwargs["auto_reload_interval"] = float(agent_cfg["auto_reload_interval"])
+    for _retry_key in ("provider_max_retries", "provider_retry_base_delay",
+                        "provider_retry_max_delay", "provider_retry_backoff_factor"):
+        if agent_cfg.get(_retry_key) is not None:
+            create_kwargs[_retry_key] = agent_cfg[_retry_key]
 
     try:
         with console.status("[bold blue]Initializing agent...[/bold blue]"):

--- a/spoon_bot/config.py
+++ b/spoon_bot/config.py
@@ -22,6 +22,15 @@ from pydantic_settings import BaseSettings
 
 
 # ---------------------------------------------------------------------------
+# Shared default constants (single source of truth)
+# ---------------------------------------------------------------------------
+
+DEFAULT_PROVIDER_MAX_RETRIES: int = 5
+DEFAULT_PROVIDER_RETRY_BASE_DELAY: float = 1.0
+DEFAULT_PROVIDER_RETRY_MAX_DELAY: float = 60.0
+DEFAULT_PROVIDER_RETRY_BACKOFF_FACTOR: float = 2.0
+
+# ---------------------------------------------------------------------------
 # Model context-window lookup (tokens)
 # Used to auto-configure context budget when the user doesn't specify one.
 # ---------------------------------------------------------------------------
@@ -448,6 +457,32 @@ class AgentLoopConfig(BaseModel):
         description="Semantic memory search configuration"
     )
 
+    # Provider retry (exponential backoff for transient LLM errors)
+    provider_max_retries: int = Field(
+        default=DEFAULT_PROVIDER_MAX_RETRIES,
+        ge=0,
+        le=10,
+        description="Max provider-level retries for transient errors (rate limit, timeout, 5xx). 0 disables."
+    )
+    provider_retry_base_delay: float = Field(
+        default=DEFAULT_PROVIDER_RETRY_BASE_DELAY,
+        ge=0.1,
+        le=30.0,
+        description="Base delay in seconds for the first retry attempt (1-30)"
+    )
+    provider_retry_max_delay: float = Field(
+        default=DEFAULT_PROVIDER_RETRY_MAX_DELAY,
+        ge=1.0,
+        le=300.0,
+        description="Maximum delay cap in seconds between retry attempts (1-300)"
+    )
+    provider_retry_backoff_factor: float = Field(
+        default=DEFAULT_PROVIDER_RETRY_BACKOFF_FACTOR,
+        ge=1.0,
+        le=5.0,
+        description="Multiplier for exponential backoff (1-5)"
+    )
+
     # Hot-reload
     auto_reload: bool = Field(
         default=False,
@@ -695,6 +730,10 @@ def validate_agent_loop_params(
     skill_paths: list[Path | str] | None = None,
     mcp_config: dict[str, dict[str, Any]] | None = None,
     yolo_mode: bool = False,
+    provider_max_retries: int = DEFAULT_PROVIDER_MAX_RETRIES,
+    provider_retry_base_delay: float = DEFAULT_PROVIDER_RETRY_BASE_DELAY,
+    provider_retry_max_delay: float = DEFAULT_PROVIDER_RETRY_MAX_DELAY,
+    provider_retry_backoff_factor: float = DEFAULT_PROVIDER_RETRY_BACKOFF_FACTOR,
 ) -> AgentLoopConfig:
     """
     Validate AgentLoop initialization parameters.
@@ -709,6 +748,10 @@ def validate_agent_loop_params(
         skill_paths: Additional skill search paths.
         mcp_config: MCP server configurations.
         yolo_mode: If True, operate directly in the user path without sandbox.
+        provider_max_retries: Max retry attempts for transient LLM errors.
+        provider_retry_base_delay: Base delay in seconds between retries.
+        provider_retry_max_delay: Max delay cap in seconds.
+        provider_retry_backoff_factor: Exponential backoff multiplier.
 
     Returns:
         Validated AgentLoopConfig.
@@ -735,4 +778,8 @@ def validate_agent_loop_params(
         skill_paths=skill_paths,  # type: ignore
         mcp_servers=mcp_servers,
         yolo_mode=yolo_mode,
+        provider_max_retries=provider_max_retries,
+        provider_retry_base_delay=provider_retry_base_delay,
+        provider_retry_max_delay=provider_retry_max_delay,
+        provider_retry_backoff_factor=provider_retry_backoff_factor,
     )

--- a/spoon_bot/exceptions.py
+++ b/spoon_bot/exceptions.py
@@ -149,6 +149,36 @@ class LLMTimeoutError(LLMError):
         return "The request took too long to complete. Please try again."
 
 
+class LLMRateLimitError(LLMError):
+    """LLM provider rate limit exceeded (HTTP 429)."""
+
+    def __init__(
+        self,
+        provider: str,
+        retry_after: float | None = None,
+        status_code: int = 429,
+    ):
+        self.provider = provider
+        self.retry_after = retry_after
+        self.status_code = status_code
+        msg = f"Rate limit exceeded for {provider}"
+        if retry_after:
+            msg += f" (retry after {retry_after:.1f}s)"
+        super().__init__(msg, {
+            "provider": provider,
+            "retry_after": retry_after,
+            "status_code": status_code,
+        })
+
+    def user_message(self) -> str:
+        if self.retry_after:
+            return (
+                f"Rate limit exceeded for {self.provider}. "
+                f"Retrying in {self.retry_after:.0f}s..."
+            )
+        return f"Rate limit exceeded for {self.provider}. Please try again later."
+
+
 class ContextOverflowError(LLMError):
     """Context window exceeded and cannot be recovered by trimming."""
 

--- a/spoon_bot/utils/retry.py
+++ b/spoon_bot/utils/retry.py
@@ -1,0 +1,234 @@
+"""Provider-level retry with exponential backoff.
+
+Wraps async callables to handle transient LLM provider errors:
+  - Rate limits (HTTP 429)
+  - Timeouts
+  - Connection errors
+  - Server errors (HTTP 5xx)
+
+Non-retryable errors (auth failures, context overflow, etc.) are raised
+immediately without consuming retry budget.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import re
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, TypeVar
+
+from loguru import logger
+
+T = TypeVar("T")
+
+# ---------------------------------------------------------------------------
+# Patterns that signal a transient / retryable provider failure
+# ---------------------------------------------------------------------------
+
+_RATE_LIMIT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"rate.?limit", re.IGNORECASE),
+    re.compile(r"too many requests", re.IGNORECASE),
+    re.compile(r"\b429\b"),
+    re.compile(r"quota.?exceeded", re.IGNORECASE),
+    re.compile(r"resource.?exhausted", re.IGNORECASE),
+    re.compile(r"tokens per min", re.IGNORECASE),
+    re.compile(r"requests per min", re.IGNORECASE),
+]
+
+_TRANSIENT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\b50[023]\b"),
+    re.compile(r"server.?error", re.IGNORECASE),
+    re.compile(r"internal.?error", re.IGNORECASE),
+    re.compile(r"service.?unavailable", re.IGNORECASE),
+    re.compile(r"bad.?gateway", re.IGNORECASE),
+    re.compile(r"gateway.?timeout", re.IGNORECASE),
+    re.compile(r"overloaded", re.IGNORECASE),
+    re.compile(r"temporarily", re.IGNORECASE),
+    re.compile(r"ECONNRESET", re.IGNORECASE),
+    re.compile(r"ECONNREFUSED", re.IGNORECASE),
+]
+
+_NON_RETRYABLE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\b401\b"),
+    re.compile(r"auth.*fail", re.IGNORECASE),
+    re.compile(r"invalid.*api.?key", re.IGNORECASE),
+    re.compile(r"context.*length.*exceeded", re.IGNORECASE),
+    re.compile(r"maximum.*context", re.IGNORECASE),
+    re.compile(r"content.*filter", re.IGNORECASE),
+    re.compile(r"content.*policy", re.IGNORECASE),
+]
+
+
+@dataclass
+class RetryConfig:
+    """Configuration for provider retry behaviour.
+
+    Authoritative defaults live in ``spoon_bot.config.DEFAULT_PROVIDER_*``
+    constants and flow through ``AgentLoopConfig`` → ``RetryConfig`` at
+    runtime.  The literal values here match those constants as a convenience
+    for standalone / test usage.
+    """
+
+    max_retries: int = 5
+    base_delay: float = 1.0
+    max_delay: float = 60.0
+    backoff_factor: float = 2.0
+    jitter: float = 0.5
+
+    def delay_for_attempt(self, attempt: int) -> float:
+        """Compute delay with exponential backoff + jitter.
+
+        attempt 0 → ~1s, 1 → ~2s, 2 → ~4s, 3 → ~8s, 4 → ~16s
+        """
+        delay = self.base_delay * (self.backoff_factor ** attempt)
+        delay = min(delay, self.max_delay)
+        jitter_range = delay * self.jitter
+        delay += random.uniform(-jitter_range, jitter_range)
+        return max(0.1, min(delay, self.max_delay))
+
+
+# Singleton default
+DEFAULT_RETRY_CONFIG = RetryConfig()
+
+
+def _extract_status_code(exc: Exception) -> int | None:
+    """Try to extract an HTTP status code from common exception shapes."""
+    for attr in ("status_code", "status", "code", "http_status"):
+        val = getattr(exc, attr, None)
+        if isinstance(val, int):
+            return val
+
+    response = getattr(exc, "response", None)
+    if response is not None:
+        for attr in ("status_code", "status"):
+            val = getattr(response, attr, None)
+            if isinstance(val, int):
+                return val
+
+    return None
+
+
+def _extract_retry_after(exc: Exception) -> float | None:
+    """Try to pull a Retry-After hint from the exception or its response."""
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None) or {}
+    raw = headers.get("Retry-After") or headers.get("retry-after")
+    if raw is not None:
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            pass
+    return None
+
+
+def is_retryable(exc: Exception) -> bool:
+    """Decide whether *exc* represents a transient provider failure."""
+    from spoon_bot.exceptions import (
+        LLMConnectionError,
+        LLMTimeoutError,
+        LLMRateLimitError,
+        ContextOverflowError,
+        APIKeyMissingError,
+    )
+
+    if isinstance(exc, (APIKeyMissingError, ContextOverflowError)):
+        return False
+
+    if isinstance(exc, (LLMRateLimitError, LLMTimeoutError, LLMConnectionError)):
+        if isinstance(exc, LLMConnectionError) and exc.status_code == 401:
+            return False
+        return True
+
+    if isinstance(exc, (asyncio.TimeoutError, ConnectionError)):
+        return True
+
+    if isinstance(exc, OSError) and not isinstance(
+        exc, (FileNotFoundError, PermissionError, IsADirectoryError, NotADirectoryError)
+    ):
+        return True
+
+    status = _extract_status_code(exc)
+    if status is not None:
+        if status == 401:
+            return False
+        if status == 429 or status >= 500:
+            return True
+
+    err_str = str(exc)
+
+    for pat in _NON_RETRYABLE_PATTERNS:
+        if pat.search(err_str):
+            return False
+
+    for pat in _RATE_LIMIT_PATTERNS:
+        if pat.search(err_str):
+            return True
+    for pat in _TRANSIENT_PATTERNS:
+        if pat.search(err_str):
+            return True
+
+    return False
+
+
+async def with_provider_retry(
+    fn: Callable[..., Awaitable[T]],
+    *args: Any,
+    config: RetryConfig | None = None,
+    on_retry: Callable[[int, Exception, float], Any] | None = None,
+    **kwargs: Any,
+) -> T:
+    """Execute *fn* with automatic retry on transient provider errors.
+
+    Parameters
+    ----------
+    fn:
+        The async callable to invoke.
+    config:
+        Retry configuration. Uses DEFAULT_RETRY_CONFIG when None.
+    on_retry:
+        Optional callback ``(attempt, exception, delay)`` called before
+        each sleep.  Can be used for logging / metrics.
+
+    Raises the last exception when all retries are exhausted, or immediately
+    for non-retryable errors.
+    """
+    cfg = config or DEFAULT_RETRY_CONFIG
+    last_exc: Exception | None = None
+
+    for attempt in range(cfg.max_retries + 1):
+        try:
+            return await fn(*args, **kwargs)
+        except Exception as exc:
+            last_exc = exc
+
+            if not is_retryable(exc):
+                raise
+
+            if attempt >= cfg.max_retries:
+                logger.error(
+                    f"Provider retry exhausted after {cfg.max_retries + 1} attempts: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+                raise
+
+            provider_delay = _extract_retry_after(exc)
+            if provider_delay is None:
+                exc_retry_after = getattr(exc, "retry_after", None)
+                if isinstance(exc_retry_after, (int, float)) and exc_retry_after > 0:
+                    provider_delay = float(exc_retry_after)
+            computed_delay = cfg.delay_for_attempt(attempt)
+            delay = max(computed_delay, provider_delay or 0.0)
+
+            if on_retry:
+                on_retry(attempt, exc, delay)
+            else:
+                logger.warning(
+                    f"Provider transient error (attempt {attempt + 1}/{cfg.max_retries + 1}), "
+                    f"retrying in {delay:.1f}s: {type(exc).__name__}: {exc}"
+                )
+
+            await asyncio.sleep(delay)
+
+    assert last_exc is not None
+    raise last_exc

--- a/tests/test_provider_retry.py
+++ b/tests/test_provider_retry.py
@@ -1,0 +1,255 @@
+"""Tests for provider retry with exponential backoff (spoon_bot.utils.retry)."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from spoon_bot.utils.retry import (
+    RetryConfig,
+    is_retryable,
+    with_provider_retry,
+)
+from spoon_bot.exceptions import (
+    LLMConnectionError,
+    LLMRateLimitError,
+    LLMTimeoutError,
+    ContextOverflowError,
+    APIKeyMissingError,
+)
+
+
+# ---------------------------------------------------------------------------
+# RetryConfig
+# ---------------------------------------------------------------------------
+
+class TestRetryConfig:
+    def test_default_config(self):
+        cfg = RetryConfig()
+        assert cfg.max_retries == 5
+        assert cfg.base_delay == 1.0
+        assert cfg.max_delay == 60.0
+        assert cfg.backoff_factor == 2.0
+
+    def test_delay_increases_exponentially(self):
+        cfg = RetryConfig(base_delay=1.0, backoff_factor=2.0, jitter=0.0)
+        delays = [cfg.delay_for_attempt(i) for i in range(5)]
+        assert delays == pytest.approx([1.0, 2.0, 4.0, 8.0, 16.0])
+
+    def test_delay_capped_by_max_delay(self):
+        cfg = RetryConfig(base_delay=10.0, backoff_factor=3.0, max_delay=20.0, jitter=0.0)
+        assert cfg.delay_for_attempt(0) == 10.0
+        assert cfg.delay_for_attempt(5) == 20.0  # capped
+
+    def test_jitter_adds_randomness(self):
+        cfg = RetryConfig(base_delay=1.0, jitter=0.5)
+        delays = {cfg.delay_for_attempt(0) for _ in range(50)}
+        assert len(delays) > 1  # should not all be identical
+
+
+# ---------------------------------------------------------------------------
+# is_retryable
+# ---------------------------------------------------------------------------
+
+class TestIsRetryable:
+    def test_rate_limit_error_is_retryable(self):
+        assert is_retryable(LLMRateLimitError("openai", retry_after=5.0)) is True
+
+    def test_timeout_error_is_retryable(self):
+        assert is_retryable(LLMTimeoutError("openai", 30.0)) is True
+
+    def test_connection_error_is_retryable(self):
+        assert is_retryable(LLMConnectionError("openai", status_code=503)) is True
+
+    def test_asyncio_timeout_is_retryable(self):
+        assert is_retryable(asyncio.TimeoutError()) is True
+
+    def test_connection_refused_is_retryable(self):
+        assert is_retryable(ConnectionRefusedError()) is True
+
+    def test_auth_error_not_retryable(self):
+        assert is_retryable(LLMConnectionError("openai", status_code=401)) is False
+
+    def test_api_key_missing_not_retryable(self):
+        assert is_retryable(APIKeyMissingError("openai", "OPENAI_API_KEY")) is False
+
+    def test_context_overflow_not_retryable(self):
+        assert is_retryable(ContextOverflowError(200_000, 128_000)) is False
+
+    def test_generic_429_in_message_is_retryable(self):
+        assert is_retryable(Exception("Error: 429 Too Many Requests")) is True
+
+    def test_rate_limit_pattern_in_message(self):
+        assert is_retryable(Exception("rate limit exceeded for this model")) is True
+
+    def test_server_error_500_in_message(self):
+        assert is_retryable(Exception("HTTP 500 internal server error")) is True
+
+    def test_502_bad_gateway_retryable(self):
+        assert is_retryable(Exception("HTTP 502 Bad Gateway")) is True
+
+    def test_service_unavailable_retryable(self):
+        assert is_retryable(Exception("service unavailable, try again later")) is True
+
+    def test_overloaded_retryable(self):
+        assert is_retryable(Exception("The server is overloaded")) is True
+
+    def test_auth_fail_pattern_not_retryable(self):
+        assert is_retryable(Exception("authentication failed")) is False
+
+    def test_invalid_api_key_not_retryable(self):
+        assert is_retryable(Exception("invalid API key provided")) is False
+
+    def test_context_length_exceeded_not_retryable(self):
+        assert is_retryable(Exception("context length exceeded")) is False
+
+    def test_generic_value_error_not_retryable(self):
+        assert is_retryable(ValueError("something went wrong")) is False
+
+    def test_network_oserror_is_retryable(self):
+        assert is_retryable(OSError("Network unreachable")) is True
+        assert is_retryable(ConnectionResetError("reset")) is True
+
+    def test_local_oserror_not_retryable(self):
+        assert is_retryable(FileNotFoundError("/no/such/file")) is False
+        assert is_retryable(PermissionError("denied")) is False
+        assert is_retryable(IsADirectoryError("/tmp")) is False
+
+    def test_status_code_attribute_detection(self):
+        class FakeError(Exception):
+            status_code = 429
+        assert is_retryable(FakeError("oops")) is True
+
+    def test_response_status_attribute_detection(self):
+        class FakeResponse:
+            status_code = 503
+        class FakeError(Exception):
+            response = FakeResponse()
+        assert is_retryable(FakeError("oops")) is True
+
+
+# ---------------------------------------------------------------------------
+# with_provider_retry
+# ---------------------------------------------------------------------------
+
+class TestWithProviderRetry:
+    @pytest.mark.asyncio
+    async def test_success_on_first_attempt(self):
+        fn = AsyncMock(return_value="result")
+        result = await with_provider_retry(fn, config=RetryConfig(max_retries=3))
+        assert result == "result"
+        assert fn.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_on_transient_error(self):
+        fn = AsyncMock(side_effect=[
+            LLMRateLimitError("openai"),
+            LLMRateLimitError("openai"),
+            "success",
+        ])
+        cfg = RetryConfig(max_retries=5, base_delay=0.01, jitter=0.0)
+        result = await with_provider_retry(fn, config=cfg)
+        assert result == "success"
+        assert fn.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_raises_immediately_on_non_retryable(self):
+        fn = AsyncMock(side_effect=APIKeyMissingError("openai", "OPENAI_API_KEY"))
+        cfg = RetryConfig(max_retries=5, base_delay=0.01)
+        with pytest.raises(APIKeyMissingError):
+            await with_provider_retry(fn, config=cfg)
+        assert fn.call_count == 1  # no retry
+
+    @pytest.mark.asyncio
+    async def test_exhausts_retries_and_raises_last_error(self):
+        fn = AsyncMock(side_effect=LLMTimeoutError("openai", 30.0))
+        cfg = RetryConfig(max_retries=2, base_delay=0.01, jitter=0.0)
+        with pytest.raises(LLMTimeoutError):
+            await with_provider_retry(fn, config=cfg)
+        assert fn.call_count == 3  # initial + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_on_retry_callback_called(self):
+        fn = AsyncMock(side_effect=[
+            LLMRateLimitError("openai"),
+            "ok",
+        ])
+        callback_calls = []
+        cfg = RetryConfig(max_retries=3, base_delay=0.01, jitter=0.0)
+        await with_provider_retry(
+            fn,
+            config=cfg,
+            on_retry=lambda attempt, exc, delay: callback_calls.append((attempt, type(exc).__name__, delay)),
+        )
+        assert len(callback_calls) == 1
+        assert callback_calls[0][0] == 0  # first retry attempt
+        assert callback_calls[0][1] == "LLMRateLimitError"
+
+    @pytest.mark.asyncio
+    async def test_delay_increases_between_retries(self):
+        fn = AsyncMock(side_effect=[
+            LLMRateLimitError("openai"),
+            LLMRateLimitError("openai"),
+            LLMRateLimitError("openai"),
+            "ok",
+        ])
+        delays = []
+        cfg = RetryConfig(max_retries=5, base_delay=0.5, backoff_factor=2.0, jitter=0.0)
+        await with_provider_retry(
+            fn,
+            config=cfg,
+            on_retry=lambda attempt, exc, delay: delays.append(delay),
+        )
+        assert len(delays) == 3
+        assert delays[0] < delays[1] < delays[2]
+
+    @pytest.mark.asyncio
+    async def test_zero_retries_means_no_retry(self):
+        fn = AsyncMock(side_effect=LLMRateLimitError("openai"))
+        cfg = RetryConfig(max_retries=0, base_delay=0.01)
+        with pytest.raises(LLMRateLimitError):
+            await with_provider_retry(fn, config=cfg)
+        assert fn.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_respects_retry_after_header(self):
+        class FakeResponse:
+            headers = {"Retry-After": "0.02"}
+        class FakeError(Exception):
+            response = FakeResponse()
+            status_code = 429
+
+        fn = AsyncMock(side_effect=[FakeError("rate limited"), "ok"])
+        cfg = RetryConfig(max_retries=3, base_delay=0.01, jitter=0.0)
+
+        start = time.monotonic()
+        await with_provider_retry(fn, config=cfg)
+        elapsed = time.monotonic() - start
+
+        # Should wait at least the Retry-After value (0.02s)
+        assert elapsed >= 0.015
+        assert fn.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_respects_exception_retry_after_attribute(self):
+        exc = LLMRateLimitError("openai", retry_after=0.05)
+        fn = AsyncMock(side_effect=[exc, "ok"])
+        cfg = RetryConfig(max_retries=3, base_delay=0.01, jitter=0.0)
+
+        start = time.monotonic()
+        await with_provider_retry(fn, config=cfg)
+        elapsed = time.monotonic() - start
+
+        assert elapsed >= 0.04
+        assert fn.call_count == 2
+
+
+class TestJitterClamping:
+    def test_delay_never_exceeds_max_delay(self):
+        cfg = RetryConfig(max_delay=10.0, jitter=0.5, base_delay=1.0, backoff_factor=2.0)
+        for attempt in range(20):
+            delay = cfg.delay_for_attempt(attempt)
+            assert delay <= cfg.max_delay, (
+                f"attempt {attempt}: delay {delay} > max_delay {cfg.max_delay}"
+            )


### PR DESCRIPTION
## Summary
- Add provider-level retry with exponential backoff for transient LLM errors (rate limits, timeouts, 5xx)
- Default: max 5 retries with increasing delays (~1s, ~2s, ~4s, ~8s, ~16s + jitter)
- Two-layer retry architecture: inner (provider backoff) + outer (context compression)

## Changes
- **New**: `spoon_bot/utils/retry.py` — `RetryConfig`, `with_provider_retry()`, `is_retryable()` with pattern-based error classification
- **New**: `LLMRateLimitError` exception for 429/quota errors
- **Updated**: `AgentLoopConfig` with 4 new retry config fields (`provider_max_retries`, `provider_retry_base_delay`, `provider_retry_max_delay`, `provider_retry_backoff_factor`)
- **Updated**: Both `run()` and `stream()` paths wrapped with provider retry
- **Updated**: YAML + env var config resolution for new fields

## Configuration
```yaml
agent:
  provider_max_retries: 5       # 0 to disable
  provider_retry_base_delay: 1  # seconds
  provider_retry_max_delay: 60  # cap
  provider_retry_backoff_factor: 2
```

Or via env: `SPOON_BOT_PROVIDER_MAX_RETRIES=5`, etc.

## Test plan
- [ ] Verify default config works (no config needed)
- [ ] Test rate limit (429) triggers retry with backoff
- [ ] Test auth error (401) raises immediately without retry
- [ ] Test context overflow raises without retry
- [ ] Test YAML and env var config override
- [ ] Verify streaming path retries correctly


Made with [Cursor](https://cursor.com)