### PR TITLE
Add reasoning effort controls across spoon-bot config and channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ To enable Telegram or other channel integrations, create a `config.yaml` in the 
 agent:
   provider: anthropic
   model: claude-sonnet-4-20250514
+  reasoning_effort: high          # Optional: low/medium/high/xhigh
   # api_key: sk-xxx  # Or use environment variable
 
 channels:
@@ -111,6 +112,20 @@ channels:
         groups:
           enabled: false
           require_mention: true
+```
+
+`reasoning_effort` is provider-neutral. spoon-bot maps it to each provider's current API shape:
+
+- OpenAI: `reasoning_effort`
+- Anthropic: `thinking: {type: "adaptive"}` plus `output_config.effort` on supported models
+- Gemini 3: `thinkingLevel`
+- Gemini 2.5: `thinkingBudget`
+- OpenRouter: `extra_body.reasoning.effort`
+
+Environment override:
+
+```bash
+export SPOON_BOT_REASONING_EFFORT=medium
 ```
 
 **Telegram setup:**
@@ -145,7 +160,7 @@ spoon-bot agent -m "List files in the current directory"
 ```bash
 # OpenAI GPT-5.2
 export OPENAI_API_KEY=your-key
-spoon-bot agent --provider openai --model gpt-5.2
+spoon-bot agent --provider openai --model gpt-5.2 --reasoning-effort xhigh
 
 # DeepSeek V3.2
 export DEEPSEEK_API_KEY=your-key
@@ -153,12 +168,30 @@ spoon-bot agent --provider deepseek --model deepseek-v3.2
 
 # Google Gemini 3
 export GEMINI_API_KEY=your-key
-spoon-bot agent --provider gemini --model gemini-3-flash-preview
+spoon-bot agent --provider gemini --model gemini-3-flash-preview --reasoning-effort high
 
 # OpenRouter (access 400+ models with one key)
 export OPENROUTER_API_KEY=sk-or-xxx
