### PR TITLE
fix: repair orphaned tool messages before LLM call

### DIFF
--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -1140,6 +1140,16 @@ class AgentLoop:
         """Prepare request context by trimming and injecting session history."""
         trimmed_count = self._trim_context_if_needed()
         injected_count = await self._sync_runtime_history_from_session()
+
+        # Repair tool-call ordering after history injection — session storage
+        # may not preserve tool_call_id metadata, producing orphaned tool
+        # messages that providers (OpenAI, Gemini, etc.) reject.
+        repaired = 0
+        if self._agent and hasattr(self._agent, "memory"):
+            messages = getattr(self._agent.memory, "messages", None)
+            if isinstance(messages, list):
+                repaired = self._normalize_runtime_tool_context(messages)
+
         estimated_tokens = self._estimate_token_count()
 
         logger.info(
@@ -1147,6 +1157,7 @@ class AgentLoop:
             f"injected_messages={injected_count}, "
             f"estimated_tokens~{estimated_tokens}, "
             f"trimmed_messages={trimmed_count}"
+            + (f", repaired_tool_order={repaired}" if repaired else "")
         )
 
     def _build_runtime_message_content(
@@ -1686,39 +1697,55 @@ class AgentLoop:
         logger.info(f"Reordered {moved} runtime message positions to restore tool adjacency")
         return moved
 
-    @staticmethod
-    def _repair_tool_pairing(messages: list) -> int:
+    @classmethod
+    def _repair_tool_pairing(cls, messages: list) -> int:
         """Remove orphaned tool results and tool calls after message deletion.
 
         Ensures every tool_call_id in a tool-result message has a matching
         tool_calls entry in a preceding assistant message, and vice-versa.
+        Also removes tool-role messages with no tool_call_id at all (e.g.
+        injected from session history without metadata).
         Without this, the LLM API rejects the conversation.
 
         Returns the number of messages removed.
         """
         removed = 0
 
-        # Collect all tool_call IDs from assistant messages
-        offered_ids: set[str] = set()
-        for msg in messages:
-            if getattr(msg, 'tool_calls', None):
-                for tc in msg.tool_calls:
-                    tc_id = getattr(tc, 'id', None)
-                    if tc_id:
-                        offered_ids.add(tc_id)
+        # Phase 1: remove orphaned tool messages — delegate to spoon-core's
+        # shared utility when available so detection logic isn't duplicated.
+        try:
+            from spoon_ai.llm.message_utils import drop_orphaned_tool_messages
 
-        # Remove tool-result messages whose tool_call_id is not in offered_ids
-        i = 0
-        while i < len(messages):
-            msg = messages[i]
-            tc_id = getattr(msg, 'tool_call_id', None)
-            if tc_id and tc_id not in offered_ids:
-                del messages[i]
-                removed += 1
-                continue
-            i += 1
+            before = len(messages)
+            cleaned = drop_orphaned_tool_messages(messages)
+            messages[:] = cleaned
+            removed += before - len(messages)
+        except ImportError:
+            offered_ids: set[str] = set()
+            for msg in messages:
+                if getattr(msg, 'tool_calls', None):
+                    for tc in msg.tool_calls:
+                        tc_id = getattr(tc, 'id', None)
+                        if tc_id:
+                            offered_ids.add(tc_id)
 
-        # Collect all answered tool_call IDs
+            i = 0
+            while i < len(messages):
+                msg = messages[i]
+                role = cls._message_role_value(msg)
+                tc_id = getattr(msg, 'tool_call_id', None)
+
+                if role == "tool" and not tc_id:
+                    del messages[i]
+                    removed += 1
+                    continue
+                if tc_id and tc_id not in offered_ids:
+                    del messages[i]
+                    removed += 1
+                    continue
+                i += 1
+
+        # Phase 2: collect all answered tool_call IDs
         answered_ids: set[str] = set()
         for msg in messages:
             tc_id = getattr(msg, 'tool_call_id', None)
@@ -1750,7 +1777,11 @@ class AgentLoop:
         return normalized
 
     def _uses_strict_tool_turn_order(self) -> bool:
-        """True for providers/models that reject non-adjacent function call turns."""
+        """True for providers/models that reject non-adjacent function call turns.
+
+        Both OpenAI and Gemini require tool-result messages to immediately
+        follow the assistant message that issued the tool_calls.
+        """
         provider_raw = getattr(self, "provider", None)
         model_raw = getattr(self, "model", None)
         base_url_raw = getattr(self, "base_url", None)
@@ -1759,9 +1790,15 @@ class AgentLoop:
         model = model_raw.strip().lower() if isinstance(model_raw, str) else ""
         base_url = base_url_raw.strip().lower() if isinstance(base_url_raw, str) else ""
 
+        if provider in {"openai", "openrouter"}:
+            return True
         if provider in {"gemini", "google", "google_ai_studio", "google-ai-studio"}:
             return True
+        if any(prefix in model for prefix in ("gpt-", "o3", "o4", "openai/")):
+            return True
         if "gemini" in model or model.startswith("google/"):
+            return True
+        if "api.openai.com" in base_url:
             return True
         return "generativelanguage.googleapis.com" in base_url
 

--- a/tests/test_tool_message_ordering.py
+++ b/tests/test_tool_message_ordering.py
@@ -1,0 +1,214 @@
+"""Tests for tool message ordering and orphan cleanup in AgentLoop.
+
+Covers:
+- _repair_tool_pairing: drops tool messages with missing/unmatched tool_call_id
+- _reorder_tool_messages: moves tool results next to their issuing assistant turn
+- _normalize_runtime_tool_context: combined repair pipeline
+- _uses_strict_tool_turn_order: provider detection
+"""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    from spoon_ai.schema import Message, ToolCall as CoreToolCall, Function
+    SPOON_CORE_AVAILABLE = True
+except ImportError:
+    SPOON_CORE_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not SPOON_CORE_AVAILABLE, reason="spoon-core SDK not installed"
+)
+
+
+def _msg(role: str, content: str = "", **kwargs) -> Message:
+    return Message(role=role, content=content, **kwargs)
+
+
+def _assistant_with_tools(tool_ids: list[str], content: str = "") -> Message:
+    tool_calls = [
+        CoreToolCall(
+            id=tid,
+            type="function",
+            function=Function(name=f"tool_{tid}", arguments="{}"),
+        )
+        for tid in tool_ids
+    ]
+    return Message(role="assistant", content=content, tool_calls=tool_calls)
+
+
+def _tool_result(tool_call_id: str, content: str = "result") -> Message:
+    return Message(role="tool", content=content, tool_call_id=tool_call_id)
+
+
+# Lazy import to avoid import-time side effects
+def _get_agent_loop_class():
+    from spoon_bot.agent.loop import AgentLoop
+    return AgentLoop
+
+
+# ---------------------------------------------------------------------------
+# _repair_tool_pairing
+# ---------------------------------------------------------------------------
+
+class TestRepairToolPairing:
+    def test_drops_tool_message_with_no_tool_call_id(self):
+        AgentLoop = _get_agent_loop_class()
+        messages = [
+            _msg("user", "hello"),
+            _msg("tool", "orphan result"),  # no tool_call_id
+            _msg("assistant", "hi"),
+        ]
+        removed = AgentLoop._repair_tool_pairing(messages)
+        assert removed >= 1
+        roles = [m.role if isinstance(m.role, str) else m.role.value for m in messages]
+        assert "tool" not in roles
+
+    def test_drops_tool_message_with_unmatched_tool_call_id(self):
+        AgentLoop = _get_agent_loop_class()
+        messages = [
+            _msg("user", "run"),
+            _assistant_with_tools(["call_A"]),
+            _tool_result("call_A"),
+            _tool_result("call_GHOST"),  # no matching tool_call
+        ]
+        removed = AgentLoop._repair_tool_pairing(messages)
+        assert removed >= 1
+        tool_ids = [
+            m.tool_call_id for m in messages
+            if getattr(m, "tool_call_id", None)
+        ]
+        assert "call_GHOST" not in tool_ids
+        assert "call_A" in tool_ids
+
+    def test_keeps_valid_paired_tool_messages(self):
+        AgentLoop = _get_agent_loop_class()
+        messages = [
+            _msg("user", "run two"),
+            _assistant_with_tools(["c1", "c2"]),
+            _tool_result("c1"),
+            _tool_result("c2"),
+            _msg("assistant", "done"),
+        ]
+        removed = AgentLoop._repair_tool_pairing(messages)
+        assert removed == 0
+        tool_msgs = [m for m in messages if getattr(m, "tool_call_id", None)]
+        assert len(tool_msgs) == 2
+
+    def test_removes_assistant_tool_calls_without_results(self):
+        AgentLoop = _get_agent_loop_class()
+        messages = [
+            _msg("user", "run"),
+            _assistant_with_tools(["c1", "c2"]),
+            _tool_result("c1"),  # only c1 answered, c2 has no result
+        ]
+        removed = AgentLoop._repair_tool_pairing(messages)
+        assert removed >= 1
+        assistant = messages[1]
+        remaining_ids = [tc.id for tc in (assistant.tool_calls or [])]
+        assert "c2" not in remaining_ids
+
+
+# ---------------------------------------------------------------------------
+# _reorder_tool_messages
+# ---------------------------------------------------------------------------
+
+class TestReorderToolMessages:
+    def test_moves_tool_result_adjacent_to_assistant(self):
+        AgentLoop = _get_agent_loop_class()
+        messages = [
+            _msg("user", "do something"),
+            _assistant_with_tools(["call_X"]),
+            _msg("user", "focus please"),  # interleaved user message
+            _tool_result("call_X"),
+        ]
+        moved = AgentLoop._reorder_tool_messages(messages)
+        assert moved > 0
+        roles = [m.role if isinstance(m.role, str) else m.role.value for m in messages]
+        assert roles == ["user", "assistant", "tool", "user"]
+
+    def test_no_change_when_already_ordered(self):
+        AgentLoop = _get_agent_loop_class()
+        messages = [
+            _msg("user", "run"),
+            _assistant_with_tools(["c1"]),
+            _tool_result("c1"),
+            _msg("assistant", "done"),
+        ]
+        moved = AgentLoop._reorder_tool_messages(messages)
+        assert moved == 0
+
+
+# ---------------------------------------------------------------------------
+# _normalize_runtime_tool_context
+# ---------------------------------------------------------------------------
+
+class TestNormalizeRuntimeToolContext:
+    def test_combined_reorder_and_repair(self):
+        AgentLoop = _get_agent_loop_class()
+        messages = [
+            _msg("user", "do it"),
+            _assistant_with_tools(["c1"]),
+            _msg("user", "focus"),
+            _tool_result("c1"),
+            _msg("tool", "orphan"),  # no tool_call_id
+        ]
+        normalized = AgentLoop._normalize_runtime_tool_context(messages)
+        assert normalized > 0
+        roles = [m.role if isinstance(m.role, str) else m.role.value for m in messages]
+        assert roles == ["user", "assistant", "tool", "user"]
+        tool_msgs = [m for m in messages if (m.role if isinstance(m.role, str) else m.role.value) == "tool"]
+        assert all(getattr(m, "tool_call_id", None) for m in tool_msgs)
+
+
+# ---------------------------------------------------------------------------
+# _uses_strict_tool_turn_order
+# ---------------------------------------------------------------------------
+
+class TestUsesStrictToolTurnOrder:
+    def _make_loop_stub(self, provider: str, model: str = "", base_url: str = ""):
+        """Create a minimal object with the attributes _uses_strict_tool_turn_order reads."""
+        AgentLoop = _get_agent_loop_class()
+
+        class Stub:
+            pass
+
+        stub = Stub()
+        stub.provider = provider
+        stub.model = model
+        stub.base_url = base_url
+        stub._uses_strict_tool_turn_order = AgentLoop._uses_strict_tool_turn_order.__get__(stub)
+        return stub
+
+    def test_openai_is_strict(self):
+        stub = self._make_loop_stub(provider="openai")
+        assert stub._uses_strict_tool_turn_order() is True
+
+    def test_openrouter_is_strict(self):
+        stub = self._make_loop_stub(provider="openrouter")
+        assert stub._uses_strict_tool_turn_order() is True
+
+    def test_gemini_is_strict(self):
+        stub = self._make_loop_stub(provider="gemini")
+        assert stub._uses_strict_tool_turn_order() is True
+
+    def test_gpt_model_is_strict(self):
+        stub = self._make_loop_stub(provider="custom", model="gpt-5.2")
+        assert stub._uses_strict_tool_turn_order() is True
+
+    def test_o3_model_is_strict(self):
+        stub = self._make_loop_stub(provider="custom", model="o3-mini")
+        assert stub._uses_strict_tool_turn_order() is True
+
+    def test_openai_base_url_is_strict(self):
+        stub = self._make_loop_stub(provider="custom", base_url="https://api.openai.com/v1")
+        assert stub._uses_strict_tool_turn_order() is True
+
+    def test_anthropic_not_strict(self):
+        stub = self._make_loop_stub(provider="anthropic", model="claude-sonnet-4.5")
+        assert stub._uses_strict_tool_turn_order() is False
+
+    def test_deepseek_not_strict(self):
+        stub = self._make_loop_stub(provider="deepseek", model="deepseek-chat")
+        assert stub._uses_strict_tool_turn_order() is False


### PR DESCRIPTION
## Summary
- Fix OpenAI API rejection: `messages with role 'tool' must be a response to a preceding message with 'tool_calls'`
- Root cause: session-injected tool messages lack `tool_call_id` metadata and were never normalized before the LLM call
- Add OpenAI/OpenRouter to strict tool turn order detection

## Root Causes
1. `_prepare_request_context()` never called `_normalize_runtime_tool_context()` — orphaned tool messages from session history went directly to the LLM
2. `_repair_tool_pairing()` skipped tool messages with `tool_call_id=None` (session-injected messages have no metadata)
3. `_uses_strict_tool_turn_order()` only detected Gemini, missing OpenAI which has the same requirement

## Fixes
- Call `_normalize_runtime_tool_context()` at the end of `_prepare_request_context()`
- Remove tool-role messages with missing `tool_call_id` in `_repair_tool_pairing()`
- Add OpenAI/OpenRouter to `_uses_strict_tool_turn_order()` detection

## Test plan
- [ ] Verify existing session with tool history loads without API error
- [ ] Confirm OpenAI provider no longer gets `messages.[N].role` rejection
- [ ] Verify Gemini strict ordering still works
- [ ] Test fresh sessions (no history) are unaffected


Made with [Cursor](https://cursor.com)