-spoon-bot agent --provider openrouter --model anthropic/claude-sonnet-4.5
+spoon-bot agent --provider openrouter --model anthropic/claude-sonnet-4.5 --reasoning-effort high
 ```
+
+### Reasoning Effort
+
+You can set the default reasoning intensity in YAML, env, CLI, or Telegram `/think`.
+
+```yaml
+agent:
+  provider: openai
+  model: gpt-5.2
+  reasoning_effort: xhigh
+```
+
+```bash
+spoon-bot agent --reasoning-effort medium
+spoon-bot gateway --reasoning-effort high
+```
+
+Telegram `/think` now exposes `Off`, `Low`, `Medium`, `High`, and `X-High`. Older saved values like `basic` and `extended` are still accepted and mapped to `low` and `high`.
 
 ## LLM Providers
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,6 +13,12 @@
 agent:
   model: "anthropic/claude-sonnet-4.6"  # or "other-model-name"
   provider: "openrouter" # openai, openrouter, anthropic, google, etc.
+  reasoning_effort: "high"  # Optional: low/medium/high/xhigh (provider-dependent)
+                             # OpenAI: Chat Completions -> reasoning_effort
+                             # Anthropic: adaptive thinking + output_config.effort
+                             # Gemini 3: thinkingLevel, Gemini 2.5: thinkingBudget
+                             # OpenRouter: extra_body.reasoning.effort
+                             # Env override: SPOON_BOT_REASONING_EFFORT=medium
   workspace: "~/.spoon-bot/workspace"
   max_iterations: 20
   tool_profile: "core"  # Options: core, coding, web3, research, full
@@ -83,6 +89,7 @@ channels:
         # Agent configuration for this bot
         agent_config:
           tool_profile: "full"  # This bot uses all tools
+          # reasoning_effort: "medium"  # Optional per-channel override
           # Or specify individual tools:
           # enabled_tools:
           #   - shell

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -369,6 +369,7 @@ class AgentLoop:
         provider_retry_base_delay: float = 1.0,
         provider_retry_max_delay: float = 60.0,
         provider_retry_backoff_factor: float = 2.0,
+        reasoning_effort: str | None = None,
     ) -> None:
         """
         Initialize the agent loop.
@@ -402,6 +403,7 @@ class AgentLoop:
             self._config = validate_agent_loop_params(
                 workspace=workspace,
                 model=model,
+                reasoning_effort=reasoning_effort,
                 max_iterations=max_iterations,
                 shell_timeout=shell_timeout,
                 shell_max_timeout=shell_max_timeout,
@@ -426,6 +428,7 @@ class AgentLoop:
         self.provider = provider
         self.api_key = api_key
         self.base_url = base_url
+        self.reasoning_effort = self._config.reasoning_effort
         self.max_iterations = self._config.max_iterations
         self.shell_timeout = self._config.shell_timeout
         self.shell_max_timeout = self._config.shell_max_timeout
@@ -1257,6 +1260,7 @@ class AgentLoop:
         media: list[str] | None = None,
         session_key: str | None = None,
         attachments: list[dict[str, Any]] | None = None,
+        reasoning_effort: str | None = None,
     ) -> str:
         """
         Process a user message and return the agent's response.
@@ -1287,6 +1291,7 @@ class AgentLoop:
             logger.debug(f"Switched to session: {session_key}")
 
         logger.info(f"Processing message: {message[:100]}...")
+        effective_reasoning_effort = reasoning_effort or getattr(self, "reasoning_effort", None)
 
         # Refresh memory context
         try:
@@ -1350,7 +1355,13 @@ class AgentLoop:
                     ):
                         await self._agent.add_message("user", runtime_message)
                     retry_requires_runtime_message_check = False
-                    result = await self._run_agent_with_retry(label="process")
+                    run_kwargs: dict[str, Any] = {}
+                    if (
+                        effective_reasoning_effort
+                        and self._callable_accepts_kwarg(self._agent.run, "reasoning_effort")
+                    ):
+                        run_kwargs["reasoning_effort"] = effective_reasoning_effort
+                    result = await self._run_agent_with_retry(label="process", **run_kwargs)
 
                     logger.debug(f"Agent result type: {type(result)}")
                     if hasattr(result, 'content'):
@@ -2503,6 +2514,7 @@ class AgentLoop:
         media: list[str] | None = None,
         attachments: list[dict[str, Any]] | None = None,
         thinking: bool = False,
+        reasoning_effort: str | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Stream a response with typed chunks.
@@ -2523,6 +2535,7 @@ class AgentLoop:
 
         logger.info(f"Streaming message: {message[:100]}...")
         self._reset_reasoning_capture()
+        effective_reasoning_effort = reasoning_effort or getattr(self, "reasoning_effort", None)
 
         # Refresh memory context
         try:
@@ -2593,6 +2606,11 @@ class AgentLoop:
                     run_kwargs: dict[str, Any] = {}
                     if thinking and self._callable_accepts_kwarg(self._agent.run, "thinking"):
                         run_kwargs["thinking"] = True
+                    if (
+                        effective_reasoning_effort
+                        and self._callable_accepts_kwarg(self._agent.run, "reasoning_effort")
+                    ):
+                        run_kwargs["reasoning_effort"] = effective_reasoning_effort
 
                     def _drain_queue() -> None:
                         while not self._agent.output_queue.empty():
@@ -2954,6 +2972,7 @@ class AgentLoop:
         media: list[str] | None = None,
         session_key: str | None = None,
         attachments: list[dict[str, Any]] | None = None,
+        reasoning_effort: str | None = None,
     ) -> tuple[str, str | None]:
         """
         Process a user message and return the agent's response with thinking content.
@@ -2977,6 +2996,7 @@ class AgentLoop:
 
         logger.info(f"Processing message (with thinking): {message[:100]}...")
         self._reset_reasoning_capture()
+        effective_reasoning_effort = reasoning_effort or getattr(self, "reasoning_effort", None)
         original_system_prompt: str | None = None
         original_base_system_prompt: object = _MISSING
 
@@ -3012,6 +3032,11 @@ class AgentLoop:
             run_kwargs: dict[str, Any] = {}
             if self._callable_accepts_kwarg(self._agent.run, "thinking"):
                 run_kwargs["thinking"] = True
+            if (
+                effective_reasoning_effort
+                and self._callable_accepts_kwarg(self._agent.run, "reasoning_effort")
+            ):
+                run_kwargs["reasoning_effort"] = effective_reasoning_effort
             with bind_tool_owner(self._current_tool_owner_key()):
                 result = await self._agent.run(**run_kwargs)
 
@@ -3589,6 +3614,7 @@ async def create_agent(
     auto_reload_interval: float = 5.0,
     config_path: Path | str | None = None,
     yolo_mode: bool = False,
+    reasoning_effort: str | None = None,
     **kwargs: Any,
 ) -> AgentLoop:
     """
@@ -3657,6 +3683,7 @@ async def create_agent(
         auto_reload_interval=auto_reload_interval,
         config_path=config_path,
         yolo_mode=yolo_mode,
+        reasoning_effort=reasoning_effort,
         **kwargs,
     )
 

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2203,6 +2203,13 @@ class AgentLoop:
         def _log_agent_reasoning():
             """Extract and log the agent's reasoning text from its last response."""
             from spoon_bot.utils.privacy import mask_secrets
+            provider_reasoning = getattr(agent, "last_reasoning_summary", None)
+            if isinstance(provider_reasoning, str) and provider_reasoning.strip():
+                safe_reasoning = mask_secrets(provider_reasoning.strip())
+                captured = agent_loop._capture_reasoning_text(safe_reasoning)
+                if captured:
+                    logger.info(f"💭 Agent reasoning: {captured}")
+                return
             if not hasattr(agent, 'memory') or not agent.memory.messages:
                 return
             for msg in reversed(agent.memory.messages[-3:]):
@@ -3052,7 +3059,10 @@ class AgentLoop:
             elif hasattr(result, "thinking"):
                 thinking_content = result.thinking
             elif hasattr(result, "metadata") and isinstance(result.metadata, dict):
-                thinking_content = result.metadata.get("thinking")
+                thinking_content = (
+                    result.metadata.get("thinking")
+                    or result.metadata.get("reasoning")
+                )
             if self._looks_like_duplicate_thinking(thinking_content, final_content):
                 thinking_content = None
 

--- a/spoon_bot/channels/config.py
+++ b/spoon_bot/channels/config.py
@@ -719,6 +719,7 @@ def load_agent_config(config_path: str | Path | None = None) -> dict[str, Any]:
 
         model, provider, api_key, base_url, workspace, yolo_mode,
         max_iterations, tool_profile, enabled_tools, enable_skills,
+        reasoning_effort,
         shell_timeout, shell_max_timeout, max_output, context_window,
         session_store_backend, session_store_dsn, session_store_db_path,
         mcp_config (alias: mcp_servers)
@@ -757,6 +758,7 @@ def load_agent_config(config_path: str | Path | None = None) -> dict[str, Any]:
         "model": ["SPOON_BOT_DEFAULT_MODEL", "SPOON_MODEL"],
         "workspace": ["SPOON_BOT_WORKSPACE_PATH"],
         "max_iterations": ["SPOON_BOT_MAX_ITERATIONS", "SPOON_MAX_STEPS"],
+        "reasoning_effort": ["SPOON_BOT_REASONING_EFFORT"],
         "enable_skills": ["SPOON_BOT_ENABLE_SKILLS"],
         "yolo_mode": ["SPOON_BOT_YOLO_MODE"],
         "shell_timeout": ["SPOON_BOT_SHELL_TIMEOUT"],

--- a/spoon_bot/channels/manager.py
+++ b/spoon_bot/channels/manager.py
@@ -201,6 +201,18 @@ class ChannelManager:
         return False
 
     @staticmethod
+    def _reasoning_effort_from_think_level(level: object) -> str | None:
+        normalized = str(level or "").strip().lower()
+        aliases = {
+            "basic": "low",
+            "extended": "high",
+        }
+        normalized = aliases.get(normalized, normalized)
+        if normalized in {"low", "medium", "high", "xhigh"}:
+            return normalized
+        return None
+
+    @staticmethod
     def _sanitize_workspace_segment(name: str) -> str:
         """Return a filesystem-safe workspace segment for a channel/account."""
         safe = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in name)
@@ -1001,18 +1013,31 @@ class ChannelManager:
 
             # Route based on think/verbose metadata from channel
             think_level = message.metadata.get("think_level", "off")
+            raw_think_level = str(think_level or "").strip().lower()
+            reasoning_effort = self._reasoning_effort_from_think_level(think_level)
+            thinking_enabled = raw_think_level in {
+                "basic",
+                "extended",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+            }
             media = message.media if message.has_media else None
             raw_attachments = message.metadata.get("attachments")
             attachments = raw_attachments if isinstance(raw_attachments, list) else None
             session_key = message.session_key or None
 
-            if think_level != "off":
-                response_text, thinking_content = await agent.process_with_thinking(
-                    message=content,
-                    media=media,
-                    session_key=session_key,
-                    attachments=attachments,
-                )
+            if thinking_enabled:
+                process_kwargs = {
+                    "message": content,
+                    "media": media,
+                    "session_key": session_key,
+                    "attachments": attachments,
+                }
+                if reasoning_effort:
+                    process_kwargs["reasoning_effort"] = reasoning_effort
+                response_text, thinking_content = await agent.process_with_thinking(**process_kwargs)
                 # Include thinking content in verbose mode
                 if message.metadata.get("verbose") and thinking_content:
                     response_text = (
@@ -1020,12 +1045,15 @@ class ChannelManager:
                         f"---\n\n{response_text}"
                     )
             else:
-                response_text = await agent.process(
-                    message=content,
-                    media=media,
-                    session_key=session_key,
-                    attachments=attachments,
-                )
+                process_kwargs = {
+                    "message": content,
+                    "media": media,
+                    "session_key": session_key,
+                    "attachments": attachments,
+                }
+                if reasoning_effort:
+                    process_kwargs["reasoning_effort"] = reasoning_effort
+                response_text = await agent.process(**process_kwargs)
 
             self._circuit_breaker.record_success()
 

--- a/spoon_bot/channels/telegram/callbacks.py
+++ b/spoon_bot/channels/telegram/callbacks.py
@@ -14,7 +14,9 @@ from spoon_bot.channels.telegram.constants import (
     CALLBACK_PREFIX,
     MODEL_PROVIDERS,
     REASONING_LEVELS,
+    THINK_LEVEL_ALIASES,
     THINK_LEVELS,
+    normalize_think_level,
 )
 from spoon_bot.channels.telegram.keyboards import (
     build_commands_keyboard,
@@ -134,7 +136,10 @@ class CallbackRouter:
     # ------------------------------------------------------------------
 
     async def _on_think_select(self, query: Any, data: str, user_id: int) -> None:
-        level = data[len(CALLBACK_PREFIX["think"]):]
+        raw_level = data[len(CALLBACK_PREFIX["think"]):].strip().lower()
+        if raw_level not in THINK_LEVELS and raw_level not in THINK_LEVEL_ALIASES:
+            return
+        level = normalize_think_level(raw_level)
         if level not in THINK_LEVELS:
             return
 
@@ -144,7 +149,7 @@ class CallbackRouter:
         keyboard = build_think_keyboard(level)
         label = THINK_LEVELS[level]
         await query.edit_message_text(
-            f"*Think mode:* {label}\n\nSelect thinking level:",
+            f"*Think mode:* {label}\n\nSelect reasoning intensity:",
             reply_markup=keyboard,
             parse_mode="Markdown",
         )

--- a/spoon_bot/channels/telegram/commands.py
+++ b/spoon_bot/channels/telegram/commands.py
@@ -9,7 +9,12 @@ from loguru import logger
 from telegram import Update
 from telegram.ext import CommandHandler
 
-from spoon_bot.channels.telegram.constants import BOT_COMMANDS, REASONING_LEVELS, THINK_LEVELS
+from spoon_bot.channels.telegram.constants import (
+    BOT_COMMANDS,
+    REASONING_LEVELS,
+    THINK_LEVELS,
+    normalize_think_level,
+)
 from spoon_bot.channels.telegram.keyboards import (
     build_commands_keyboard,
     build_confirm_keyboard,
@@ -160,13 +165,13 @@ class CommandHandlers:
 
         try:
             state = self._get_state(update)
-            current = state.get("think_level", "off")
+            current = normalize_think_level(state.get("think_level", "off"))
             keyboard = build_think_keyboard(current)
 
             level_label = THINK_LEVELS.get(current, current)
             await self._reply(
                 update,
-                f"Think mode: {level_label}\n\nSelect thinking level:",
+                f"Think mode: {level_label}\n\nSelect reasoning intensity:",
                 reply_markup=keyboard,
             )
         except Exception as e:
@@ -272,7 +277,7 @@ class CommandHandlers:
                 f"*Provider:* `{self._agent.provider}`",
                 f"*Tools:* {active_count}/{total_count} active",
                 f"*Skills:* {len(skill_list)}",
-                f"*Think:* {THINK_LEVELS.get(state.get('think_level', 'off'), 'off')}",
+                f"*Think:* {THINK_LEVELS.get(normalize_think_level(state.get('think_level', 'off')), 'off')}",
                 f"*Verbose:* {'ON' if state.get('verbose') else 'OFF'}",
             ]
 

--- a/spoon_bot/channels/telegram/constants.py
+++ b/spoon_bot/channels/telegram/constants.py
@@ -73,9 +73,24 @@ MODELS_PER_PROVIDER_PAGE = 8
 
 THINK_LEVELS: dict[str, str] = {
     "off": "Disabled",
-    "basic": "Basic",
-    "extended": "Extended",
+    "low": "Low",
+    "medium": "Medium",
+    "high": "High",
+    "xhigh": "X-High",
 }
+
+THINK_LEVEL_ALIASES: dict[str, str] = {
+    "basic": "low",
+    "extended": "high",
+}
+
+
+def normalize_think_level(level: object) -> str:
+    normalized = str(level or "").strip().lower()
+    if not normalized:
+        return "off"
+    normalized = THINK_LEVEL_ALIASES.get(normalized, normalized)
+    return normalized if normalized in THINK_LEVELS else "off"
 
 # ---------------------------------------------------------------------------
 # Reasoning display levels for /reasoning command

--- a/spoon_bot/channels/telegram/keyboards.py
+++ b/spoon_bot/channels/telegram/keyboards.py
@@ -15,6 +15,7 @@ from spoon_bot.channels.telegram.constants import (
     MODELS_PER_PROVIDER_PAGE,
     REASONING_LEVELS,
     THINK_LEVELS,
+    normalize_think_level,
 )
 
 
@@ -95,16 +96,27 @@ def build_think_keyboard(current_level: str = "off") -> InlineKeyboardMarkup:
     Returns:
         InlineKeyboardMarkup with think level buttons.
     """
-    buttons: list[InlineKeyboardButton] = []
-    for level, label in THINK_LEVELS.items():
-        text = f"✓ {label}" if level == current_level else label
-        buttons.append(
-            InlineKeyboardButton(
-                text=text,
-                callback_data=f"{CALLBACK_PREFIX['think']}{level}",
+    normalized_current = normalize_think_level(current_level)
+    ordered_levels = list(THINK_LEVELS.items())
+    row_sizes = (2, 2, 1)
+
+    rows: list[list[InlineKeyboardButton]] = []
+    index = 0
+    for size in row_sizes:
+        row: list[InlineKeyboardButton] = []
+        for level, label in ordered_levels[index:index + size]:
+            text = f"✓ {label}" if level == normalized_current else label
+            row.append(
+                InlineKeyboardButton(
+                    text=text,
+                    callback_data=f"{CALLBACK_PREFIX['think']}{level}",
+                )
             )
-        )
-    return InlineKeyboardMarkup([buttons])
+        if row:
+            rows.append(row)
+        index += size
+
+    return InlineKeyboardMarkup(rows)
 
 
 def build_verbose_keyboard(current_state: bool = False) -> InlineKeyboardMarkup:

--- a/spoon_bot/cli.py
+++ b/spoon_bot/cli.py
@@ -178,6 +178,10 @@ def agent(
         None, "--base-url",
         help="Custom LLM API base URL (overrides YAML agent.base_url)",
     ),
+    reasoning_effort: Optional[str] = typer.Option(
+        None, "--reasoning-effort",
+        help="Reasoning effort hint (e.g. low/medium/high/xhigh)",
+    ),
     tool_profile: Optional[str] = typer.Option(
         None, "--tool-profile",
         help="Tool profile (core/coding/research/full) (overrides YAML agent.tool_profile)",
@@ -210,6 +214,7 @@ def agent(
         provider=provider,
         api_key=api_key,
         base_url=base_url,
+        reasoning_effort=reasoning_effort,
         tool_profile=tool_profile,
         workspace=workspace,
         max_iterations=max_iterations,
@@ -499,6 +504,7 @@ async def _run_agent(
     provider: Optional[str],
     api_key: Optional[str],
     base_url: Optional[str],
+    reasoning_effort: Optional[str],
     tool_profile: Optional[str],
     workspace: Optional[Path],
     max_iterations: int,
@@ -531,6 +537,7 @@ async def _run_agent(
     effective_model = model or agent_cfg.get("model")
     effective_base_url = base_url or agent_cfg.get("base_url")
     effective_api_key = api_key or agent_cfg.get("api_key")
+    effective_reasoning_effort = reasoning_effort or agent_cfg.get("reasoning_effort")
     effective_workspace = (
         workspace
         or (Path(agent_cfg["workspace"]) if agent_cfg.get("workspace") else None)
@@ -568,6 +575,7 @@ async def _run_agent(
         provider=effective_provider,
         api_key=effective_api_key,
         base_url=effective_base_url,
+        reasoning_effort=effective_reasoning_effort,
         workspace=effective_workspace,
         max_iterations=effective_max_iterations,
         enable_skills=effective_enable_skills,
@@ -921,6 +929,10 @@ def gateway(
         None, "--base-url",
         help="Custom LLM API base URL (overrides YAML agent.base_url)",
     ),
+    reasoning_effort: Optional[str] = typer.Option(
+        None, "--reasoning-effort",
+        help="Reasoning effort hint (e.g. low/medium/high/xhigh)",
+    ),
     tool_profile: Optional[str] = typer.Option(
         None, "--tool-profile",
         help="Tool profile (core/coding/research/full) (overrides YAML agent.tool_profile)",
@@ -959,6 +971,7 @@ def gateway(
         provider=provider,
         api_key=api_key,
         base_url=base_url,
+        reasoning_effort=reasoning_effort,
         tool_profile=tool_profile,
         workspace=workspace,
     ))
@@ -972,6 +985,7 @@ async def _run_gateway(
     provider: Optional[str] = None,
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     tool_profile: Optional[str] = None,
     workspace: Optional[Path] = None,
 ) -> None:
@@ -1006,6 +1020,7 @@ async def _run_gateway(
     effective_model = model or agent_cfg.get("model")
     effective_base_url = base_url or agent_cfg.get("base_url")
     effective_api_key = api_key or agent_cfg.get("api_key")
+    effective_reasoning_effort = reasoning_effort or agent_cfg.get("reasoning_effort")
     effective_workspace = (
         workspace
         or (Path(agent_cfg["workspace"]) if agent_cfg.get("workspace") else None)
@@ -1051,6 +1066,7 @@ async def _run_gateway(
         provider=effective_provider,
         api_key=effective_api_key,
         base_url=effective_base_url,
+        reasoning_effort=effective_reasoning_effort,
         workspace=effective_workspace,
         enable_skills=effective_enable_skills,
     )

--- a/spoon_bot/config.py
+++ b/spoon_bot/config.py
@@ -389,6 +389,10 @@ class AgentLoopConfig(BaseModel):
         default=None,
         description="LLM model name (uses provider default if not specified)"
     )
+    reasoning_effort: str | None = Field(
+        default=None,
+        description="Provider-neutral reasoning effort hint (mapped per provider)"
+    )
     max_iterations: int = Field(
         default=DEFAULT_MAX_ITERATIONS,
         ge=1,
@@ -638,6 +642,10 @@ class SpoonBotSettings(BaseSettings):
         default=None,
         description="Default model name"
     )
+    reasoning_effort: str | None = Field(
+        default=None,
+        description="Default provider-neutral reasoning effort hint"
+    )
 
     # Agent settings
     max_iterations: int = Field(
@@ -740,6 +748,7 @@ def validate_mcp_configs(configs: dict[str, dict[str, Any]]) -> dict[str, MCPSer
 def validate_agent_loop_params(
     workspace: Path | str | None = None,
     model: str | None = None,
+    reasoning_effort: str | None = None,
     max_iterations: int = DEFAULT_MAX_ITERATIONS,
     shell_timeout: int = DEFAULT_SHELL_TIMEOUT,
     max_output: int = DEFAULT_MAX_OUTPUT,
@@ -759,6 +768,7 @@ def validate_agent_loop_params(
     Args:
         workspace: Workspace directory path.
         model: LLM model name.
+        reasoning_effort: Provider-neutral reasoning effort hint.
         max_iterations: Maximum tool call iterations.
         shell_timeout: Default shell foreground timeout in seconds.
         max_output: Maximum output characters.
@@ -790,6 +800,7 @@ def validate_agent_loop_params(
     return AgentLoopConfig(
         workspace=workspace,  # type: ignore
         model=model,
+        reasoning_effort=reasoning_effort,
         max_iterations=max_iterations,
         shell_timeout=shell_timeout,
         shell_max_timeout=shell_max_timeout,

--- a/spoon_bot/core.py
+++ b/spoon_bot/core.py
@@ -93,6 +93,7 @@ class SpoonBotConfig:
     provider: str = ""
     api_key: str | None = None
     base_url: str | None = None
+    reasoning_effort: str | None = None
 
     # Agent settings
     max_steps: int = 15
@@ -127,6 +128,7 @@ class SpoonBotConfig:
             provider=cfg.get("provider", ""),
             api_key=cfg.get("api_key"),
             base_url=cfg.get("base_url"),
+            reasoning_effort=cfg.get("reasoning_effort"),
             max_steps=cfg.get("max_iterations", 15),
             mcp_servers=cfg.get("mcp_config", {}) or {},
             enable_skills=cfg.get("enable_skills", True),
@@ -156,6 +158,13 @@ class SpoonBot:
         self._skill_manager: SkillManager | None = None
         self._mcp_tools: list[MCPTool] = []
         self._initialized = False
+
+    def _apply_default_reasoning_effort(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        if self.config.reasoning_effort and kwargs.get("reasoning_effort") is None:
+            updated = dict(kwargs)
+            updated["reasoning_effort"] = self.config.reasoning_effort
+            return updated
+        return kwargs
 
     async def initialize(self) -> None:
         """Initialize all components."""
@@ -295,6 +304,7 @@ class SpoonBot:
         if not self._initialized:
             await self.initialize()
 
+        kwargs = self._apply_default_reasoning_effort(kwargs)
         result = await self._agent.run(message, **kwargs)
 
         if hasattr(result, "content"):
@@ -318,6 +328,7 @@ class SpoonBot:
         if not self._initialized:
             await self.initialize()
 
+        kwargs = self._apply_default_reasoning_effort(kwargs)
         messages = [{"role": "user", "content": message}]
         async for chunk in self._chatbot.astream(messages, **kwargs):
             if hasattr(chunk, "delta") and chunk.delta:
@@ -343,6 +354,7 @@ class SpoonBot:
         if not self._initialized:
             await self.initialize()
 
+        kwargs = self._apply_default_reasoning_effort(kwargs)
         response = await self._chatbot.ask_tool(
             messages=[{"role": "user", "content": message}],
             tools=tools,
@@ -472,11 +484,14 @@ async def create_agent(
         ... )
     """
     # If model/provider not explicitly passed, resolve from YAML/env
-    if not model or not provider:
+    cfg: dict[str, Any] = {}
+    if not model or not provider or kwargs.get("reasoning_effort") is None:
         from spoon_bot.channels.config import load_agent_config
         cfg = load_agent_config()
         model = model or cfg.get("model", "")
         provider = provider or cfg.get("provider", "")
+        if kwargs.get("reasoning_effort") is None and cfg.get("reasoning_effort") is not None:
+            kwargs["reasoning_effort"] = cfg.get("reasoning_effort")
 
     config = SpoonBotConfig(
         model=model,

--- a/spoon_bot/gateway/api/v1/agent.py
+++ b/spoon_bot/gateway/api/v1/agent.py
@@ -191,6 +191,7 @@ async def _stream_sse(
     media: list[str] | None,
     attachments: list[dict[str, Any]] | None,
     thinking: bool,
+    reasoning_effort: str | None = None,
     *,
     session_key: str | None = None,
     user_id: str | None = None,
@@ -221,6 +222,8 @@ async def _stream_sse(
             setattr(agent, "user_id", user_id or "anonymous")
 
             kwargs = {"message": message, "thinking": thinking}
+            if reasoning_effort:
+                kwargs["reasoning_effort"] = reasoning_effort
             if media:
                 kwargs["media"] = media
             if attachments:
@@ -310,6 +313,7 @@ async def chat(
     # Determine options
     stream = request.options.stream if request.options else False
     thinking = request.options.thinking if request.options else False
+    reasoning_effort = request.options.reasoning_effort if request.options else None
 
     try:
         agent = get_agent()
@@ -345,6 +349,7 @@ async def chat(
                     media or None,
                     attachments or None,
                     thinking,
+                    reasoning_effort,
                     session_key=session_key,
                     user_id=owner_user_id,
                     trace_id=trace_id,
@@ -368,6 +373,8 @@ async def chat(
                 setattr(agent, "user_id", owner_user_id)
 
                 kwargs = {"message": message}
+                if reasoning_effort:
+                    kwargs["reasoning_effort"] = reasoning_effort
                 if media:
                     kwargs["media"] = media
                 if attachments:

--- a/spoon_bot/gateway/models/requests.py
+++ b/spoon_bot/gateway/models/requests.py
@@ -14,6 +14,7 @@ class ChatOptions(BaseModel):
     max_iterations: int = Field(default=20, ge=1, le=100)
     stream: bool = False
     thinking: bool = False
+    reasoning_effort: str | None = None
     model: str | None = None
 
 

--- a/spoon_bot/gateway/server.py
+++ b/spoon_bot/gateway/server.py
@@ -133,6 +133,8 @@ async def _lifespan(app: FastAPI):
             create_kwargs["tool_profile"] = agent_cfg["tool_profile"]
         if agent_cfg.get("max_iterations"):
             create_kwargs["max_iterations"] = int(agent_cfg["max_iterations"])
+        if agent_cfg.get("reasoning_effort") is not None:
+            create_kwargs["reasoning_effort"] = str(agent_cfg["reasoning_effort"])
 
         agent = await create_agent(**create_kwargs)
         app_module._agent = agent

--- a/spoon_bot/gateway/websocket/handler.py
+++ b/spoon_bot/gateway/websocket/handler.py
@@ -668,6 +668,7 @@ class WebSocketHandler:
 
         stream = params.get("stream", False)
         thinking = params.get("thinking", False)
+        reasoning_effort = params.get("reasoning_effort")
         task_id = f"task_{uuid4().hex[:8]}"
         trace_id = new_trace_id()
         span = TimerSpan("ws_chat")
@@ -699,7 +700,13 @@ class WebSocketHandler:
                     if stream:
                         # Streaming mode: emit chunks via WSEvent
                         full_content = ""
-                        async for chunk_data in agent.stream(message=message, media=media, attachments=attachments, thinking=thinking):
+                        async for chunk_data in agent.stream(
+                            message=message,
+                            media=media,
+                            attachments=attachments,
+                            thinking=thinking,
+                            reasoning_effort=reasoning_effort,
+                        ):
                             check_budget("stream", config.budget.stream_timeout_ms, span.elapsed_ms)
                             if self._cancel_requested:
                                 break
@@ -776,9 +783,19 @@ class WebSocketHandler:
                     else:
                         # Non-streaming mode
                         if thinking:
-                            response, thinking_content = await agent.process_with_thinking(message=message, media=media, attachments=attachments)
+                            response, thinking_content = await agent.process_with_thinking(
+                                message=message,
+                                media=media,
+                                attachments=attachments,
+                                reasoning_effort=reasoning_effort,
+                            )
                         else:
-                            response = await agent.process(message=message, media=media, attachments=attachments)
+                            response = await agent.process(
+                                message=message,
+                                media=media,
+                                attachments=attachments,
+                                reasoning_effort=reasoning_effort,
+                            )
                             thinking_content = None
                         check_budget("request", config.budget.request_timeout_ms, span.elapsed_ms)
 

--- a/tests/test_config_and_channels.py
+++ b/tests/test_config_and_channels.py
@@ -53,6 +53,36 @@ class TestConfigPriority:
         assert result["model"] == "claude-sonnet"  # from YAML
         assert result["provider"] == "openai"       # from env
 
+    def test_reasoning_effort_loaded_from_yaml_or_env(self, tmp_path, monkeypatch):
+        """reasoning_effort should resolve like other top-level agent settings."""
+        cfg_path = self._write_yaml(tmp_path, """\
+            agent:
+              reasoning_effort: high
+        """)
+        monkeypatch.setenv("SPOON_BOT_REASONING_EFFORT", "low")
+
+        from spoon_bot.channels.config import load_agent_config
+
+        result = load_agent_config(cfg_path)
+        assert result["reasoning_effort"] == "high"
+
+        cfg_path = self._write_yaml(tmp_path, """\
+            agent:
+              provider: openai
+        """)
+        result = load_agent_config(cfg_path)
+        assert result["reasoning_effort"] == "low"
+
+    def test_validate_agent_loop_params_accepts_reasoning_effort(self, tmp_path):
+        from spoon_bot.config import validate_agent_loop_params
+
+        config = validate_agent_loop_params(
+            workspace=tmp_path / "workspace",
+            reasoning_effort="high",
+        )
+
+        assert config.reasoning_effort == "high"
+
     def test_no_hidden_defaults_for_model_provider(self, tmp_path, monkeypatch):
         """model/provider must not have silent fallback values."""
         for var in (
@@ -363,6 +393,66 @@ class TestManagedChannelAgents:
             attachments=None,
         )
         manager._channel_agents["feishu:testbot"].process.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handle_message_maps_legacy_think_level_to_reasoning_effort(self):
+        from spoon_bot.bus.events import InboundMessage
+        from spoon_bot.channels.manager import ChannelManager
+
+        manager = ChannelManager()
+        manager._agent = MagicMock()
+        manager._channel_agents["feishu:testbot"] = MagicMock()
+        manager._channel_agents["feishu:testbot"].process_with_thinking = AsyncMock(
+            return_value=("ok", "thoughts")
+        )
+
+        message = InboundMessage(
+            content="analyze this",
+            channel="feishu:testbot",
+            sender_id="u1",
+            metadata={"chat_type": "dm", "is_dm": True, "think_level": "basic"},
+        )
+
+        response = await manager._handle_message(message)
+
+        assert response is not None
+        manager._channel_agents["feishu:testbot"].process_with_thinking.assert_awaited_once_with(
+            message="analyze this",
+            media=None,
+            session_key="default",
+            attachments=None,
+            reasoning_effort="low",
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_message_maps_canonical_think_level_to_reasoning_effort(self):
+        from spoon_bot.bus.events import InboundMessage
+        from spoon_bot.channels.manager import ChannelManager
+
+        manager = ChannelManager()
+        manager._agent = MagicMock()
+        manager._channel_agents["feishu:testbot"] = MagicMock()
+        manager._channel_agents["feishu:testbot"].process_with_thinking = AsyncMock(
+            return_value=("ok", "thoughts")
+        )
+
+        message = InboundMessage(
+            content="analyze this",
+            channel="feishu:testbot",
+            sender_id="u1",
+            metadata={"chat_type": "dm", "is_dm": True, "think_level": "xhigh"},
+        )
+
+        response = await manager._handle_message(message)
+
+        assert response is not None
+        manager._channel_agents["feishu:testbot"].process_with_thinking.assert_awaited_once_with(
+            message="analyze this",
+            media=None,
+            session_key="default",
+            attachments=None,
+            reasoning_effort="xhigh",
+        )
 
     @pytest.mark.asyncio
     async def test_handle_message_creates_scoped_group_agent_for_group_override(self, tmp_path):

--- a/tests/test_core_reasoning_effort.py
+++ b/tests/test_core_reasoning_effort.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from spoon_bot.core import SpoonBot, SpoonBotConfig, create_agent
+
+
+@pytest.mark.asyncio
+async def test_spoonbot_chat_uses_configured_reasoning_effort():
+    bot = SpoonBot(
+        SpoonBotConfig(
+            model="gpt-5.4",
+            provider="openai",
+            reasoning_effort="high",
+        )
+    )
+    bot._initialized = True
+    bot._agent = SimpleNamespace(
+        run=AsyncMock(return_value=SimpleNamespace(content="ok"))
+    )
+
+    response = await bot.chat("hi")
+
+    assert response == "ok"
+    assert bot._agent.run.await_args.kwargs["reasoning_effort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_core_create_agent_loads_reasoning_effort_from_config():
+    with patch(
+        "spoon_bot.channels.config.load_agent_config",
+        return_value={
+            "model": "gpt-5.4",
+            "provider": "openai",
+            "reasoning_effort": "high",
+        },
+    ), patch.object(SpoonBot, "initialize", new=AsyncMock(return_value=None)):
+        bot = await create_agent()
+
+    assert bot.config.reasoning_effort == "high"

--- a/tests/test_runtime_message_sequence.py
+++ b/tests/test_runtime_message_sequence.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -120,3 +120,39 @@ async def test_install_anti_loop_tracker_keeps_prompt_for_non_strict_providers()
 
     assert seen_prompts == ["prompt"]
     assert agent._agent.next_step_prompt == "prompt"
+
+
+@pytest.mark.requires_spoon_core
+@pytest.mark.asyncio
+async def test_install_anti_loop_tracker_logs_provider_reasoning_summary():
+    from spoon_bot.agent.loop import AgentLoop
+
+    async def base_think() -> bool:
+        agent._agent.last_reasoning_summary = "Plan from provider summary"
+        return True
+
+    agent = AgentLoop.__new__(AgentLoop)
+    agent.workspace = Path("/workspace")
+    agent.provider = "openai"
+    agent.model = "gpt-5.2"
+    agent.base_url = None
+    agent._agent = MagicMock()
+    agent._agent.think = base_think
+    agent._agent._spoon_bot_base_think = base_think
+    agent._agent.next_step_prompt = "prompt"
+    agent._agent.tool_calls = []
+    agent._agent.memory = MagicMock()
+    agent._agent.memory.messages = []
+    agent._agent.last_reasoning_summary = None
+    agent._compress_runtime_context = MagicMock(return_value=0)
+    agent._latest_reasoning_excerpt = None
+    agent._pending_reasoning_chunks = []
+
+    with patch("spoon_bot.agent.loop.logger.info") as log_info:
+        AgentLoop._install_anti_loop_tracker(agent, "prompt")
+        await agent._agent.think()
+
+    assert any(
+        call.args and call.args[0] == "💭 Agent reasoning: Plan from provider summary"
+        for call in log_info.call_args_list
+    )

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -908,6 +908,37 @@ class TestAgentLoopThinkingMode:
         assert thinking == "reasoning trace"
         assert loop._agent.run_calls == [((), {"thinking": True})]
 
+    @pytest.mark.asyncio
+    async def test_process_with_thinking_passes_reasoning_effort_when_runtime_accepts_it(self, tmp_dir: Path):
+        from spoon_bot.agent.loop import AgentLoop
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop._initialized = True
+        loop.workspace = tmp_dir
+        loop.memory = MagicMock()
+        loop.memory.get_memory_context = MagicMock(return_value=None)
+        loop.context = MagicMock()
+        loop._agent = _ThinkingRuntimeAgent("answer", "reasoning trace")
+        loop._session = Session(session_key="thinking_mode")
+        loop.sessions = MagicMock()
+        loop.sessions.save = MagicMock()
+        loop._prepare_request_context = AsyncMock(return_value=None)
+        loop._build_step_prompt = lambda message: f"prompt::{message}"
+        loop._install_anti_loop_tracker = lambda prompt: None
+        loop._restore_agent_think = lambda: None
+        loop._auto_commit = False
+        loop._git = None
+
+        response, thinking = await AgentLoop.process_with_thinking(
+            loop,
+            message="Explain the answer.",
+            reasoning_effort="high",
+        )
+
+        assert response == "answer"
+        assert thinking == "reasoning trace"
+        assert loop._agent.run_calls == [((), {"thinking": True, "reasoning_effort": "high"})]
+
 
 # ============================================================================
 # §5  create_session_store factory

--- a/tests/test_stream_thinking_fix.py
+++ b/tests/test_stream_thinking_fix.py
@@ -42,6 +42,11 @@ def _make_mock_stream_agent(run_impl) -> tuple[object, asyncio.Queue, asyncio.Ev
     agent._build_step_prompt = MagicMock(return_value="prompt")
     agent._install_anti_loop_tracker = MagicMock()
     agent._restore_agent_think = MagicMock()
+
+    async def _run_with_retry_stub(**kwargs):
+        return await run_impl(**kwargs)
+
+    agent._run_agent_with_retry = AsyncMock(side_effect=_run_with_retry_stub)
     agent._callable_accepts_kwarg = AgentLoop._callable_accepts_kwarg
     return agent, oq, td
 
@@ -75,6 +80,34 @@ class TestStreamThinkingParam:
 
         assert len(run_kwargs_captured) == 1
         assert run_kwargs_captured[0].get("thinking") is True
+
+    @pytest.mark.asyncio
+    async def test_reasoning_effort_passed_to_run(self):
+        """stream() should forward reasoning_effort alongside thinking mode."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        run_kwargs_captured: list[dict] = []
+
+        async def mock_run(**kwargs):
+            run_kwargs_captured.append(kwargs)
+            result = MagicMock()
+            result.content = "done"
+            return result
+
+        agent, _, _ = _make_mock_stream_agent(mock_run)
+
+        chunks = []
+        async for chunk in AgentLoop.stream(
+            agent,
+            message="test",
+            thinking=True,
+            reasoning_effort="high",
+        ):
+            chunks.append(chunk)
+
+        assert len(run_kwargs_captured) == 1
+        assert run_kwargs_captured[0].get("thinking") is True
+        assert run_kwargs_captured[0].get("reasoning_effort") == "high"
 
     @pytest.mark.asyncio
     async def test_thinking_false_not_passed_to_run(self):

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -1884,6 +1884,45 @@ class TestAgentLoopProcessWithThinking:
         assert thinking == "Metadata thought"
 
     @pytest.mark.asyncio
+    async def test_thinking_from_reasoning_metadata(self):
+        """Should fall back to provider reasoning metadata when thinking is absent."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        result = MagicMock(spec=["content", "metadata"])
+        result.content = "Answer"
+        result.metadata = {"reasoning": "Provider reasoning summary"}
+
+        mock_inner_agent = MagicMock()
+        mock_inner_agent.run = AsyncMock(return_value=result)
+        mock_inner_agent.add_message = AsyncMock()
+
+        agent = MagicMock(spec=AgentLoop)
+        agent._initialized = True
+        agent._agent = mock_inner_agent
+        agent._session = MagicMock()
+        agent._session.add_message = MagicMock()
+        agent.sessions = MagicMock()
+        agent.memory = MagicMock()
+        agent.memory.get_memory_context = MagicMock(return_value=None)
+        agent.context = MagicMock()
+        agent._auto_commit = False
+        agent._git = None
+        agent._prepare_request_context = AsyncMock()
+        agent._build_runtime_message_content = MagicMock(side_effect=lambda *args, **kwargs: args[1])
+        agent._build_step_prompt = MagicMock(return_value="prompt")
+        agent._install_anti_loop_tracker = MagicMock()
+        agent._restore_agent_think = MagicMock()
+        agent._callable_accepts_kwarg = MagicMock(return_value=True)
+        agent._reset_reasoning_capture = MagicMock()
+        agent._looks_like_duplicate_thinking = AgentLoop._looks_like_duplicate_thinking.__get__(agent, AgentLoop)
+        agent._normalize_comparable_text = AgentLoop._normalize_comparable_text
+        agent._latest_reasoning_excerpt = None
+
+        response, thinking = await AgentLoop.process_with_thinking(agent, message="test")
+        assert response == "Answer"
+        assert thinking == "Provider reasoning summary"
+
+    @pytest.mark.asyncio
     async def test_does_not_fall_back_to_tracked_reasoning_when_provider_omits_thinking_fields(self):
         """process_with_thinking() should not reuse tracked assistant output as thinking."""
         from spoon_bot.agent.loop import AgentLoop

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -32,6 +32,7 @@ class TestChatOptionsModel:
         opts = ChatOptions()
         assert opts.stream is False
         assert opts.thinking is False
+        assert opts.reasoning_effort is None
         assert opts.max_iterations == 20
         assert opts.model is None
 
@@ -74,6 +75,14 @@ class TestChatOptionsModel:
         parsed = json.loads(json_str)
         assert parsed["stream"] is True
         assert parsed["thinking"] is True
+
+    def test_reasoning_effort_roundtrip(self):
+        from spoon_bot.gateway.models.requests import ChatOptions
+
+        opts = ChatOptions(stream=True, thinking=True, reasoning_effort="high")
+        data = opts.model_dump()
+        restored = ChatOptions(**data)
+        assert restored.reasoning_effort == "high"
 
 
 class TestStreamChunkModel:


### PR DESCRIPTION
## Summary
- thread a provider-neutral `reasoning_effort` setting through config, gateway startup, channels, and agent loop entrypoints
- keep websocket/runtime request options backward compatible while letting core apply the latest provider-specific reasoning controls
- add tests around config loading, runtime sequencing, and stream option round-trips for reasoning effort

## Verification
- `PYTHONPATH=C:\Users\Ricky\Documents\Project\XSpoonAi\spoon-bot-pr-reasoning-effort C:\Users\Ricky\Documents\Project\XSpoonAi\.venv\Scripts\python.exe -m pytest tests/test_core_reasoning_effort.py tests/test_streaming_thinking.py tests/test_session_persistence.py -k "reasoning_effort" -q`
- `PYTHONPATH=C:\Users\Ricky\Documents\Project\XSpoonAi\spoon-bot-pr-reasoning-effort C:\Users\Ricky\Documents\Project\XSpoonAi\.venv\Scripts\python.exe -m pytest tests/test_config_and_channels.py -k "reasoning_effort" -q`

## Notes
- The full `tests/test_streaming_thinking.py` file still has pre-existing `AgentLoop.stream` failures outside the reasoning-effort subset.
- This PR pairs with the core provider follow-up PR for Anthropic/Gemini/OpenRouter reasoning fixes.
