### PR TITLE
feat: conversation history search + segment-aware context compaction

### DIFF
--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -81,6 +81,7 @@ from spoon_bot.agent.tools.filesystem import (
     ListDirTool,
 )
 from spoon_bot.agent.tools.grep import GrepTool
+from spoon_bot.agent.tools.history_search import SearchHistoryTool
 from spoon_bot.agent.tools.execution_context import (
     bind_tool_owner,
     build_tool_owner_key,
@@ -503,6 +504,18 @@ class AgentLoop:
 
         self._git = GitManager(self.workspace) if auto_commit else None
 
+        # Deploy built-in skills to the runtime workspace (idempotent)
+        try:
+            from spoon_bot.skills.builtin import ensure_builtin_skills
+            _newly_installed = ensure_builtin_skills(self.workspace)
+            if _newly_installed:
+                logger.info(
+                    f"Installed {len(_newly_installed)} built-in skill(s): "
+                    f"{[p.name for p in _newly_installed]}"
+                )
+        except Exception as exc:
+            logger.debug(f"Built-in skill deployment skipped: {exc}")
+
         # Skill paths: runtime workspace + bundled skills shipped with spoon-bot
         self._skill_paths = [self.workspace / "skills"]
         _bundled_skills = Path(__file__).resolve().parent.parent.parent / "workspace" / "skills"
@@ -549,6 +562,14 @@ class AgentLoop:
         # Stop flag: set by stop_current_task(), cleared on next process() call
         self._stop_requested = False
 
+        # Tracks the skill name injected by _pre_inject_matched_skill()
+        self._pre_injected_skill_name: str | None = None
+
+        # Conditional activation — file paths touched during this session.
+        # Skills declaring ``paths`` frontmatter are dormant until a touched
+        # file matches one of their patterns (mirrors Claude Code behaviour).
+        self._touched_paths: set[str] = set()
+
         # Provider retry config (exponential backoff for transient LLM errors)
         self._retry_config = RetryConfig(
             max_retries=self._config.provider_max_retries,
@@ -594,31 +615,27 @@ class AgentLoop:
         skills_xml = self._build_skills_for_prompt()
         if skills_xml:
             system_prompt += f"\n## Installed Skills\n{skills_xml}\n"
-
-        if skills_xml:
             system_prompt += (
-                "\n> **FIRST ACTION**: Match the user's request to a skill above "
-                "by name/description, then `read_file` its `<location>` path. "
-                "Do NOT call skill_marketplace, web_search, or filesystem search first.\n"
+                "\nWhen a user request matches a skill by name, description, or "
+                "`when_to_use`, read its SKILL.md first (unless already pre-loaded "
+                "in the message). Follow the skill's own procedures directly.\n"
             )
 
         system_prompt += (
             "\n## Workflow\n"
             f"You have up to {self.max_iterations} steps. Minimize steps.\n\n"
-            "1. **Read SKILL.md**: If a skill above matches, `read_file` its path. "
-            "Extract config, addresses, commands.\n"
-            "2. **Execute**: Run commands from SKILL.md directly via shell "
-            "(`cast`, `curl`, etc.). Do NOT write script files.\n"
-            "3. **Done**: Summarize result. Save key state to `soul.md`.\n\n"
-            "Only use `web_search` if NO installed skill matches the task.\n\n"
+            "1. If a [PRE-LOADED SKILL] block is present in the user message, "
+            "execute its instructions immediately — do NOT re-read it.\n"
+            "2. Otherwise, if a skill matches, `read_file` its SKILL.md path, "
+            "then execute.\n"
+            "3. Run commands from SKILL.md directly via shell. Do NOT write script files.\n"
+            "4. Summarize result when done.\n\n"
             "### Rules\n"
             "- Do NOT re-read files already in context.\n"
             "- `source .env.local` before commands that need env vars.\n"
             "- If a command fails, analyze the error and retry with fixes.\n"
             "- Follow user instructions exactly — respect specific IDs, names, actions.\n"
-            "\n## Agent Memory (soul.md)\n"
-            "After completing significant actions, append a timestamped entry to `soul.md`.\n"
-            "Format: `## YYYY-MM-DD HH:MM — <topic>` followed by bullet points.\n"
+            "- Only use `web_search` if NO installed skill matches the task.\n"
         )
 
         # Inject soul.md content if it exists
@@ -776,11 +793,17 @@ class AgentLoop:
         _extra_read: list[Path] = [Path.home()]
         if self.yolo_mode:
             _extra_read.extend(p for p in self.workspace.parents if p != Path.home())
-        self.tools.register(ReadFileTool(workspace=self.workspace, additional_read_paths=_extra_read, max_output=15000))
-        self.tools.register(WriteFileTool(workspace=self.workspace))
-        self.tools.register(EditFileTool(workspace=self.workspace))
-        self.tools.register(ListDirTool(workspace=self.workspace, additional_read_paths=_extra_read))
-        self.tools.register(GrepTool(workspace=self.workspace))
+
+        _file_tools = [
+            ReadFileTool(workspace=self.workspace, additional_read_paths=_extra_read, max_output=15000),
+            WriteFileTool(workspace=self.workspace),
+            EditFileTool(workspace=self.workspace),
+            ListDirTool(workspace=self.workspace, additional_read_paths=_extra_read),
+            GrepTool(workspace=self.workspace),
+        ]
+        for ft in _file_tools:
+            ft._path_touch_callback = lambda p: self.record_touched_paths(p)
+            self.tools.register(ft)
 
         # Self-management tools
         self.tools.register(SelfConfigTool())
@@ -804,6 +827,29 @@ class AgentLoop:
 
         # Background task tool
         self.tools.register(SpawnTool())
+
+        # Conversation history search — fallback for post-compaction
+        # recovery of earlier tool calls / results / user messages.
+        #
+        # Pass a resolver callable instead of relying on
+        # ``set_default_session_key`` being invoked on every session
+        # switch.  Session switches can happen from multiple call
+        # sites (gateway WS handler, channel code, REST routes) and
+        # not all of them go through AgentLoop's explicit switch
+        # hooks, so a pull-based lookup is safer than push-based
+        # synchronisation.
+        def _current_session_key() -> str | None:
+            sess = self._session
+            return sess.session_key if sess is not None else None
+
+        self._history_search_tool = SearchHistoryTool(
+            self.sessions,
+            default_session_key=(
+                self._session.session_key if self._session is not None else None
+            ),
+            session_key_resolver=_current_session_key,
+        )
+        self.tools.register(self._history_search_tool)
 
         # Web tools
         self.tools.register(WebSearchTool())
@@ -1071,40 +1117,33 @@ class AgentLoop:
         return sum(len(m.get("content", "")) for m in self._session.messages) // 4
 
     def _trim_context_if_needed(self) -> int:
-        """Auto-trim oldest messages if context budget approaches the limit.
+        """No-op placeholder.
 
-        Keeps at minimum the two most recent messages (last user + assistant pair).
-        Raises ContextOverflowError if even after trimming the context is too large.
+        History compaction is deliberately **runtime-only** now
+        (``_compress_runtime_context`` / ``_force_compress_runtime_context``):
+
+        * The persisted session store remains the authoritative, *complete*
+          transcript — tool-call inputs/outputs included.
+        * Runtime memory (what the LLM sees) is compacted in place with
+          full tool-pair atomicity (see :meth:`_compress_runtime_context`).
+        * Anything that falls out of runtime memory is still reachable via
+          the :class:`SearchHistoryTool` because the store was never
+          mutated.
+
+        Earlier versions of this method would call
+        ``self._session.messages.pop(0)`` whenever the *session-side*
+        estimate exceeded the window.  That permanently destroyed
+        persisted history (breaking ``search_history`` / cross-session
+        recall), and could leave orphan tool results behind because the
+        pop was not tool-segment-aware.  Both problems are now fixed by
+        simply refusing to touch the session store here.
+
+        A future bounded-history policy (e.g. "cap each JSONL at N
+        messages") should be implemented as a dedicated, opt-in pruner
+        that *also* updates any search index — NOT inside the per-turn
+        context-budget path.
         """
-        if not self._session.messages:
-            return 0
-
-        budget = int(self.context_window * 0.75)
-        estimated = self._estimate_token_count()
-
-        if estimated <= budget:
-            return 0
-
-        logger.warning(
-            f"Context approaching limit: ~{estimated:,} tokens "
-            f"(budget: {budget:,}, window: {self.context_window:,}). "
-            f"Trimming oldest messages."
-        )
-
-        messages = self._session.messages
-        trimmed_count = 0
-        while len(messages) > 2 and self._estimate_token_count() > budget:
-            removed = messages.pop(0)
-            trimmed_count += 1
-            logger.debug(
-                f"Trimmed message: role={removed.get('role')}, "
-                f"len={len(removed.get('content', ''))}"
-            )
-
-        # If still over the hard limit after trimming, raise
-        final_estimate = self._estimate_token_count()
-        if final_estimate > self.context_window:
-            raise ContextOverflowError(final_estimate, self.context_window)
+        return 0
 
         return trimmed_count
 
@@ -1129,6 +1168,65 @@ class AgentLoop:
             if hasattr(self._session, "get_messages")
             else self._session.get_history()
         )
+
+        # Lazy import — these are only needed when re-hydrating tool-call
+        # metadata persisted by _capture_turn_tool_trace.
+        try:
+            from spoon_ai.schema import Function as _CoreFunction  # noqa: F401
+        except Exception:  # pragma: no cover - defensive
+            _CoreFunction = None  # type: ignore[assignment]
+
+        def _rehydrate_tool_calls(raw: Any) -> list | None:
+            """Convert persisted ``tool_calls`` extras back into ToolCall objects.
+
+            The tool-trace capture path stores ``tool_calls`` as a list of
+            plain dicts (``{"id", "type", "function": {"name", "arguments"}}``).
+            spoon-core's ``agent.add_message`` expects ``ToolCall`` models so
+            it can normalise / serialise them for the LLM provider.  Without
+            this rehydration the tool_call <-> tool-result pairing is lost on
+            every history sync and ``drop_orphaned_tool_messages`` will prune
+            every tool result before the next API call.
+            """
+            if not raw or _CoreFunction is None:
+                return None
+            if not isinstance(raw, list):
+                return None
+            out: list = []
+            for item in raw:
+                if isinstance(item, CoreToolCall):
+                    out.append(item)
+                    continue
+                if not isinstance(item, dict):
+                    continue
+                tc_id = item.get("id")
+                if not tc_id:
+                    continue
+                fn = item.get("function") or {}
+                if isinstance(fn, dict):
+                    name = fn.get("name") or ""
+                    arguments = fn.get("arguments") or ""
+                else:
+                    name = getattr(fn, "name", "") or ""
+                    arguments = getattr(fn, "arguments", "") or ""
+                if arguments is not None and not isinstance(arguments, str):
+                    try:
+                        arguments = json.dumps(arguments, ensure_ascii=False)
+                    except Exception:
+                        arguments = str(arguments)
+                try:
+                    out.append(
+                        CoreToolCall(
+                            id=str(tc_id),
+                            type=str(item.get("type") or "function"),
+                            function=_CoreFunction(
+                                name=str(name), arguments=str(arguments or "")
+                            ),
+                        )
+                    )
+                except Exception:
+                    continue
+            return out or None
+
         for msg in history_messages:
             role = str(msg.get("role", "")).strip().lower()
             if role not in {"user", "assistant", "tool"}:
@@ -1157,8 +1255,26 @@ class AgentLoop:
                 attachments=attachments,
             )
 
+            # Forward tool metadata so runtime memory stays a faithful
+            # replay of what the LLM originally saw.  Without these
+            # fields, ``drop_orphaned_tool_messages`` will strip every
+            # persisted tool result before the next provider call
+            # because its ``tool_call_id`` will be ``None``.
+            extra_kwargs: dict[str, Any] = {}
+            if role == "tool":
+                tc_id = msg.get("tool_call_id")
+                if tc_id:
+                    extra_kwargs["tool_call_id"] = str(tc_id)
+                tool_name = msg.get("name") or msg.get("tool_name")
+                if tool_name:
+                    extra_kwargs["tool_name"] = str(tool_name)
+            elif role == "assistant":
+                rehydrated = _rehydrate_tool_calls(msg.get("tool_calls"))
+                if rehydrated:
+                    extra_kwargs["tool_calls"] = rehydrated
+
             try:
-                await self._agent.add_message(role, content)
+                await self._agent.add_message(role, content, **extra_kwargs)
                 injected_count += 1
             except Exception as exc:
                 logger.warning(
@@ -1169,28 +1285,206 @@ class AgentLoop:
         return injected_count
 
     async def _prepare_request_context(self) -> None:
-        """Prepare request context by trimming and injecting session history."""
-        trimmed_count = self._trim_context_if_needed()
+        """Prepare request context by injecting session history and, if
+        needed, compacting runtime memory *before* the LLM sees it.
+
+        Persisted history (``self._session.messages``) is the authoritative
+        store and is never trimmed here — see
+        :meth:`_trim_context_if_needed` for the reasoning.  Runtime memory
+        is what goes into the next provider request, so that is the only
+        thing compacted by this method.
+        """
+        trimmed_count = self._trim_context_if_needed()  # always 0 now
         injected_count = await self._sync_runtime_history_from_session()
 
         # Repair tool-call ordering after history injection — session storage
         # may not preserve tool_call_id metadata, producing orphaned tool
         # messages that providers (OpenAI, Gemini, etc.) reject.
         repaired = 0
+        messages_ref: list | None = None
         if self._agent and hasattr(self._agent, "memory"):
-            messages = getattr(self._agent.memory, "messages", None)
-            if isinstance(messages, list):
-                repaired = self._normalize_runtime_tool_context(messages)
+            messages_ref = getattr(self._agent.memory, "messages", None)
+            if isinstance(messages_ref, list):
+                repaired = self._normalize_runtime_tool_context(messages_ref)
 
-        estimated_tokens = self._estimate_token_count()
+        # Proactively compact runtime memory before the turn so we don't
+        # have to rely on a provider token-overflow error to trigger
+        # compaction.  ``_compress_runtime_context`` is a no-op when we're
+        # under the 50 % budget.  It preserves tool-pair atomicity and
+        # (if a drop happens) injects a ``[history-compacted]`` marker
+        # message pointing the model at ``search_history``.
+        compressed = 0
+        if isinstance(messages_ref, list) and messages_ref:
+            try:
+                compressed = self._compress_runtime_context()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug(f"Proactive runtime compression skipped: {exc}")
+
+        runtime_tokens = self._estimate_runtime_tokens()
+        session_tokens = self._estimate_token_count()
 
         logger.info(
             f"Session context prepared: session={self.session_key}, "
             f"injected_messages={injected_count}, "
-            f"estimated_tokens~{estimated_tokens}, "
+            f"runtime_tokens~{runtime_tokens}, session_tokens~{session_tokens}, "
             f"trimmed_messages={trimmed_count}"
             + (f", repaired_tool_order={repaired}" if repaired else "")
+            + (f", compressed_actions={compressed}" if compressed else "")
         )
+
+    def _runtime_memory_snapshot_index(self) -> int:
+        """Return the current length of runtime memory.
+
+        Callers snapshot this *before* a turn begins so they can later
+        iterate only the messages that were produced during that turn —
+        typically tool-call and intermediate assistant messages that we
+        want to persist for post-hoc search/recovery.
+        """
+        try:
+            return len(AgentLoop._get_runtime_memory_messages(self))
+        except Exception:
+            return 0
+
+    def _capture_turn_tool_trace(self, start_index: int) -> list[dict[str, Any]]:
+        """Capture tool-call artifacts added since ``start_index``.
+
+        We persist three kinds of messages so a later ``search_history``
+        query can surface them after context compaction:
+
+        * ``role=tool`` — the full tool result the model actually saw.
+          We keep ``tool_call_id`` and ``name`` as extras so they can be
+          correlated with the originating assistant call and filtered by
+          tool name.
+        * ``role=assistant`` messages that carry non-empty ``tool_calls``
+          but no final user-visible content (the "I'm about to call X"
+          turns).  These are normally squashed into the final assistant
+          reply; without them, future history sync can't pair tool
+          results with their call-site.  We serialize ``tool_calls`` in
+          the same shape the OpenAI function-calling spec uses.
+
+        The final assistant reply is persisted separately by the caller.
+        ``role=user`` messages are untouched — the caller handles those
+        with their own media / attachment kwargs.
+        """
+        if not isinstance(start_index, int) or start_index < 0:
+            return []
+
+        messages = AgentLoop._get_runtime_memory_messages(self)
+        if not messages or start_index >= len(messages):
+            return []
+
+        captured: list[dict[str, Any]] = []
+        for msg in messages[start_index:]:
+            role = AgentLoop._stream_message_role(msg).lower()
+            if role not in ("tool", "assistant"):
+                continue
+
+            content = AgentLoop._stream_message_attr(msg, "text_content", None)
+            if not isinstance(content, str) or not content:
+                content = AgentLoop._stream_message_attr(msg, "content", "") or ""
+            if not isinstance(content, str):
+                try:
+                    content = json.dumps(content, ensure_ascii=False)
+                except Exception:
+                    content = str(content)
+
+            extras: dict[str, Any] = {}
+
+            if role == "tool":
+                tool_call_id = AgentLoop._stream_message_attr(msg, "tool_call_id", None) \
+                    or AgentLoop._stream_message_attr(msg, "id", None)
+                if tool_call_id:
+                    extras["tool_call_id"] = str(tool_call_id)
+                name = AgentLoop._stream_message_attr(msg, "name", None)
+                if name:
+                    extras["name"] = str(name)
+            else:  # assistant
+                tool_calls = AgentLoop._stream_message_attr(msg, "tool_calls", None) or []
+                serialized: list[dict[str, Any]] = []
+                for tc in tool_calls:
+                    tc_id = getattr(tc, "id", None) or (tc.get("id") if isinstance(tc, dict) else None)
+                    tc_type = (
+                        getattr(tc, "type", None)
+                        or (tc.get("type") if isinstance(tc, dict) else None)
+                        or "function"
+                    )
+                    fn = getattr(tc, "function", None) or (
+                        tc.get("function") if isinstance(tc, dict) else None
+                    )
+                    if fn is not None:
+                        tc_name = getattr(fn, "name", None) or (
+                            fn.get("name") if isinstance(fn, dict) else None
+                        )
+                        tc_args = getattr(fn, "arguments", None) or (
+                            fn.get("arguments") if isinstance(fn, dict) else None
+                        )
+                    else:
+                        tc_name = getattr(tc, "name", None)
+                        tc_args = getattr(tc, "arguments", None)
+
+                    if tc_args is not None and not isinstance(tc_args, str):
+                        try:
+                            tc_args = json.dumps(tc_args, ensure_ascii=False)
+                        except Exception:
+                            tc_args = str(tc_args)
+
+                    if tc_name or tc_id:
+                        serialized.append(
+                            {
+                                "id": tc_id,
+                                "type": tc_type,
+                                "function": {
+                                    "name": tc_name,
+                                    "arguments": tc_args or "",
+                                },
+                            }
+                        )
+                if not serialized:
+                    # Nothing tool-related to preserve; the final assistant
+                    # reply is saved separately by the caller.
+                    continue
+                extras["tool_calls"] = serialized
+
+            captured.append({"role": role, "content": content, "extras": extras})
+        return captured
+
+    def _persist_turn_tool_trace(self, start_index: int) -> int:
+        """Append captured tool-trace messages to ``self._session``.
+
+        Returns the number of messages appended.  Skipped silently when the
+        session has no room or persistence is disabled via
+        ``SPOON_BOT_PERSIST_TOOL_TRACE=false`` / ``0`` / ``no``.
+        """
+        if not self._should_persist_tool_trace():
+            return 0
+
+        try:
+            trace = self._capture_turn_tool_trace(start_index)
+        except Exception as exc:
+            logger.debug(f"Tool-trace capture failed: {exc}")
+            return 0
+
+        if not trace:
+            return 0
+
+        for entry in trace:
+            try:
+                self._session.add_message(
+                    entry["role"], entry["content"], **entry.get("extras", {})
+                )
+            except Exception as exc:
+                logger.debug(f"Tool-trace persist skipped a message: {exc}")
+        return len(trace)
+
+    @staticmethod
+    def _should_persist_tool_trace() -> bool:
+        """Whether to persist tool traces alongside user/assistant turns."""
+        import os as _os
+
+        raw = _os.getenv("SPOON_BOT_PERSIST_TOOL_TRACE")
+        if raw is None:
+            return True
+        return raw.strip().lower() not in {"0", "false", "no", "off"}
 
     def _build_runtime_message_content(
         self,
@@ -1284,9 +1578,17 @@ class AgentLoop:
         if session_key and session_key != self.session_key:
             self._session = self.sessions.get_or_create(session_key)
             self.session_key = session_key
+            if getattr(self, "_history_search_tool", None) is not None:
+                try:
+                    self._history_search_tool.set_default_session_key(session_key)
+                except Exception:
+                    pass
             logger.debug(f"Switched to session: {session_key}")
 
         logger.info(f"Processing message: {message[:100]}...")
+
+        # Reset per-request state
+        self._pre_injected_skill_name = None
 
         # Refresh memory context
         try:
@@ -1323,6 +1625,10 @@ class AgentLoop:
         )
         if isinstance(runtime_message, str):
             message = runtime_message
+
+        # Snapshot runtime memory length before this turn begins so we can
+        # later persist the tool-call trace produced during the turn.
+        _pre_turn_memory_index = self._runtime_memory_snapshot_index()
 
         # Build a minimal per-step prompt with the user's request for context.
         # The anti-loop tracker will dynamically append progress info.
@@ -1425,6 +1731,7 @@ class AgentLoop:
                 _strip_attachment_context(message, attachments or []),
                 **save_kwargs,
             )
+            self._persist_turn_tool_trace(_pre_turn_memory_index)
             self._session.add_message("assistant", final_content)
             self.sessions.save(self._session)
         except Exception as e:
@@ -1893,6 +2200,84 @@ class AgentLoop:
             return role == "tool"
         return False
 
+    @classmethod
+    def _snap_drop_end_to_turn_boundary(
+        cls, messages: list, keep_head: int, desired_end: int
+    ) -> int:
+        """Return an index <= desired_end that sits on a safe boundary.
+
+        A *safe* drop boundary is a position ``k`` where:
+          * ``messages[k]`` is ``role="user"`` (start of the next turn), OR
+          * ``messages[k]`` is ``role="assistant"`` with no ``tool_calls`` and
+            not followed immediately by a ``role="tool"`` message (i.e. the
+            tool chain that the previous assistant opened is fully settled
+            at the end of index ``k - 1``).
+
+        Snapping ensures we never split an assistant(tool_calls) → tool(result)
+        pair, which would leak orphans the provider rejects.  If no boundary
+        is found, we fall back to ``keep_head`` (i.e. drop nothing) so the
+        safety invariant wins over the token-budget target.
+        """
+        if desired_end <= keep_head:
+            return keep_head
+        end = min(desired_end, len(messages))
+
+        def _role(i: int) -> str | None:
+            if i < 0 or i >= len(messages):
+                return None
+            return cls._message_role_value(messages[i])
+
+        def _has_tool_calls(i: int) -> bool:
+            if i < 0 or i >= len(messages):
+                return False
+            tc = getattr(messages[i], "tool_calls", None)
+            return bool(tc)
+
+        # Walk backwards from desired_end looking for a clean cut.  The cut
+        # index k means "delete messages[keep_head:k]", so messages[k]
+        # becomes the new first non-head message.
+        for k in range(end, keep_head, -1):
+            role = _role(k)
+            if role == "user":
+                return k
+            if role == "assistant" and not _has_tool_calls(k):
+                if _role(k + 1) != "tool":
+                    return k
+        return keep_head
+
+    def _insert_compaction_marker(self, messages: list, dropped: int) -> None:
+        """Insert a runtime-only marker telling the model history was trimmed.
+
+        The marker is a ``role="user"`` system-style message that documents
+        how many prior messages were removed from runtime memory and points
+        the model at the :class:`SearchHistoryTool` as the recovery path.
+        It is **not** persisted to the session store — the store still holds
+        the full transcript — so adding the marker is idempotent across
+        turns.
+        """
+        if not self._agent or not hasattr(self._agent, "memory"):
+            return
+        try:
+            from spoon_ai.schema import Message, Role  # lazy import
+        except Exception:  # pragma: no cover - defensive
+            return
+
+        marker_text = (
+            "[history-compacted] "
+            f"{dropped} older message(s) (including any tool-call/result pairs) "
+            "were removed from this turn's in-memory context to fit the token "
+            "budget.  The full transcript is preserved on disk — if you need "
+            "an earlier tool result, argument, or user statement, call the "
+            "`search_history` tool (scope='current')."
+        )
+        try:
+            marker = Message(role=Role.USER, content=marker_text)
+        except Exception:
+            return
+
+        insert_at = 1 if messages else 0
+        messages.insert(insert_at, marker)
+
     def _compress_runtime_context(self) -> int:
         """Proactively compress the agent's runtime context.
 
@@ -1953,16 +2338,39 @@ class AgentLoop:
                 compressed += 1
 
         # Phase 3: If still over budget, drop oldest rounds (keep first + last 8).
+        #
+        # *Segment-aware* drop: we only cut along user-turn boundaries so a
+        # drop never splits an ``assistant(tool_calls) -> tool(result)``
+        # chain.  Partial splits would leak through as orphaned tool
+        # messages and the LLM provider would reject the whole request.
+        # The persisted session store is untouched, so anything dropped
+        # here remains reachable via ``search_history``.
         estimated = self._estimate_runtime_tokens()
+        dropped_in_phase3 = 0
         if estimated > budget and len(messages) > 12:
             keep_head = 1
             keep_tail_drop = min(8, len(messages) - 1)
             droppable = len(messages) - keep_head - keep_tail_drop
             if droppable > 4:
-                drop_count = droppable // 2
-                del messages[keep_head:keep_head + drop_count]
-                compressed += drop_count
-                logger.info(f"Phase 3: dropped {drop_count} oldest messages")
+                desired = droppable // 2
+                snap_end = self._snap_drop_end_to_turn_boundary(
+                    messages, keep_head, keep_head + desired
+                )
+                actual_drop = max(0, snap_end - keep_head)
+                if actual_drop > 0:
+                    del messages[keep_head:keep_head + actual_drop]
+                    compressed += actual_drop
+                    dropped_in_phase3 = actual_drop
+                    logger.info(
+                        f"Phase 3: dropped {actual_drop} oldest messages "
+                        f"(segment-snapped from desired {desired})"
+                    )
+
+        # Phase 3b: Insert a compaction marker so the model knows prior
+        # turns are recoverable via ``search_history``.  The marker is
+        # runtime-only; it never touches the persisted session.
+        if dropped_in_phase3 > 0:
+            self._insert_compaction_marker(messages, dropped_in_phase3)
 
         # Phase 4: Repair tool_use/tool_result pairing broken by message deletion.
         compressed += self._repair_tool_pairing(messages)
@@ -1997,14 +2405,23 @@ class AgentLoop:
                 msg.content = compressed_content
                 compressed += 1
 
-        # Drop all but first + last 6 messages
+        # Drop all but first + last 6 messages (segment-aware)
+        dropped = 0
         if len(messages) > 8:
             keep_head = 1
             keep_tail = min(6, len(messages) - 1)
-            drop_count = len(messages) - keep_head - keep_tail
-            if drop_count > 0:
-                del messages[keep_head:keep_head + drop_count]
-                compressed += drop_count
+            desired_end = len(messages) - keep_tail
+            snap_end = self._snap_drop_end_to_turn_boundary(
+                messages, keep_head, desired_end
+            )
+            actual_drop = max(0, snap_end - keep_head)
+            if actual_drop > 0:
+                del messages[keep_head:keep_head + actual_drop]
+                compressed += actual_drop
+                dropped = actual_drop
+
+        if dropped > 0:
+            self._insert_compaction_marker(messages, dropped)
 
         # Repair tool pairing broken by message deletion
         compressed += self._repair_tool_pairing(messages)
@@ -2554,6 +2971,10 @@ class AgentLoop:
         if isinstance(runtime_message, str):
             message = runtime_message
 
+        # Snapshot runtime memory length before the turn so we can persist
+        # the tool-call trace produced while streaming.
+        _pre_turn_memory_index = self._runtime_memory_snapshot_index()
+
         try:
             capture_manager = capture_tool_outputs()
             tool_output_capture_scope = capture_manager.__enter__()
@@ -2943,6 +3364,10 @@ class AgentLoop:
                     _strip_attachment_context(message, attachments or []),
                     **save_kwargs,
                 )
+                # Persist intermediate tool-call artifacts generated while
+                # streaming so they remain searchable even after runtime
+                # context compaction.
+                self._persist_turn_tool_trace(_pre_turn_memory_index)
                 self._session.add_message("assistant", full_content)
                 self.sessions.save(self._session)
             except Exception as e:
@@ -2973,6 +3398,11 @@ class AgentLoop:
         if session_key and session_key != self.session_key:
             self._session = self.sessions.get_or_create(session_key)
             self.session_key = session_key
+            if getattr(self, "_history_search_tool", None) is not None:
+                try:
+                    self._history_search_tool.set_default_session_key(session_key)
+                except Exception:
+                    pass
             logger.debug(f"Switched to session: {session_key}")
 
         logger.info(f"Processing message (with thinking): {message[:100]}...")
@@ -2998,6 +3428,11 @@ class AgentLoop:
         )
         if isinstance(runtime_message, str):
             message = runtime_message
+
+        # Snapshot runtime memory length *before* adding the new user turn
+        # so we can later collect the tool-call trace produced during this
+        # turn and persist it for post-hoc search.
+        _pre_turn_memory_index = self._runtime_memory_snapshot_index()
 
         try:
             _base_prompt = self._select_next_step_prompt(message, thinking=True)
@@ -3054,6 +3489,10 @@ class AgentLoop:
                 _strip_attachment_context(message, attachments or []),
                 **save_kwargs,
             )
+            # Persist intermediate tool-call artifacts (tool results and the
+            # assistant messages that called them) so they remain searchable
+            # even after runtime context compaction.
+            self._persist_turn_tool_trace(_pre_turn_memory_index)
             self._session.add_message("assistant", final_content)
             self.sessions.save(self._session)
         except Exception as e:
@@ -3078,72 +3517,405 @@ class AgentLoop:
             raw = _re.sub(r'^([A-Za-z]):', lambda m: f'/{m.group(1).lower()}', raw)
         return raw
 
-    def _pre_inject_matched_skill(self, message: str) -> str:
-        """Match user message to an installed skill and prepend SKILL.md content.
+    # Directories in the workspace root that are never skills
+    _WORKSPACE_INFRA_DIRS = frozenset({
+        "skills", "logs", "sessions", "memory",
+        "channels", "wallet", ".git",
+    })
 
-        Saves 2-5 agent steps by providing skill content upfront so the
-        agent can start executing immediately without calling read_file.
+    # Common stop words filtered out during skill-matching token comparison
+    _SKILL_MATCH_STOP_WORDS = frozenset({
+        "when", "use", "this", "the", "for", "and", "with",
+        "that", "from", "needs", "need", "should", "also",
+        "through", "using", "codex", "claude", "agent",
+        "local", "based", "first", "only", "needed", "prefer", "logic",
+    })
+
+    # Scoring weights for _pre_inject_matched_skill (tune here, not inline)
+    _SCORE_NAME_TOKEN = 2
+    _SCORE_TRIGGER = 3
+    _SCORE_WHEN_TO_USE = 4
+    _SCORE_DESCRIPTION = 1
+    _SCORE_THRESHOLD = 2
+
+    # ------------------------------------------------------------------
+    # Conditional activation helpers
+    # ------------------------------------------------------------------
+
+    def record_touched_paths(self, *paths: str | Path) -> None:
+        """Register file paths the agent has interacted with.
+
+        Called by file-oriented tools (read_file, write_file, edit_file, etc.)
+        so that path-conditional skills can be activated dynamically.
+
+        Also performs **dynamic discovery**: walks up from the touched path
+        looking for directories containing ``SKILL.md`` and adds them to
+        ``_skill_paths`` if not already known (inspired by Claude Code's
+        ``discoverSkillDirsForPaths``).
+        """
+        for p in paths:
+            resolved = Path(p)
+            if not resolved.is_absolute():
+                resolved = self.workspace / resolved
+            try:
+                resolved = resolved.resolve()
+            except OSError:
+                pass
+
+            try:
+                rel = str(resolved.relative_to(self.workspace))
+            except (ValueError, OSError):
+                rel = str(p)
+            self._touched_paths.add(rel.replace("\\", "/"))
+
+            self._discover_skills_near(resolved)
+
+    def _discover_skills_near(self, file_path: Path) -> None:
+        """Walk up from *file_path* looking for ``skills/`` directories.
+
+        When a directory containing ``SKILL.md`` files is found and is not
+        already in ``_skill_paths``, it is added dynamically.  This mirrors
+        Claude Code's ``discoverSkillDirsForPaths`` which walks up from every
+        file operation to find project-level ``.claude/skills/`` directories.
+
+        Only walks up to ``self.workspace`` (never above).
+        """
+        known = {str(Path(sp).resolve()) for sp in self._skill_paths}
+        current = file_path.parent if file_path.is_file() else file_path
+
+        try:
+            ws_resolved = self.workspace.resolve()
+        except OSError:
+            return
+
+        while True:
+            try:
+                if not current.is_relative_to(ws_resolved):
+                    break
+            except (TypeError, ValueError):
+                break
+
+            skills_dir = current / "skills"
+            if skills_dir.is_dir() and str(skills_dir.resolve()) not in known:
+                has_skill = any(
+                    (child / "SKILL.md").exists()
+                    for child in skills_dir.iterdir()
+                    if child.is_dir()
+                )
+                if has_skill:
+                    self._skill_paths.append(skills_dir)
+                    known.add(str(skills_dir.resolve()))
+                    logger.info(f"Dynamic skill discovery: found {skills_dir}")
+
+            if current == ws_resolved:
+                break
+            current = current.parent
+
+    @staticmethod
+    def _skill_paths_match(
+        patterns: list[str], touched: set[str], workspace: Path | None = None,
+    ) -> bool:
+        """Return True if any *touched* file matches at least one *pattern*.
+
+        Patterns use gitignore-style globs (``fnmatch``).  A leading ``!``
+        negates (exclude) the pattern — same semantics as ``.gitignore``.
+        An empty *patterns* list means "always active" (unconditional).
+        """
+        from fnmatch import fnmatch
+
+        if not patterns:
+            return True
+        if not touched:
+            return False
+
+        for fp in touched:
+            included = False
+            for pat in patterns:
+                negate = pat.startswith("!")
+                glob = pat.lstrip("!")
+                if fnmatch(fp, glob) or fnmatch(fp, f"**/{glob}"):
+                    included = not negate
+            if included:
+                return True
+        return False
+
+    @staticmethod
+    def _parse_skill_frontmatter(skill_md: Path) -> dict[str, str | list[str]]:
+        """Extract description, when_to_use, triggers, and paths from SKILL.md YAML frontmatter.
+
+        The ``paths`` field (list of gitignore-style glob patterns) enables
+        conditional activation: skills declaring ``paths`` are only active when
+        recently-touched files match at least one pattern.  Skills without
+        ``paths`` are unconditionally active.
         """
         import re as _re
 
+        result: dict[str, str | list[str]] = {
+            "description": "", "when_to_use": "", "triggers": "", "paths": [],
+        }
+        try:
+            raw = skill_md.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            return result
+
+        fm = _re.match(r'^---\s*\n(.*?)\n---', raw, _re.DOTALL)
+        if not fm:
+            for line in raw.split("\n")[1:20]:
+                stripped = line.strip()
+                if stripped and not stripped.startswith(("#", "---", "```")):
+                    result["description"] = stripped[:300]
+                    break
+            return result
+
+        fm_text = fm.group(1)
+        in_multiline = ""
+        in_paths_list = False
+        trigger_fragments: list[str] = []
+        paths_list: list[str] = []
+
+        for line in fm_text.split("\n"):
+            stripped = line.strip()
+
+            if in_paths_list:
+                if stripped.startswith("- "):
+                    paths_list.append(stripped[2:].strip().strip("'\""))
+                    continue
+                elif line.startswith("  ") or line.startswith("\t"):
+                    if stripped.startswith("- "):
+                        paths_list.append(stripped[2:].strip().strip("'\""))
+                    continue
+                else:
+                    in_paths_list = False
+
+            if in_multiline:
+                if line.startswith("  ") or line.startswith("\t"):
+                    if in_multiline == "description":
+                        result["description"] += " " + stripped
+                    elif in_multiline == "when_to_use":
+                        result["when_to_use"] += " " + stripped
+                    continue
+                else:
+                    in_multiline = ""
+
+            if stripped.startswith("description:"):
+                val = stripped.split(":", 1)[1].strip().strip("'\"")
+                if val and val not in (">", "|"):
+                    result["description"] = val
+                elif val in (">", "|"):
+                    in_multiline = "description"
+
+            elif stripped.startswith(("when_to_use:", "whenToUse:")):
+                val = stripped.split(":", 1)[1].strip().strip("'\"")
+                if val and val not in (">", "|"):
+                    result["when_to_use"] = val
+                elif val in (">", "|"):
+                    in_multiline = "when_to_use"
+
+            elif stripped.startswith("paths:"):
+                inline = stripped.split(":", 1)[1].strip()
+                if inline.startswith("[") and inline.endswith("]"):
+                    for p in inline[1:-1].split(","):
+                        p = p.strip().strip("'\"")
+                        if p:
+                            paths_list.append(p)
+                else:
+                    in_paths_list = True
+
+            elif "triggers" in stripped.lower() or "trigger" in stripped.lower():
+                trigger_fragments.extend(_re.findall(r'"([^"]+)"', stripped))
+
+        if not result["description"]:
+            for line in raw.split("\n")[1:20]:
+                stripped = line.strip()
+                if stripped and not stripped.startswith(("#", "---", "```")):
+                    result["description"] = stripped[:300]
+                    break
+
+        result["description"] = str(result["description"]).strip()[:300]
+        result["when_to_use"] = str(result["when_to_use"]).strip()[:200]
+        result["triggers"] = "|".join(trigger_fragments)
+        result["paths"] = paths_list
+        return result
+
+    def _iter_skill_candidates(
+        self, *, include_dormant: bool = False,
+    ) -> list[tuple[str, Path, Path, bool]]:
+        """Return (name, dir, skill_md_path, is_organized) for all discoverable skills.
+
+        Scans in priority order:
+        1. ``workspace/skills/`` — primary organized location
+        2. All entries in ``_skill_paths`` (includes bundled/dev skills)
+        3. Workspace root — unorganized skills the user may have dropped in
+
+        Deduplicates by both name AND resolved (realpath) canonical path so
+        symlinks pointing to the same physical directory are counted once.
+        Earlier entries take priority (matches Claude Code's first-wins logic).
+
+        **Conditional activation (``paths`` frontmatter)**:
+        Skills declaring ``paths`` patterns are dormant until a touched file
+        matches.  Set *include_dormant* to ``True`` to include them anyway
+        (useful for listing all skills in the prompt with a "dormant" tag).
+        """
         skills_dir = self.workspace / "skills"
-        if not skills_dir.is_dir():
+
+        # (parent_dir, is_organized)
+        scan_dirs: list[tuple[Path, bool]] = []
+        if skills_dir.is_dir():
+            scan_dirs.append((skills_dir, True))
+        for sp in getattr(self, "_skill_paths", []):
+            resolved = Path(sp).resolve()
+            if resolved.is_dir() and resolved != skills_dir.resolve():
+                scan_dirs.append((resolved, True))
+        if self.workspace.is_dir():
+            scan_dirs.append((self.workspace, False))
+
+        candidates: list[tuple[str, Path, Path, bool]] = []
+        seen_names: set[str] = set()
+        seen_realpaths: set[str] = set()
+
+        for parent_dir, is_organized in scan_dirs:
+            for child in sorted(parent_dir.iterdir()):
+                if not (child.is_dir() or child.is_symlink()):
+                    continue
+                if not is_organized and child.name in self._WORKSPACE_INFRA_DIRS:
+                    continue
+                skill_md = child / "SKILL.md"
+                if not skill_md.exists():
+                    continue
+                name = child.name
+                if name in seen_names:
+                    continue
+
+                try:
+                    canonical = str(skill_md.resolve())
+                except OSError:
+                    canonical = str(skill_md)
+                if canonical in seen_realpaths:
+                    logger.debug(
+                        f"Skipping duplicate skill '{name}' "
+                        f"(same file already loaded via another path)"
+                    )
+                    continue
+
+                if not include_dormant:
+                    fm = self._parse_skill_frontmatter(skill_md)
+                    skill_paths = fm.get("paths", [])
+                    if isinstance(skill_paths, list) and skill_paths:
+                        if not self._skill_paths_match(
+                            skill_paths, self._touched_paths, self.workspace,
+                        ):
+                            logger.debug(
+                                f"Skill '{name}' dormant (paths not matched)"
+                            )
+                            continue
+
+                seen_names.add(name)
+                seen_realpaths.add(canonical)
+                candidates.append((name, child, skill_md, is_organized))
+
+        return candidates
+
+    def _pre_inject_matched_skill(self, message: str) -> str:
+        """Match user message to an installed skill and prepend SKILL.md content.
+
+        Scoring uses multiple signals inspired by Claude Code's skill matching:
+        - Skill name tokens (split on ``-`` / ``_``)
+        - YAML frontmatter ``description`` keywords
+        - ``when_to_use`` / ``whenToUse`` field (highest weight)
+        - ``triggers`` keyword list
+
+        Scans both ``workspace/skills/`` (organized) and the workspace root
+        (unorganized).  When an unorganized skill matches, the injection
+        includes a note asking the agent to move it into ``skills/`` first.
+        """
+        import re as _re, sys as _sys
+
+        candidates = self._iter_skill_candidates()
+        if not candidates:
             return message
 
         msg_lower = message.lower()
         best_skill = None
         best_score = 0
 
-        for child in sorted(skills_dir.iterdir()):
-            if not child.is_dir():
-                continue
-            skill_md = child / "SKILL.md"
-            if not skill_md.exists():
-                continue
-
-            name = child.name
+        for name, skill_dir, skill_md, is_organized in candidates:
             score = 0
 
-            # Match skill name tokens against user message
             name_tokens = _re.split(r'[-_]', name)
             for token in name_tokens:
                 if len(token) >= 3 and token.lower() in msg_lower:
-                    score += 2
+                    score += self._SCORE_NAME_TOKEN
 
-            # Match trigger words from frontmatter
-            try:
-                raw = skill_md.read_text(encoding="utf-8", errors="replace")
-                fm = _re.match(r'^---\s*\n(.*?)\n---', raw, _re.DOTALL)
-                if fm:
-                    for line in fm.group(1).split("\n"):
-                        if "triggers" in line.lower() or "trigger" in line.lower():
-                            triggers = _re.findall(r'"([^"]+)"', line)
-                            for t in triggers:
-                                if t.lower() in msg_lower:
-                                    score += 3
-            except Exception:
-                pass
+            fm = self._parse_skill_frontmatter(skill_md)
+
+            for t in fm["triggers"].split("|"):
+                if t and t.lower() in msg_lower:
+                    score += self._SCORE_TRIGGER
+
+            if fm["when_to_use"]:
+                wtu_tokens = _re.findall(r'[A-Za-z\u4e00-\u9fff]{2,}', fm["when_to_use"].lower())
+                for token in wtu_tokens:
+                    if token not in self._SKILL_MATCH_STOP_WORDS and token in msg_lower:
+                        score += self._SCORE_WHEN_TO_USE
+
+            if fm["description"]:
+                desc_tokens = _re.findall(r'[A-Za-z\u4e00-\u9fff]{3,}', fm["description"].lower())
+                for token in desc_tokens:
+                    if token not in self._SKILL_MATCH_STOP_WORDS and token in msg_lower:
+                        score += self._SCORE_DESCRIPTION
 
             if score > best_score:
                 best_score = score
-                best_skill = (name, skill_md)
+                best_skill = (name, skill_dir, skill_md, is_organized)
 
-        if not best_skill or best_score < 2:
+        if not best_skill or best_score < self._SCORE_THRESHOLD:
             return message
 
-        skill_name, skill_path = best_skill
+        skill_name, skill_dir, skill_path, is_organized = best_skill
         try:
             content = skill_path.read_text(encoding="utf-8", errors="replace").strip()
         except Exception:
             return message
 
-        logger.info(f"Pre-injected skill '{skill_name}' (score={best_score}) into message")
+        base_dir = str(skill_dir).replace("\\", "/")
+        if _sys.platform == "win32":
+            base_dir = _re.sub(r'^([A-Za-z]):', lambda m: f'/{m.group(1).lower()}', base_dir)
+
+        ws_posix = self._workspace_posix_path()
+
+        if is_organized:
+            skill_rel = f"skills/{skill_name}"
+        else:
+            skill_rel = skill_name
+
+        content = content.replace("${SKILL_DIR}", f"{ws_posix}/{skill_rel}")
+        content = content.replace("$SKILL_DIR", f"{ws_posix}/{skill_rel}")
+
+        self._pre_injected_skill_name = skill_name
+
+        organize_note = ""
+        if not is_organized:
+            organize_note = (
+                f"\n⚠️ ORGANIZE FIRST: This skill is at the workspace root, not in skills/.\n"
+                f"Before executing, move it:\n"
+                f"  mv {skill_name} skills/{skill_name}\n"
+                f"Then update your working paths to use skills/{skill_name}/ as the base.\n"
+            )
+
+        logger.info(
+            f"Pre-injected skill '{skill_name}' (score={best_score}, "
+            f"organized={is_organized}) into message"
+        )
         return (
             f"{message}\n\n"
             f"---\n"
-            f"[PRE-LOADED SKILL: {skill_name}] "
-            f"The following SKILL.md is already loaded — execute its steps directly. "
-            f"Do NOT call read_file on this skill again.\n\n"
+            f"[PRE-LOADED SKILL: {skill_name}]\n"
+            f"Base directory: {base_dir}\n"
+            f"Workspace-relative path: {skill_rel}/\n"
+            f"{organize_note}\n"
+            f"The SKILL.md below is already loaded — follow its procedures directly. "
+            f"Do NOT call read_file on this skill. Do NOT search for alternatives. "
+            f"Start executing the skill's instructions immediately.\n\n"
             f"{content}\n"
             f"---"
         )
@@ -3285,75 +4057,50 @@ class AgentLoop:
     def _build_skills_for_prompt(self) -> str:
         """Build Openclaw-style XML metadata for installed skills.
 
-        Scans skill directories, extracts name + description from SKILL.md
-        frontmatter, and returns an <available_skills> XML block for the
-        system prompt. The agent reads SKILL.md lazily when needed.
+        Uses ``_iter_skill_candidates`` and ``_parse_skill_frontmatter`` to
+        build an ``<available_skills>`` XML block.  Unorganized skills (in the
+        workspace root) are flagged so the agent knows to move them first.
+
+        Path-conditional skills are included with ``include_dormant=True``
+        so the agent is *aware* of them, but they carry a ``<status>dormant``
+        tag indicating they will activate when matching files are touched.
         """
-        import re as _re, os as _os, sys as _sys
-
-        skills_dir = self.workspace / "skills"
-        if not skills_dir.is_dir():
+        candidates = self._iter_skill_candidates(include_dormant=True)
+        if not candidates:
             return ""
 
-        ws_str = str(self.workspace).replace("\\", "/")
-        if _sys.platform == "win32":
-            ws_str = _re.sub(r'^([A-Za-z]):', lambda m: f'/{m.group(1).lower()}', ws_str)
+        entries: list[str] = []
+        for name, _dir, skill_md, is_organized in candidates:
+            fm = self._parse_skill_frontmatter(skill_md)
+            description = fm["description"] or name
+            when_to_use = fm["when_to_use"]
+            skill_paths = fm.get("paths", [])
 
-        entries = []
-        for child in sorted(skills_dir.iterdir()):
-            if not child.is_dir():
-                continue
-            skill_md = child / "SKILL.md"
-            if not skill_md.exists():
-                continue
+            location = f"skills/{name}/SKILL.md" if is_organized else f"{name}/SKILL.md"
 
-            name = child.name
-            description = ""
-            try:
-                raw = skill_md.read_text(encoding="utf-8", errors="replace")
-                fm_match = _re.match(r'^---\s*\n(.*?)\n---', raw, _re.DOTALL)
-                if fm_match:
-                    for line in fm_match.group(1).split("\n"):
-                        stripped = line.strip()
-                        if stripped.startswith("description:"):
-                            val = stripped.split(":", 1)[1].strip().strip("'\"")
-                            if val and val != ">":
-                                description = val[:200]
-                                break
-                    if not description:
-                        in_desc = False
-                        desc_lines = []
-                        for line in fm_match.group(1).split("\n"):
-                            if line.strip().startswith("description:"):
-                                in_desc = True
-                                val = line.split(":", 1)[1].strip()
-                                if val and val not in (">", "|"):
-                                    desc_lines.append(val)
-                                continue
-                            if in_desc:
-                                if line.startswith("  ") or line.startswith("\t"):
-                                    desc_lines.append(line.strip())
-                                else:
-                                    break
-                        description = " ".join(desc_lines)[:200]
-                if not description:
-                    for line in raw.split("\n")[1:20]:
-                        stripped = line.strip()
-                        if stripped and not stripped.startswith(("#", "---", "```")):
-                            description = stripped[:200]
-                            break
-            except Exception:
-                description = name
+            parts = [
+                f'<skill name="{name}">',
+                f'  <description>{description}</description>',
+            ]
+            if when_to_use:
+                parts.append(f'  <when_to_use>{when_to_use}</when_to_use>')
+            parts.append(f'  <location>{location}</location>')
+            if not is_organized:
+                parts.append(
+                    f'  <status>unorganized — move to skills/{name}/ before use</status>'
+                )
+            elif isinstance(skill_paths, list) and skill_paths:
+                is_active = self._skill_paths_match(
+                    skill_paths, self._touched_paths, self.workspace,
+                )
+                if not is_active:
+                    parts.append(
+                        f'  <status>dormant — activates when files matching '
+                        f'{", ".join(skill_paths[:3])} are touched</status>'
+                    )
+            parts.append('</skill>')
+            entries.append("\n".join(parts))
 
-            entries.append(
-                f'<skill name="{name}">\n'
-                f'  <description>{description}</description>\n'
-                f'  <location>skills/{name}/SKILL.md</location>\n'
-                f'</skill>'
-            )
-
-        if not entries:
-            return ""
         return "<available_skills>\n" + "\n".join(entries) + "\n</available_skills>"
 
     @staticmethod
@@ -3516,6 +4263,11 @@ class AgentLoop:
         new_key = session_key or f"session-{uuid.uuid4().hex[:8]}"
         self._session = self.sessions.get_or_create(new_key)
         self.session_key = new_key
+        if getattr(self, "_history_search_tool", None) is not None:
+            try:
+                self._history_search_tool.set_default_session_key(new_key)
+            except Exception:
+                pass
         logger.info(f"Switched to new session: {new_key}")
         return new_key
 

--- a/spoon_bot/agent/tools/history_search.py
+++ b/spoon_bot/agent/tools/history_search.py
@@ -1,0 +1,307 @@
+"""Conversation history search tool.
+
+Fallback mechanism for the model to recover earlier tool calls, tool
+results, and message bodies *after* runtime context has been compacted.
+
+The tool delegates to the agent's :class:`~spoon_bot.session.manager.SessionManager`,
+which in turn uses whatever the active session store can offer:
+
+* ``PostgresSessionStore`` — native ``ILIKE`` / ``LIKE`` / POSIX regex
+  filtering at the database layer.
+* ``SQLiteSessionStore`` — ``LIKE`` / ``GLOB`` prefilter + Python ``re``
+  refinement in memory.
+* ``FileSessionStore`` (or any other backend) — in-memory scan of the
+  JSONL transcripts (i.e. a grep fallback).
+
+Because the underlying store is consulted (not runtime memory), results
+remain available even when messages have been trimmed from the agent's
+working context.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Optional, TYPE_CHECKING
+
+from spoon_bot.agent.tools.base import Tool
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from spoon_bot.session.manager import SessionManager
+
+
+SessionKeyResolver = Callable[[], Optional[str]]
+
+
+class SearchHistoryTool(Tool):
+    """Search persisted conversation history (messages + tool calls/results).
+
+    The model should reach for this tool whenever:
+
+    * It's asked about an earlier turn that is no longer in context
+      (e.g. "what did the previous X tool return?").
+    * It needs to reconstruct a tool call chain after compaction.
+    * The user references a prior topic the current context does not
+      cover.
+    """
+
+    def __init__(
+        self,
+        sessions_manager: "SessionManager",
+        *,
+        default_session_key: str | None = None,
+        session_key_resolver: SessionKeyResolver | None = None,
+    ) -> None:
+        """Create a new :class:`SearchHistoryTool`.
+
+        Args:
+            sessions_manager: The agent's :class:`SessionManager`.
+            default_session_key: Optional fixed session key used when no
+                resolver is provided or the resolver returns ``None``.
+            session_key_resolver: Zero-arg callable that returns the
+                *current* session key.  Preferred over
+                ``default_session_key`` because the agent's active
+                session can be switched out-of-band (e.g. by the WS
+                gateway on every chat.send).  The resolver is consulted
+                on every :meth:`execute` call, guaranteeing the tool
+                always targets the live session rather than a stale
+                cached value.
+        """
+        self._sessions_manager = sessions_manager
+        self._default_session_key = default_session_key
+        self._session_key_resolver = session_key_resolver
+
+    def set_default_session_key(self, session_key: str | None) -> None:
+        """Update which session this tool searches by default.
+
+        Kept for backwards compatibility — prefer passing a
+        ``session_key_resolver`` at construction time so switches
+        happening outside :class:`AgentLoop` (e.g. in the WS gateway)
+        are picked up automatically.
+        """
+        self._default_session_key = session_key
+
+    def set_session_key_resolver(
+        self, resolver: SessionKeyResolver | None
+    ) -> None:
+        """Swap the zero-arg resolver returning the active session key."""
+        self._session_key_resolver = resolver
+
+    def _resolve_active_session_key(self) -> str | None:
+        """Return the session key the tool should default to right now."""
+        if self._session_key_resolver is not None:
+            try:
+                resolved = self._session_key_resolver()
+            except Exception:  # pragma: no cover - defensive
+                resolved = None
+            if resolved:
+                return str(resolved)
+        return self._default_session_key
+
+    @property
+    def name(self) -> str:
+        return "search_history"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search the persisted conversation history (messages, tool "
+            "calls, and tool results) using literal substring or regex "
+            "matching. Use this to recover information after the runtime "
+            "context has been compacted, for example to look up an earlier "
+            "tool result, attachment id, or user question. By default the "
+            "current session is searched; pass scope='all' to search every "
+            "session for the current agent. Returns a JSON object with a "
+            "'hits' array containing role, snippet, timestamp, and "
+            "tool_call metadata for each match."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Substring (default) or regex (when regex=true) to "
+                        "search for in message content and, unless "
+                        "include_extras=false, serialized tool_call_id / "
+                        "tool_calls / attachments metadata."
+                    ),
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": ["current", "all"],
+                    "description": (
+                        "'current' (default) searches only the active "
+                        "session; 'all' searches every session owned by "
+                        "the agent."
+                    ),
+                },
+                "session_key": {
+                    "type": "string",
+                    "description": (
+                        "Explicit session to search. Overrides scope. "
+                        "Usually left blank."
+                    ),
+                },
+                "regex": {
+                    "type": "boolean",
+                    "description": "Interpret query as a regular expression.",
+                },
+                "case_sensitive": {
+                    "type": "boolean",
+                    "description": "Match case-sensitively (default false).",
+                },
+                "roles": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Restrict to these message roles, e.g. "
+                        "['tool', 'assistant']. Useful for finding only "
+                        "tool results or only the user's prior questions."
+                    ),
+                },
+                "include_extras": {
+                    "type": "boolean",
+                    "description": (
+                        "Also match against serialized tool_call_id / "
+                        "tool_calls / attachments metadata (default true)."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max hits to return (default 20, max 200).",
+                    "minimum": 1,
+                    "maximum": 200,
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Number of hits to skip (for paging).",
+                    "minimum": 0,
+                },
+                "max_content_length": {
+                    "type": "integer",
+                    "description": (
+                        "Truncate each returned message content to this "
+                        "many characters (default 1000). Reduces token "
+                        "usage when a single hit is very large."
+                    ),
+                    "minimum": 1,
+                    "maximum": 20000,
+                },
+            },
+            "required": ["query"],
+        }
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    async def execute(
+        self,
+        query: str,
+        scope: str = "current",
+        session_key: str | None = None,
+        regex: bool = False,
+        case_sensitive: bool = False,
+        roles: Iterable[str] | None = None,
+        include_extras: bool = True,
+        limit: int = 20,
+        offset: int = 0,
+        max_content_length: int | None = 1000,
+        **kwargs: Any,
+    ) -> str:
+        import json
+        import re
+
+        if not isinstance(query, str) or not query.strip():
+            return "Error: 'query' must be a non-empty string."
+
+        try:
+            limit_int = max(1, min(200, int(limit)))
+        except (TypeError, ValueError):
+            limit_int = 20
+        try:
+            offset_int = max(0, int(offset))
+        except (TypeError, ValueError):
+            offset_int = 0
+        mcl: int | None
+        if max_content_length is None:
+            mcl = None
+        else:
+            try:
+                mcl = max(1, min(20_000, int(max_content_length)))
+            except (TypeError, ValueError):
+                mcl = 1000
+
+        # Resolve which session(s) to search.
+        if session_key is not None and str(session_key).strip():
+            target_session_key: str | None = str(session_key)
+        elif isinstance(scope, str) and scope.lower() == "all":
+            target_session_key = None
+        else:
+            # Always ask the resolver first so we pick up WS-driven
+            # session switches that bypass AgentLoop's internal hooks.
+            target_session_key = self._resolve_active_session_key()
+
+        roles_list: list[str] | None
+        if roles is None:
+            roles_list = None
+        else:
+            roles_list = [str(r) for r in roles if str(r).strip()]
+            if not roles_list:
+                roles_list = None
+
+        try:
+            hits = self._sessions_manager.search_messages(
+                query,
+                session_key=target_session_key,
+                regex=bool(regex),
+                case_sensitive=bool(case_sensitive),
+                roles=roles_list,
+                include_extras=bool(include_extras),
+                limit=limit_int,
+                offset=offset_int,
+                max_content_length=mcl,
+            )
+        except re.error as exc:
+            return f"Error: invalid regex: {exc}"
+        except ValueError as exc:
+            return f"Error: {exc}"
+
+        payload = {
+            "query": query,
+            "scope": (
+                "session" if target_session_key is not None else "all"
+            ),
+            "session_key": target_session_key,
+            "total": len(hits),
+            "limit": limit_int,
+            "offset": offset_int,
+            "hits": [
+                {
+                    "session_key": h.session_key,
+                    "seq": h.seq,
+                    "role": h.role,
+                    "snippet": h.snippet,
+                    "content": h.content,
+                    "timestamp": h.timestamp,
+                    "matched_in": h.matched_in,
+                    "tool_call_id": (
+                        h.extras.get("tool_call_id") if h.extras else None
+                    ),
+                    "tool_calls": (
+                        h.extras.get("tool_calls") if h.extras else None
+                    ),
+                }
+                for h in hits
+            ],
+        }
+
+        if not hits:
+            payload["note"] = (
+                "No matches found. Try a broader substring, scope='all', "
+                "or regex=true for fuzzier matching."
+            )
+
+        return json.dumps(payload, ensure_ascii=False, default=str)

--- a/spoon_bot/agent/tools/registry.py
+++ b/spoon_bot/agent/tools/registry.py
@@ -18,6 +18,7 @@ from spoon_bot.agent.tools.execution_context import bind_tool_invocation, finali
 CORE_TOOLS: frozenset[str] = frozenset({
     "shell", "read_file", "write_file", "edit_file", "list_dir", "grep",
     "self_config", "memory", "activate_tool", "self_upgrade",
+    "search_history",
 })
 
 RISKY_LOCAL_TOOLS: frozenset[str] = frozenset({

--- a/spoon_bot/gateway/api/v1/sessions.py
+++ b/spoon_bot/gateway/api/v1/sessions.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Any
 from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 
 from spoon_bot.gateway.app import get_agent
 from spoon_bot.gateway.auth.dependencies import CurrentUser
@@ -17,15 +18,14 @@ from spoon_bot.gateway.models.responses import (
     SessionResponse,
     SessionListResponse,
     SessionInfo,
+    SessionSearchHit,
+    SessionSearchResponse,
 )
 
 router = APIRouter()
 
 
-@router.get("", response_model=APIResponse[SessionListResponse])
-async def list_sessions(user: CurrentUser) -> APIResponse[SessionListResponse]:
-    """List all sessions."""
-    request_id = f"req_{uuid4().hex[:12]}"
+def _get_sessions_manager() -> Any:
     agent: Any = get_agent()
     sessions_manager: Any = getattr(agent, "sessions", None)
     if sessions_manager is None:
@@ -33,6 +33,66 @@ async def list_sessions(user: CurrentUser) -> APIResponse[SessionListResponse]:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={"code": "INTERNAL_ERROR", "message": "Session manager unavailable"},
         )
+    return sessions_manager
+
+
+def _run_search(
+    sessions_manager: Any,
+    *,
+    query: str,
+    session_key: str | None,
+    regex: bool,
+    case_sensitive: bool,
+    roles: list[str] | None,
+    include_extras: bool,
+    limit: int,
+    offset: int,
+    max_content_length: int | None,
+) -> list[SessionSearchHit]:
+    """Call the session manager's ``search_messages`` and shape the results."""
+    try:
+        hits = sessions_manager.search_messages(
+            query,
+            session_key=session_key,
+            regex=regex,
+            case_sensitive=case_sensitive,
+            roles=roles,
+            include_extras=include_extras,
+            limit=limit,
+            offset=offset,
+            max_content_length=max_content_length,
+        )
+    except re.error as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_REGEX", "message": str(exc)},
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_QUERY", "message": str(exc)},
+        )
+
+    return [
+        SessionSearchHit(
+            session_key=hit.session_key,
+            seq=hit.seq,
+            role=hit.role,
+            content=hit.content,
+            timestamp=hit.timestamp,
+            matched_in=hit.matched_in,
+            snippet=hit.snippet,
+            extras=hit.extras or {},
+        )
+        for hit in hits
+    ]
+
+
+@router.get("", response_model=APIResponse[SessionListResponse])
+async def list_sessions(user: CurrentUser) -> APIResponse[SessionListResponse]:
+    """List all sessions."""
+    request_id = f"req_{uuid4().hex[:12]}"
+    sessions_manager = _get_sessions_manager()
 
     session_keys = sessions_manager.list_sessions()
     sessions: list[Any] = []
@@ -66,15 +126,8 @@ async def create_session(
 ) -> APIResponse[SessionResponse]:
     """Create a new session."""
     request_id = f"req_{uuid4().hex[:12]}"
-    agent: Any = get_agent()
-    sessions_manager: Any = getattr(agent, "sessions", None)
-    if sessions_manager is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"code": "INTERNAL_ERROR", "message": "Session manager unavailable"},
-        )
+    sessions_manager = _get_sessions_manager()
 
-    # Check if session already exists
     existing = sessions_manager.get(request.key)
     if existing:
         raise HTTPException(
@@ -82,7 +135,6 @@ async def create_session(
             detail={"code": "SESSION_EXISTS", "message": f"Session '{request.key}' already exists"},
         )
 
-    # Create session
     session = sessions_manager.get_or_create(request.key)
     sessions_manager.save(session)
 
@@ -99,6 +151,73 @@ async def create_session(
     )
 
 
+# NOTE: Route registration order matters in FastAPI — static paths like
+# ``/search`` MUST be registered before ``/{session_key}`` or the latter
+# will swallow them as ``session_key="search"``.  Keep the search routes
+# ABOVE the ``/{session_key}`` handlers.
+@router.get(
+    "/search",
+    response_model=APIResponse[SessionSearchResponse],
+)
+async def search_sessions(
+    user: CurrentUser,
+    q: str = Query(..., min_length=1, description="Search query"),
+    regex: bool = Query(False, description="Interpret query as a regular expression"),
+    case_sensitive: bool = Query(False, description="Match case-sensitively"),
+    roles: list[str] | None = Query(
+        None,
+        description="Restrict to these message roles (e.g. tool, assistant, user, system)",
+    ),
+    include_extras: bool = Query(
+        True,
+        description="Also match tool_call_id / tool_calls / attachments serialized extras",
+    ),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    max_content_length: int | None = Query(
+        2000,
+        ge=1,
+        le=100_000,
+        description="Truncate each returned content to at most this many characters",
+    ),
+) -> APIResponse[SessionSearchResponse]:
+    """Search across *all* persisted sessions for the current agent.
+
+    This is the fallback used when runtime context has been compacted and
+    callers (user or model) want to recover earlier tool calls / results
+    or message bodies.  The underlying store picks the most efficient
+    strategy available (SQL ``LIKE``/``ILIKE``/regex, or an in-memory
+    grep fallback for file-backed stores).
+    """
+    request_id = f"req_{uuid4().hex[:12]}"
+    sessions_manager = _get_sessions_manager()
+
+    hits = _run_search(
+        sessions_manager,
+        query=q,
+        session_key=None,
+        regex=regex,
+        case_sensitive=case_sensitive,
+        roles=roles,
+        include_extras=include_extras,
+        limit=limit,
+        offset=offset,
+        max_content_length=max_content_length,
+    )
+
+    return APIResponse(
+        success=True,
+        data=SessionSearchResponse(
+            query=q,
+            total=len(hits),
+            limit=limit,
+            offset=offset,
+            hits=hits,
+        ),
+        meta=MetaInfo(request_id=request_id),
+    )
+
+
 @router.get("/{session_key}", response_model=APIResponse[SessionResponse])
 async def get_session(
     session_key: str,
@@ -106,13 +225,7 @@ async def get_session(
 ) -> APIResponse[SessionResponse]:
     """Get session details."""
     request_id = f"req_{uuid4().hex[:12]}"
-    agent: Any = get_agent()
-    sessions_manager: Any = getattr(agent, "sessions", None)
-    if sessions_manager is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"code": "INTERNAL_ERROR", "message": "Session manager unavailable"},
-        )
+    sessions_manager = _get_sessions_manager()
 
     session = sessions_manager.get(session_key)
     if not session:
@@ -134,22 +247,71 @@ async def get_session(
     )
 
 
+@router.get(
+    "/{session_key}/search",
+    response_model=APIResponse[SessionSearchResponse],
+)
+async def search_session(
+    session_key: str,
+    user: CurrentUser,
+    q: str = Query(..., min_length=1, description="Search query"),
+    regex: bool = Query(False),
+    case_sensitive: bool = Query(False),
+    roles: list[str] | None = Query(None),
+    include_extras: bool = Query(True),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    max_content_length: int | None = Query(2000, ge=1, le=100_000),
+) -> APIResponse[SessionSearchResponse]:
+    """Search persisted messages within a single session.
+
+    Primary fallback path for the user / model to recover an earlier
+    tool call, tool result, or message body after runtime context
+    compaction has trimmed it from memory.
+    """
+    request_id = f"req_{uuid4().hex[:12]}"
+    sessions_manager = _get_sessions_manager()
+
+    if sessions_manager.get(session_key) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "NOT_FOUND", "message": f"Session '{session_key}' not found"},
+        )
+
+    hits = _run_search(
+        sessions_manager,
+        query=q,
+        session_key=session_key,
+        regex=regex,
+        case_sensitive=case_sensitive,
+        roles=roles,
+        include_extras=include_extras,
+        limit=limit,
+        offset=offset,
+        max_content_length=max_content_length,
+    )
+
+    return APIResponse(
+        success=True,
+        data=SessionSearchResponse(
+            query=q,
+            total=len(hits),
+            limit=limit,
+            offset=offset,
+            hits=hits,
+        ),
+        meta=MetaInfo(request_id=request_id),
+    )
+
+
 @router.delete("/{session_key}")
 async def delete_session(
     session_key: str,
     user: CurrentUser,
 ) -> dict:
     """Delete a session."""
-    agent: Any = get_agent()
-    sessions_manager: Any = getattr(agent, "sessions", None)
-    if sessions_manager is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"code": "INTERNAL_ERROR", "message": "Session manager unavailable"},
-        )
-
+    sessions_manager = _get_sessions_manager()
     deleted = sessions_manager.delete(session_key)
-
     return {"deleted": deleted}
 
 
@@ -159,13 +321,7 @@ async def clear_session(
     user: CurrentUser,
 ) -> dict:
     """Clear session history."""
-    agent: Any = get_agent()
-    sessions_manager: Any = getattr(agent, "sessions", None)
-    if sessions_manager is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"code": "INTERNAL_ERROR", "message": "Session manager unavailable"},
-        )
+    sessions_manager = _get_sessions_manager()
 
     session = sessions_manager.get(session_key)
     if not session:

--- a/spoon_bot/gateway/models/responses.py
+++ b/spoon_bot/gateway/models/responses.py
@@ -119,6 +119,29 @@ class SessionListResponse(BaseModel):
     sessions: list[SessionInfo]
 
 
+class SessionSearchHit(BaseModel):
+    """A single match from a session history search."""
+
+    session_key: str
+    seq: int
+    role: str
+    content: str
+    timestamp: str | None = None
+    matched_in: str = "content"  # "content" or "extras"
+    snippet: str = ""
+    extras: dict[str, Any] = Field(default_factory=dict)
+
+
+class SessionSearchResponse(BaseModel):
+    """Session search response model."""
+
+    query: str
+    total: int
+    limit: int
+    offset: int
+    hits: list[SessionSearchHit] = Field(default_factory=list)
+
+
 class ToolInfo(BaseModel):
     """Tool information."""
 

--- a/spoon_bot/gateway/websocket/handler.py
+++ b/spoon_bot/gateway/websocket/handler.py
@@ -524,6 +524,7 @@ class WebSocketHandler:
             "session.clear": self._handle_session_clear,
             ClientMethod.SESSION_EXPORT.value: self._handle_session_export,
             ClientMethod.SESSION_IMPORT.value: self._handle_session_import,
+            ClientMethod.SESSION_SEARCH.value: self._handle_session_search,
             # Subscription
             "subscribe": self._handle_subscribe,
             "unsubscribe": self._handle_unsubscribe,
@@ -1088,6 +1089,133 @@ class WebSocketHandler:
             }
         except Exception:
             return {"sessions": []}
+
+    async def _handle_session_search(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Handle ``session.search``.
+
+        Runs a persisted-history search across one or all sessions so the
+        client / model can recover earlier tool calls, tool results, or
+        message bodies that have fallen out of the runtime context due to
+        compaction.
+
+        Params:
+          q (str, required): search query.
+          session_key (str, optional): restrict to a single session.
+          regex (bool, default False): interpret ``q`` as a regex.
+          case_sensitive (bool, default False).
+          roles (list[str], optional): restrict to these message roles
+              (e.g. ``["tool", "assistant"]``).
+          include_extras (bool, default True): also match serialized
+              ``tool_call_id`` / ``tool_calls`` / ``attachments`` metadata.
+          limit (int, default 50, max 500).
+          offset (int, default 0).
+          max_content_length (int, default 2000): truncate returned
+              ``content`` to at most N characters.
+        """
+        import re as _re
+
+        query = params.get("q") or params.get("query")
+        if not isinstance(query, str) or not query:
+            return {"error": "INVALID_QUERY", "message": "q is required"}
+
+        # Wait for any pending chat task so the freshest turn is persisted
+        # before we search.
+        if self._current_task and not self._current_task.done():
+            try:
+                await asyncio.wait_for(asyncio.shield(self._current_task), timeout=30.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                pass
+
+        agent = get_agent()
+        sessions_manager = getattr(agent, "sessions", None)
+        if sessions_manager is None:
+            return {"error": "INTERNAL_ERROR", "message": "Session manager unavailable"}
+
+        session_key = params.get("session_key")
+        if session_key is not None and not isinstance(session_key, str):
+            return {"error": "INVALID_QUERY", "message": "session_key must be a string"}
+
+        roles_raw = params.get("roles")
+        roles: list[str] | None
+        if roles_raw is None:
+            roles = None
+        elif isinstance(roles_raw, (list, tuple)):
+            roles = [str(r) for r in roles_raw if r]
+            if not roles:
+                roles = None
+        else:
+            return {"error": "INVALID_QUERY", "message": "roles must be a list"}
+
+        def _as_bool(value: Any, default: bool) -> bool:
+            if value is None:
+                return default
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, str):
+                return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+            return bool(value)
+
+        def _as_int(value: Any, default: int, *, low: int, high: int) -> int:
+            if value is None:
+                return default
+            try:
+                n = int(value)
+            except (TypeError, ValueError):
+                return default
+            return max(low, min(high, n))
+
+        regex = _as_bool(params.get("regex"), False)
+        case_sensitive = _as_bool(params.get("case_sensitive"), False)
+        include_extras = _as_bool(params.get("include_extras"), True)
+        limit = _as_int(params.get("limit"), 50, low=1, high=500)
+        offset = _as_int(params.get("offset"), 0, low=0, high=1_000_000)
+        max_content_length_raw = params.get("max_content_length", 2000)
+        if max_content_length_raw is None:
+            max_content_length: int | None = None
+        else:
+            max_content_length = _as_int(
+                max_content_length_raw, 2000, low=1, high=100_000
+            )
+
+        try:
+            hits = sessions_manager.search_messages(
+                query,
+                session_key=session_key,
+                regex=regex,
+                case_sensitive=case_sensitive,
+                roles=roles,
+                include_extras=include_extras,
+                limit=limit,
+                offset=offset,
+                max_content_length=max_content_length,
+            )
+        except _re.error as exc:
+            return {"error": "INVALID_REGEX", "message": str(exc)}
+        except ValueError as exc:
+            return {"error": "INVALID_QUERY", "message": str(exc)}
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"session.search failed: {exc}")
+            return {"error": "INTERNAL_ERROR", "message": "Search failed"}
+
+        return {
+            "query": query,
+            "total": len(hits),
+            "limit": limit,
+            "offset": offset,
+            "hits": [
+                {
+                    "session_key": h.session_key,
+                    "seq": h.seq,
+                    "role": h.role,
+                    "content": h.content,
+                    "timestamp": h.timestamp,
+                    "matched_in": h.matched_in,
+                    "snippet": h.snippet,
+                    "extras": dict(h.extras) if h.extras else {},
+                }
+                for h in hits
+            ],
+        }
 
     async def _handle_session_clear(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle session clear."""

--- a/spoon_bot/gateway/websocket/protocol.py
+++ b/spoon_bot/gateway/websocket/protocol.py
@@ -48,6 +48,7 @@ class ClientMethod(str, Enum):
     SESSION_CLEAR = "session.clear"
     SESSION_EXPORT = "session.export"
     SESSION_IMPORT = "session.import"
+    SESSION_SEARCH = "session.search"
 
     # Agent methods
     AGENT_STATUS = "agent.status"

--- a/spoon_bot/session/manager.py
+++ b/spoon_bot/session/manager.py
@@ -12,12 +12,12 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from threading import RLock
 from pathlib import Path
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Iterable, Optional, TYPE_CHECKING
 
 from loguru import logger
 
 if TYPE_CHECKING:
-    from spoon_bot.session.store import SessionStore
+    from spoon_bot.session.store import SearchHit, SessionStore
 
 
 # ============================================================================
@@ -210,6 +210,61 @@ class SessionManager:
         """Release backend resources."""
         with self._lock:
             self._store.close()
+
+    def search_messages(
+        self,
+        query: str,
+        *,
+        session_key: Optional[str] = None,
+        regex: bool = False,
+        case_sensitive: bool = False,
+        roles: Optional[Iterable[str]] = None,
+        include_extras: bool = True,
+        limit: int = 50,
+        offset: int = 0,
+        max_content_length: Optional[int] = 2000,
+    ) -> list["SearchHit"]:
+        """Search persisted messages (grep / SQL fallback for compacted context).
+
+        Results reflect whatever is currently *persisted* by the store; in-memory
+        mutations that haven't been ``save()``'d will not be visible.  Agent
+        loops save after every user turn, so in practice this returns the
+        current state minus any partial stream in flight.
+
+        Args / Returns: see :meth:`SessionStore.search_messages`.
+        """
+        with self._lock:
+            # Flush any dirty hot sessions that match the search scope so that
+            # search reflects the latest in-memory state.  We only flush the
+            # specific session if ``session_key`` is given; otherwise we
+            # flush everything cached (small dict, bounded by LRU).
+            to_flush: list[Session] = []
+            if session_key is not None:
+                sess = self._sessions.get(session_key)
+                if sess is not None:
+                    to_flush.append(sess)
+            else:
+                to_flush.extend(self._sessions.values())
+            for sess in to_flush:
+                try:
+                    self._store.save_session(sess)
+                except Exception as exc:
+                    logger.debug(
+                        f"search_messages: best-effort flush failed for "
+                        f"{sess.session_key}: {exc}"
+                    )
+
+        return self._store.search_messages(
+            query,
+            session_key=session_key,
+            regex=regex,
+            case_sensitive=case_sensitive,
+            roles=roles,
+            include_extras=include_extras,
+            limit=limit,
+            offset=offset,
+            max_content_length=max_content_length,
+        )
 
     def _evict_if_needed(self) -> None:
         """Bound in-memory cache size by evicting oldest inserted sessions."""

--- a/spoon_bot/session/store.py
+++ b/spoon_bot/session/store.py
@@ -13,11 +13,13 @@ All backends implement the ``SessionStore`` protocol.
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from loguru import logger
 
@@ -26,6 +28,116 @@ from loguru import logger
 # store.py and manager.py share the same type.
 # ---------------------------------------------------------------------------
 from spoon_bot.session.manager import Session
+
+
+# ---------------------------------------------------------------------------
+# Search primitives
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SearchHit:
+    """A single match returned by :meth:`SessionStore.search_messages`.
+
+    Attributes:
+        session_key: Session the message lives in.
+        seq:         0-based position of the message inside the session.
+        role:        ``user`` / ``assistant`` / ``tool``.
+        content:     The raw stored content (possibly truncated if callers
+                     pass ``max_content_length``).
+        timestamp:   Timestamp string if persisted, else ``None``.
+        extras:      Everything else that was stored alongside the message
+                     (e.g. ``tool_call_id``, ``name``, ``tool_calls``).
+        matched_in:  ``"content"`` or ``"extras"`` — where the query hit.
+        snippet:     A short excerpt of the hit with the match surrounded by
+                     context characters.  Useful for a log-style preview.
+    """
+
+    session_key: str
+    seq: int
+    role: str
+    content: str
+    timestamp: Optional[str] = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+    matched_in: str = "content"
+    snippet: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "session_key": self.session_key,
+            "seq": self.seq,
+            "role": self.role,
+            "content": self.content,
+            "timestamp": self.timestamp,
+            "extras": self.extras,
+            "matched_in": self.matched_in,
+            "snippet": self.snippet,
+        }
+
+
+def _compile_query(
+    query: str,
+    *,
+    regex: bool,
+    case_sensitive: bool,
+) -> re.Pattern[str]:
+    """Compile ``query`` into a regex.
+
+    ``regex=False`` treats ``query`` as a literal substring (via
+    :func:`re.escape`) so callers get grep-like semantics by default.
+    """
+    flags = 0 if case_sensitive else re.IGNORECASE
+    pattern = query if regex else re.escape(query)
+    try:
+        return re.compile(pattern, flags)
+    except re.error as exc:
+        raise ValueError(f"Invalid regex {query!r}: {exc}") from exc
+
+
+def _snippet(haystack: str, match: re.Match[str], *, radius: int = 60) -> str:
+    start = max(0, match.start() - radius)
+    end = min(len(haystack), match.end() + radius)
+    prefix = "…" if start > 0 else ""
+    suffix = "…" if end < len(haystack) else ""
+    # Collapse runs of whitespace so the preview stays single-line-ish.
+    body = re.sub(r"\s+", " ", haystack[start:end]).strip()
+    return f"{prefix}{body}{suffix}"
+
+
+def _message_matches(
+    msg: Dict[str, Any],
+    pattern: re.Pattern[str],
+    *,
+    include_extras: bool,
+) -> tuple[bool, str, str]:
+    """Return ``(matched, where, snippet)`` for ``msg`` vs ``pattern``."""
+    content = msg.get("content", "")
+    if not isinstance(content, str):
+        try:
+            content = json.dumps(content, ensure_ascii=False)
+        except Exception:
+            content = str(content)
+
+    m = pattern.search(content)
+    if m is not None:
+        return True, "content", _snippet(content, m)
+
+    if include_extras:
+        # Search over the JSON dump of extras so callers can grep
+        # tool_call_id, tool names, arguments, etc. in one shot.
+        extras = {
+            k: v for k, v in msg.items() if k not in ("role", "content", "timestamp")
+        }
+        if extras:
+            try:
+                extras_text = json.dumps(extras, ensure_ascii=False)
+            except Exception:
+                extras_text = str(extras)
+            m2 = pattern.search(extras_text)
+            if m2 is not None:
+                return True, "extras", _snippet(extras_text, m2)
+
+    return False, "", ""
 
 
 # ============================================================================
@@ -53,6 +165,111 @@ class SessionStore(ABC):
     @abstractmethod
     def list_session_keys(self) -> List[str]:
         """Return all known session keys (sorted)."""
+
+    # -- search --------------------------------------------------------------
+
+    def search_messages(
+        self,
+        query: str,
+        *,
+        session_key: Optional[str] = None,
+        regex: bool = False,
+        case_sensitive: bool = False,
+        roles: Optional[Iterable[str]] = None,
+        include_extras: bool = True,
+        limit: int = 50,
+        offset: int = 0,
+        max_content_length: Optional[int] = 2000,
+    ) -> List[SearchHit]:
+        """Default implementation: load the relevant sessions and filter in memory.
+
+        Backends with native full-text capability (Postgres ``tsvector``,
+        SQLite FTS, etc.) SHOULD override this for large corpora, but the
+        default is correct and works for every subclass.
+
+        Args:
+            query:              Needle string.  Treated as a literal substring
+                                unless ``regex=True``.
+            session_key:        Restrict to a single session; ``None`` searches
+                                all sessions known to the store.
+            regex:              Interpret ``query`` as a Python regex.
+            case_sensitive:     Self-explanatory.  Default is case-insensitive
+                                (matches typical grep ``-i`` behaviour).
+            roles:              Iterable of roles to keep (``user``,
+                                ``assistant``, ``tool``); ``None`` = all.
+            include_extras:     Also scan extra fields (``tool_call_id``,
+                                ``name``, serialized ``tool_calls``…) so tool
+                                outputs are actually discoverable.
+            limit:              Maximum hits to return.
+            offset:             Skip this many initial hits (paging).
+            max_content_length: Truncate ``content`` on returned hits to this
+                                many characters.  ``None`` returns the full
+                                content (be careful with giant tool outputs).
+
+        Returns:
+            A list of :class:`SearchHit` sorted by session then ``seq``.
+        """
+        pattern = _compile_query(query, regex=regex, case_sensitive=case_sensitive)
+        role_filter = {r.lower() for r in roles} if roles else None
+
+        if session_key is not None:
+            keys: List[str] = [session_key]
+        else:
+            keys = list(self.list_session_keys())
+
+        collected: List[SearchHit] = []
+        skipped = 0
+        for key in keys:
+            session = self.load_session(key)
+            if session is None:
+                continue
+            for seq, msg in enumerate(session.messages):
+                if not isinstance(msg, dict):
+                    continue
+                role = str(msg.get("role", "")).lower()
+                if role_filter is not None and role not in role_filter:
+                    continue
+
+                matched, where, snippet = _message_matches(
+                    msg, pattern, include_extras=include_extras
+                )
+                if not matched:
+                    continue
+
+                if skipped < offset:
+                    skipped += 1
+                    continue
+
+                content = msg.get("content", "")
+                if not isinstance(content, str):
+                    try:
+                        content = json.dumps(content, ensure_ascii=False)
+                    except Exception:
+                        content = str(content)
+                if max_content_length is not None and len(content) > max_content_length:
+                    content = content[:max_content_length] + "…"
+
+                extras = {
+                    k: v
+                    for k, v in msg.items()
+                    if k not in ("role", "content", "timestamp")
+                }
+
+                collected.append(
+                    SearchHit(
+                        session_key=key,
+                        seq=seq,
+                        role=role,
+                        content=content,
+                        timestamp=msg.get("timestamp"),
+                        extras=extras,
+                        matched_in=where,
+                        snippet=snippet,
+                    )
+                )
+                if len(collected) >= limit:
+                    return collected
+        return collected
 
     # -- optional convenience (default impl) --------------------------------
 
@@ -286,6 +503,122 @@ class SQLiteSessionStore(SessionStore):
             return [r["session_key"] for r in rows]
         return self._exec(_do)
 
+    # -- search (SQL LIKE prefilter + in-process regex refine) --------------
+
+    def search_messages(
+        self,
+        query: str,
+        *,
+        session_key: Optional[str] = None,
+        regex: bool = False,
+        case_sensitive: bool = False,
+        roles: Optional[Iterable[str]] = None,
+        include_extras: bool = True,
+        limit: int = 50,
+        offset: int = 0,
+        max_content_length: Optional[int] = 2000,
+    ) -> List[SearchHit]:
+        """SQLite-optimized search.
+
+        Strategy: a SQL ``LIKE`` prefilter narrows the candidate rows to those
+        that textually contain the query fragment (cheap, index-friendly via
+        the existing ``idx_msg_session``), then each surviving row is
+        re-checked in Python with the full regex/case rules.  For regex
+        queries we fall back to a full scan since ``LIKE`` cannot represent
+        arbitrary patterns.
+        """
+        pattern = _compile_query(query, regex=regex, case_sensitive=case_sensitive)
+        role_filter = {r.lower() for r in roles} if roles else None
+
+        # Build WHERE fragments
+        where_parts: list[str] = []
+        params: list[Any] = []
+
+        if session_key is not None:
+            where_parts.append("session_key = ?")
+            params.append(session_key)
+
+        if role_filter:
+            placeholders = ",".join("?" for _ in role_filter)
+            where_parts.append(f"LOWER(role) IN ({placeholders})")
+            params.extend(role_filter)
+
+        if not regex and query:
+            # SQLite ``LIKE`` is case-insensitive for ASCII by default. For
+            # case-sensitive queries we flip a pragma locally via COLLATE.
+            like = f"%{query}%"
+            if include_extras:
+                if case_sensitive:
+                    where_parts.append("(content GLOB ? OR extra_json GLOB ?)")
+                    glob = f"*{query}*"
+                    params.extend([glob, glob])
+                else:
+                    where_parts.append("(content LIKE ? OR extra_json LIKE ?)")
+                    params.extend([like, like])
+            else:
+                if case_sensitive:
+                    where_parts.append("content GLOB ?")
+                    params.append(f"*{query}*")
+                else:
+                    where_parts.append("content LIKE ?")
+                    params.append(like)
+
+        where_sql = f"WHERE {' AND '.join(where_parts)}" if where_parts else ""
+
+        def _do(conn):
+            sql = f"""
+                SELECT session_key, seq, role, content, timestamp, extra_json
+                FROM messages
+                {where_sql}
+                ORDER BY session_key, seq
+            """
+            return conn.execute(sql, params).fetchall()
+
+        rows = self._exec(_do)
+
+        collected: List[SearchHit] = []
+        skipped = 0
+        for row in rows:
+            msg: Dict[str, Any] = {
+                "role": row["role"],
+                "content": row["content"] or "",
+            }
+            if row["timestamp"]:
+                msg["timestamp"] = row["timestamp"]
+            extra = json.loads(row["extra_json"]) if row["extra_json"] else {}
+            msg.update(extra)
+
+            matched, where, snippet = _message_matches(
+                msg, pattern, include_extras=include_extras
+            )
+            if not matched:
+                continue
+            if skipped < offset:
+                skipped += 1
+                continue
+
+            content = msg["content"]
+            if not isinstance(content, str):
+                content = str(content)
+            if max_content_length is not None and len(content) > max_content_length:
+                content = content[:max_content_length] + "…"
+
+            collected.append(
+                SearchHit(
+                    session_key=row["session_key"],
+                    seq=int(row["seq"]),
+                    role=str(msg.get("role", "")).lower(),
+                    content=content,
+                    timestamp=msg.get("timestamp"),
+                    extras=extra,
+                    matched_in=where,
+                    snippet=snippet,
+                )
+            )
+            if len(collected) >= limit:
+                break
+        return collected
+
     def close(self) -> None:
         """No-op — connections are opened/closed per call."""
         pass
@@ -456,6 +789,123 @@ class PostgresSessionStore(SessionStore):
                 return [r[0] for r in cur.fetchall()]
         finally:
             conn.close()
+
+    # -- search -------------------------------------------------------------
+
+    def search_messages(
+        self,
+        query: str,
+        *,
+        session_key: Optional[str] = None,
+        regex: bool = False,
+        case_sensitive: bool = False,
+        roles: Optional[Iterable[str]] = None,
+        include_extras: bool = True,
+        limit: int = 50,
+        offset: int = 0,
+        max_content_length: Optional[int] = 2000,
+    ) -> List[SearchHit]:
+        """Postgres-optimized search.
+
+        Uses ``ILIKE`` / ``LIKE`` for literal substring queries and native
+        ``~``/``~*`` regex operators when ``regex=True``.  ``extra_json`` is
+        cast to ``text`` for grep-style matching inside JSON so tool-call
+        metadata is discoverable without needing JSONPath from callers.
+        """
+        pattern = _compile_query(query, regex=regex, case_sensitive=case_sensitive)
+        role_filter = {r.lower() for r in roles} if roles else None
+
+        conn = self._conn()
+        try:
+            with conn.cursor() as cur:
+                where_parts: list[str] = []
+                params: list[Any] = []
+
+                if session_key is not None:
+                    where_parts.append("session_key = %s")
+                    params.append(session_key)
+                if role_filter:
+                    placeholders = ",".join(["%s"] * len(role_filter))
+                    where_parts.append(f"LOWER(role) IN ({placeholders})")
+                    params.extend(role_filter)
+
+                if query:
+                    if regex:
+                        op = "~" if case_sensitive else "~*"
+                        if include_extras:
+                            where_parts.append(
+                                f"(content {op} %s OR extra_json::text {op} %s)"
+                            )
+                            params.extend([query, query])
+                        else:
+                            where_parts.append(f"content {op} %s")
+                            params.append(query)
+                    else:
+                        like_op = "LIKE" if case_sensitive else "ILIKE"
+                        like = f"%{query}%"
+                        if include_extras:
+                            where_parts.append(
+                                f"(content {like_op} %s OR extra_json::text {like_op} %s)"
+                            )
+                            params.extend([like, like])
+                        else:
+                            where_parts.append(f"content {like_op} %s")
+                            params.append(like)
+
+                where_sql = f"WHERE {' AND '.join(where_parts)}" if where_parts else ""
+                sql = f"""
+                    SELECT session_key, seq, role, content, timestamp, extra_json
+                    FROM messages
+                    {where_sql}
+                    ORDER BY session_key, seq
+                """
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+        finally:
+            conn.close()
+
+        collected: List[SearchHit] = []
+        skipped = 0
+        for row in rows:
+            s_key, seq, role, content, ts, extra_json = row
+            msg: Dict[str, Any] = {"role": role, "content": content or ""}
+            if ts:
+                msg["timestamp"] = ts.isoformat() if hasattr(ts, "isoformat") else str(ts)
+            extra = (
+                json.loads(extra_json) if isinstance(extra_json, str) else (extra_json or {})
+            )
+            msg.update(extra)
+
+            matched, where, snippet = _message_matches(
+                msg, pattern, include_extras=include_extras
+            )
+            if not matched:
+                continue
+            if skipped < offset:
+                skipped += 1
+                continue
+
+            c = msg.get("content", "") or ""
+            if not isinstance(c, str):
+                c = str(c)
+            if max_content_length is not None and len(c) > max_content_length:
+                c = c[:max_content_length] + "…"
+
+            collected.append(
+                SearchHit(
+                    session_key=s_key,
+                    seq=int(seq),
+                    role=str(role or "").lower(),
+                    content=c,
+                    timestamp=msg.get("timestamp"),
+                    extras=extra,
+                    matched_in=where,
+                    snippet=snippet,
+                )
+            )
+            if len(collected) >= limit:
+                break
+        return collected
 
     def close(self) -> None:
         pass  # connections are per-call

--- a/tests/test_history_search_e2e.py
+++ b/tests/test_history_search_e2e.py
@@ -1,0 +1,567 @@
+"""End-to-end test for the conversation-history-search feature.
+
+This script exercises the full stack *without* needing a real LLM:
+
+1.  Boots the gateway FastAPI app in-process with a stub agent whose
+    ``sessions`` attribute is a real :class:`SessionManager`.
+2.  Pre-populates two sessions with:
+      - user / assistant messages
+      - ``role="tool"`` messages carrying ``tool_call_id`` + serialised
+        tool output (the exact shape ``_persist_turn_tool_trace``
+        produces during a real agent turn).
+3.  Hits every public search surface and asserts the results match:
+      - ``SessionManager.search_messages`` (store layer)
+      - ``SearchHistoryTool.execute`` (builtin tool layer)
+      - ``GET /v1/sessions/search`` and ``GET /v1/sessions/{key}/search``
+        (REST layer)
+      - WebSocket ``session.search`` method via
+        :func:`TestClient.websocket_connect` (WS layer)
+
+Usage::
+
+    # Runs under pytest:
+    pytest tests/test_history_search_e2e.py -v
+
+    # …or as a standalone script:
+    python tests/test_history_search_e2e.py
+
+Exits non-zero on the first assertion failure so the user's terminal
+shows the actual breakage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+# Make sure we import *this* worktree, not any other spoon_bot on PYTHONPATH.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+# Disable auth so TestClient requests pass without tokens.
+os.environ.setdefault("GATEWAY_AUTH_REQUIRED", "false")
+os.environ.setdefault("SPOON_BOT_LOG_LEVEL", "WARNING")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from spoon_bot.session.manager import SessionManager
+from spoon_bot.session.store import FileSessionStore, SQLiteSessionStore, SearchHit
+from spoon_bot.agent.tools.history_search import SearchHistoryTool
+from spoon_bot.gateway.api.v1 import sessions as sessions_router_module
+from spoon_bot.gateway.websocket.handler import websocket_endpoint
+from spoon_bot.gateway import app as app_module
+
+
+# ---------------------------------------------------------------------------
+# Test harness (zero-dependency on pytest for stand-alone runs)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Result:
+    passed: int = 0
+    failed: int = 0
+    failures: list[str] = field(default_factory=list)
+
+
+_RESULT = _Result()
+
+
+def _record(name: str, ok: bool, detail: str = "") -> None:
+    if ok:
+        _RESULT.passed += 1
+        print(f"  PASS  {name}")
+    else:
+        _RESULT.failed += 1
+        _RESULT.failures.append(f"{name}: {detail}")
+        print(f"  FAIL  {name} :: {detail}")
+
+
+def _assert(name: str, ok: bool, detail: str = "") -> None:
+    _record(name, bool(ok), detail)
+    if not ok:
+        # Make pytest surface the failure too.
+        raise AssertionError(f"{name}: {detail}")
+
+
+# ---------------------------------------------------------------------------
+# Stub agent — only needs ``.sessions`` and ``._session``.
+# ---------------------------------------------------------------------------
+
+
+class _StubAgent:
+    def __init__(self, sessions: SessionManager, active_session_key: str) -> None:
+        self.sessions = sessions
+        self.session_key = active_session_key
+        self._session = sessions.get_or_create(active_session_key)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_manager(tmpdir: Path, *, backend: str) -> SessionManager:
+    if backend == "file":
+        store = FileSessionStore(tmpdir / "sessions_file")
+    elif backend == "sqlite":
+        store = SQLiteSessionStore(tmpdir / "sessions.db")
+    else:
+        raise ValueError(backend)
+    return SessionManager(store=store)
+
+
+def _seed_session(mgr: SessionManager, key: str, *, variant: str) -> None:
+    """Seed a session with realistic tool-call traffic.
+
+    ``variant=alpha`` – a research turn with a web_search call.
+    ``variant=beta``  – a coding turn with a read_file call.
+    """
+    s = mgr.get_or_create(key)
+
+    if variant == "alpha":
+        s.add_message("user", "look up the current price of ETH on mainnet")
+        # assistant issues a tool call (mirrors _capture_turn_tool_trace output)
+        s.add_message(
+            "assistant",
+            "I'll look that up.",
+            tool_calls=[
+                {
+                    "id": "call_eth_price_001",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": json.dumps({"query": "ETH price USD"}),
+                    },
+                }
+            ],
+        )
+        s.add_message(
+            "tool",
+            "ETH/USD: 3421.55 (source: coingecko, ts=2025-11-04T10:22Z)",
+            tool_call_id="call_eth_price_001",
+            name="web_search",
+        )
+        s.add_message("assistant", "Ethereum is currently trading around $3,421.55.")
+    elif variant == "beta":
+        s.add_message("user", "show me the top of README.md please")
+        s.add_message(
+            "assistant",
+            "Reading the file now.",
+            tool_calls=[
+                {
+                    "id": "call_read_readme_42",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": json.dumps({"path": "README.md", "limit": 3}),
+                    },
+                }
+            ],
+        )
+        s.add_message(
+            "tool",
+            "# spoon-bot\n\nAn agent runtime with pluggable channels and skills.",
+            tool_call_id="call_read_readme_42",
+            name="read_file",
+        )
+        s.add_message("assistant", "Here are the first lines of README.md: …")
+    else:
+        raise ValueError(variant)
+
+    mgr.save(s)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — SessionManager.search_messages (store-layer)
+# ---------------------------------------------------------------------------
+
+
+def phase_store_layer(mgr: SessionManager) -> None:
+    print("\n[phase] store-layer SessionManager.search_messages")
+
+    # Substring match across both sessions
+    hits = mgr.search_messages("ETH", limit=10)
+    _assert(
+        "store.substring.any-session",
+        any(h.session_key == "s-alpha" and h.role in ("assistant", "tool") for h in hits),
+        f"no s-alpha hit in {[h.session_key + ':' + h.role for h in hits]}",
+    )
+
+    # tool_call_id lives in extras — include_extras=True must find it
+    hits = mgr.search_messages("call_read_readme_42", include_extras=True, limit=10)
+    _assert(
+        "store.extras.tool_call_id",
+        any(h.matched_in == "extras" and h.session_key == "s-beta" for h in hits),
+        f"no extras-hit for tool_call_id in {hits!r}",
+    )
+
+    # include_extras=False must NOT match tool_call_id
+    hits = mgr.search_messages("call_read_readme_42", include_extras=False, limit=10)
+    _assert("store.extras.disabled", len(hits) == 0, f"expected 0 hits, got {len(hits)}")
+
+    # Role filter
+    hits = mgr.search_messages(
+        "coingecko", roles=["tool"], limit=10, include_extras=False
+    )
+    _assert(
+        "store.roles.tool-only",
+        len(hits) == 1 and hits[0].role == "tool",
+        f"expected 1 tool hit, got {[h.role for h in hits]}",
+    )
+
+    # Session scoping
+    hits = mgr.search_messages("README", session_key="s-alpha", limit=10)
+    _assert("store.scope.single-session", len(hits) == 0, f"s-alpha should not mention README, got {hits!r}")
+
+    hits = mgr.search_messages("README", session_key="s-beta", limit=10)
+    _assert("store.scope.correct-session", len(hits) >= 1, f"expected s-beta hit, got {hits!r}")
+
+    # Regex
+    hits = mgr.search_messages(r"\$\d+,\d{3}", regex=True, limit=10)
+    _assert("store.regex", len(hits) >= 1, "regex search for $X,XXX should hit the eth reply")
+
+    # Case sensitivity: "ETH" is in content; "eth" (lowercase) also present
+    hits_ci = mgr.search_messages("eth", case_sensitive=False, limit=20)
+    hits_cs = mgr.search_messages("ETH", case_sensitive=True, limit=20)
+    _assert(
+        "store.case.insensitive-superset",
+        len(hits_ci) >= len(hits_cs),
+        f"CI should find >= CS; got CI={len(hits_ci)} CS={len(hits_cs)}",
+    )
+
+    # Snippet sanity
+    hits = mgr.search_messages("ETH/USD", limit=1)
+    _assert(
+        "store.snippet.non-empty",
+        len(hits) == 1 and "ETH/USD" in hits[0].snippet,
+        f"snippet was {hits[0].snippet!r}" if hits else "no hits",
+    )
+
+    # Dirty-flush semantics: write a message to cache then search without explicit save
+    live = mgr.get_or_create("s-alpha")
+    live.add_message("user", "UNIQUE_TOKEN_FLUSH_TEST_9271")
+    # Do NOT call mgr.save(live) — rely on search_messages to flush.
+    hits = mgr.search_messages("UNIQUE_TOKEN_FLUSH_TEST_9271", limit=5)
+    _assert(
+        "store.dirty-flush",
+        any("UNIQUE_TOKEN_FLUSH_TEST_9271" in h.content for h in hits),
+        "dirty cached message was not flushed before search",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — SearchHistoryTool (builtin tool used by the LLM)
+# ---------------------------------------------------------------------------
+
+
+def phase_builtin_tool(mgr: SessionManager) -> None:
+    print("\n[phase] builtin SearchHistoryTool.execute()")
+
+    tool = SearchHistoryTool(mgr, default_session_key="s-alpha")
+
+    # scope=current should only search the default session
+    out = asyncio.run(tool.execute(query="README"))
+    payload = json.loads(out)
+    _assert(
+        "tool.scope.current-no-match",
+        payload["total"] == 0,
+        f"scope=current (s-alpha) should not find README; got {payload['total']} hits",
+    )
+
+    # scope=all finds README hit
+    out = asyncio.run(tool.execute(query="README", scope="all"))
+    payload = json.loads(out)
+    _assert(
+        "tool.scope.all",
+        payload["total"] >= 1
+        and any(h["session_key"] == "s-beta" for h in payload["hits"]),
+        f"expected scope=all to return a s-beta README hit; got {payload}",
+    )
+
+    # tool_call_id propagates into hit.tool_call_id when matched_in=extras
+    out = asyncio.run(
+        tool.execute(query="call_eth_price_001", scope="all", include_extras=True)
+    )
+    payload = json.loads(out)
+    matching = [h for h in payload["hits"] if h["tool_call_id"] == "call_eth_price_001"]
+    _assert(
+        "tool.tool_call_id.surfaced",
+        len(matching) >= 1,
+        f"tool_call_id not surfaced in hit; got {payload}",
+    )
+
+    # Roles filter, current scope
+    out = asyncio.run(tool.execute(query="coingecko", roles=["tool"]))
+    payload = json.loads(out)
+    _assert(
+        "tool.roles.filter",
+        payload["total"] == 1 and payload["hits"][0]["role"] == "tool",
+        f"expected single tool hit, got {payload}",
+    )
+
+    # Bad regex is reported, not crashed
+    out = asyncio.run(tool.execute(query="[unclosed", regex=True))
+    _assert(
+        "tool.regex.error-message",
+        out.startswith("Error:") and "regex" in out.lower(),
+        f"bad regex should return Error; got {out!r}",
+    )
+
+    # Empty query rejected
+    out = asyncio.run(tool.execute(query=""))
+    _assert(
+        "tool.empty-query",
+        out.startswith("Error:"),
+        f"empty query should error; got {out!r}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — REST + WebSocket via TestClient
+# ---------------------------------------------------------------------------
+
+
+def _build_app(stub_agent: _StubAgent) -> FastAPI:
+    """Build a minimal FastAPI app that wires our stub as the global agent."""
+    from spoon_bot.gateway.config import GatewayConfig
+    from spoon_bot.gateway.websocket.manager import ConnectionManager
+
+    config = GatewayConfig()
+    app_module._agent = stub_agent  # type: ignore[attr-defined]
+    app_module._config = config  # type: ignore[attr-defined]
+    app_module._auth_required = False  # type: ignore[attr-defined]
+    app_module._connection_manager = ConnectionManager()  # type: ignore[attr-defined]
+
+    app = FastAPI()
+    app.include_router(
+        sessions_router_module.router, prefix="/v1/sessions", tags=["sessions"]
+    )
+    app.add_api_websocket_route("/v1/ws", websocket_endpoint)
+    return app
+
+
+def phase_rest(client: TestClient) -> None:
+    print("\n[phase] REST  GET /v1/sessions/search")
+
+    # Cross-session search
+    r = client.get("/v1/sessions/search", params={"q": "ETH"})
+    _assert("rest.search.all.status", r.status_code == 200, f"status={r.status_code} body={r.text}")
+    body = r.json()
+    _assert(
+        "rest.search.all.hit",
+        body["success"] and body["data"]["total"] >= 1,
+        f"body={body}",
+    )
+
+    # Per-session search: beta mentions README, alpha does not
+    r = client.get("/v1/sessions/s-beta/search", params={"q": "README"})
+    _assert("rest.search.beta.status", r.status_code == 200, r.text)
+    body = r.json()
+    _assert(
+        "rest.search.beta.hit",
+        body["data"]["total"] >= 1
+        and all(h["session_key"] == "s-beta" for h in body["data"]["hits"]),
+        f"body={body}",
+    )
+
+    r = client.get("/v1/sessions/s-alpha/search", params={"q": "README"})
+    body = r.json()
+    _assert(
+        "rest.search.alpha.no-readme",
+        r.status_code == 200 and body["data"]["total"] == 0,
+        f"body={body}",
+    )
+
+    # Per-session search hits tool_call_id in extras
+    r = client.get(
+        "/v1/sessions/s-beta/search", params={"q": "call_read_readme_42"}
+    )
+    body = r.json()
+    _assert(
+        "rest.search.extras",
+        r.status_code == 200
+        and body["data"]["total"] >= 1
+        and any(h["matched_in"] == "extras" for h in body["data"]["hits"]),
+        f"body={body}",
+    )
+
+    # 404 for unknown session
+    r = client.get("/v1/sessions/does-not-exist/search", params={"q": "anything"})
+    _assert("rest.search.404", r.status_code == 404, f"status={r.status_code} body={r.text}")
+
+    # Invalid regex returns 400
+    r = client.get("/v1/sessions/search", params={"q": "[unclosed", "regex": "true"})
+    _assert(
+        "rest.search.invalid-regex",
+        r.status_code == 400,
+        f"status={r.status_code} body={r.text}",
+    )
+
+    # Ensure static /search did NOT get swallowed by /{session_key}
+    r = client.get("/v1/sessions/search", params={"q": "ETH", "limit": 1})
+    body = r.json()
+    _assert(
+        "rest.search.route-order",
+        r.status_code == 200 and isinstance(body["data"]["hits"], list),
+        f"/search was swallowed by /{{session_key}}: status={r.status_code}",
+    )
+
+
+def phase_websocket(client: TestClient) -> None:
+    print("\n[phase] WS    session.search")
+
+    with client.websocket_connect("/v1/ws") as ws:
+        # First frame is the connection.established event — consume it.
+        first = ws.receive_json()
+        _assert(
+            "ws.connection.established",
+            first.get("event") == "connection.established",
+            f"first frame: {first!r}",
+        )
+
+        def _call(params: dict[str, Any], *, req_id: str) -> dict[str, Any]:
+            ws.send_json({"id": req_id, "method": "session.search", "params": params})
+            while True:
+                msg = ws.receive_json()
+                if msg.get("id") == req_id:
+                    return msg
+
+        # Cross-session search, scope via session_key=None
+        resp = _call({"q": "coingecko"}, req_id="req-1")
+        _assert(
+            "ws.search.basic",
+            resp.get("error") is None
+            and resp.get("result", {}).get("total", 0) >= 1,
+            f"resp={resp}",
+        )
+        hits = resp["result"]["hits"]
+        _assert(
+            "ws.search.tool-hit",
+            any(h["role"] == "tool" and "coingecko" in h["content"] for h in hits),
+            f"hits={hits}",
+        )
+
+        # Scoped to a single session
+        resp = _call(
+            {"q": "README", "session_key": "s-beta"}, req_id="req-2"
+        )
+        _assert(
+            "ws.search.scoped",
+            resp.get("error") is None
+            and resp["result"]["total"] >= 1
+            and all(h["session_key"] == "s-beta" for h in resp["result"]["hits"]),
+            f"resp={resp}",
+        )
+
+        # Role filter
+        resp = _call(
+            {"q": "ETH/USD", "roles": ["tool"]}, req_id="req-3"
+        )
+        _assert(
+            "ws.search.roles",
+            resp.get("error") is None
+            and resp["result"]["total"] == 1
+            and resp["result"]["hits"][0]["role"] == "tool",
+            f"resp={resp}",
+        )
+
+        # Invalid regex → structured error field (not a disconnect)
+        resp = _call({"q": "[unclosed", "regex": True}, req_id="req-4")
+        result = resp.get("result") or {}
+        err_field = result.get("error")
+        _assert(
+            "ws.search.invalid-regex",
+            err_field in {"INVALID_REGEX", "INVALID_QUERY"},
+            f"resp={resp}",
+        )
+
+        # Empty q → INVALID_QUERY
+        resp = _call({"q": ""}, req_id="req-5")
+        result = resp.get("result") or {}
+        err_field = result.get("error")
+        _assert(
+            "ws.search.empty-q",
+            err_field in {"INVALID_QUERY", "INVALID_REGEX"},
+            f"resp={resp}",
+        )
+
+        # Extras matching through the WS layer
+        resp = _call(
+            {"q": "call_eth_price_001", "include_extras": True},
+            req_id="req-6",
+        )
+        result = resp.get("result") or {}
+        hits = result.get("hits") or []
+        _assert(
+            "ws.search.extras",
+            result.get("error") is None
+            and any(h.get("matched_in") == "extras" for h in hits),
+            f"resp={resp}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main harness
+# ---------------------------------------------------------------------------
+
+
+def _run_all_for_backend(tmpdir: Path, backend: str) -> None:
+    print(f"\n================ backend: {backend} ================")
+    mgr = _build_manager(tmpdir, backend=backend)
+    _seed_session(mgr, "s-alpha", variant="alpha")
+    _seed_session(mgr, "s-beta", variant="beta")
+
+    phase_store_layer(mgr)
+    phase_builtin_tool(mgr)
+
+    stub = _StubAgent(mgr, active_session_key="s-alpha")
+    app = _build_app(stub)
+    with TestClient(app) as client:
+        phase_rest(client)
+        phase_websocket(client)
+
+
+def test_history_search_full_stack(tmp_path: Path) -> None:
+    """Pytest entrypoint – runs the full matrix."""
+    for backend in ("file", "sqlite"):
+        sub = tmp_path / backend
+        sub.mkdir()
+        _run_all_for_backend(sub, backend)
+
+    if _RESULT.failed:
+        raise AssertionError(
+            f"{_RESULT.failed} check(s) failed: {_RESULT.failures}"
+        )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        for backend in ("file", "sqlite"):
+            sub = root / backend
+            sub.mkdir()
+            try:
+                _run_all_for_backend(sub, backend)
+            except AssertionError as exc:
+                print(f"\n[FATAL] backend={backend} :: {exc}")
+                break
+
+    print("\n===================  SUMMARY  ===================")
+    print(f"  passed: {_RESULT.passed}")
+    print(f"  failed: {_RESULT.failed}")
+    for f in _RESULT.failures:
+        print(f"   - {f}")
+    return 0 if _RESULT.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_runtime_compaction.py
+++ b/tests/test_runtime_compaction.py
@@ -1,0 +1,219 @@
+"""Unit-level regression tests for the runtime context-compaction pipeline.
+
+These tests cover the invariants introduced for the "all tool inputs/outputs
+stay in context and remain searchable after compression" requirement:
+
+* ``_trim_context_if_needed`` is a no-op (the persisted session store is
+  the authoritative transcript and must never be trimmed destructively).
+* ``_snap_drop_end_to_turn_boundary`` never splits an
+  ``assistant(tool_calls) -> tool(result)`` pair.
+* Proactive compression in ``_compress_runtime_context`` only drops on
+  safe boundaries and inserts a ``[history-compacted]`` marker.
+* ``_force_compress_runtime_context`` honours the same segment-aware rule.
+
+The tests operate on a minimal ``AgentLoop`` built via ``__new__`` plus a
+``MagicMock`` memory (same pattern as ``test_runtime_message_sequence``)
+so they do not require any LLM / network setup.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_loop(messages: list, context_window: int = 10_000):
+    """Construct a bare ``AgentLoop`` with an in-memory messages list."""
+    from spoon_bot.agent.loop import AgentLoop
+
+    loop = AgentLoop.__new__(AgentLoop)
+    loop.context_window = context_window
+    loop._agent = MagicMock()
+    loop._agent.memory = MagicMock()
+    loop._agent.memory.messages = messages
+    return loop
+
+
+def _roles(messages: list) -> list[str | None]:
+    from spoon_bot.agent.loop import AgentLoop
+
+    return [AgentLoop._message_role_value(m) for m in messages]
+
+
+@pytest.mark.requires_spoon_core
+def test_trim_context_if_needed_is_noop():
+    """``_trim_context_if_needed`` must never mutate the session store."""
+    from spoon_ai.schema import Message
+    from spoon_bot.agent.loop import AgentLoop
+
+    loop = _make_loop([Message(role="user", content=f"m{i}") for i in range(100)])
+    # ``_session`` and other session-related attrs are intentionally missing;
+    # the method must bail out cleanly regardless.
+    result = AgentLoop._trim_context_if_needed(loop)
+    assert result == 0
+
+
+@pytest.mark.requires_spoon_core
+def test_snap_drop_end_never_splits_tool_pair():
+    """Snapping must land on a user boundary when a tool pair would split."""
+    from spoon_ai.schema import Function, Message, ToolCall
+    from spoon_bot.agent.loop import AgentLoop
+
+    tc = ToolCall(id="call_a", function=Function(name="shell", arguments="{}"))
+    messages = [
+        Message(role="system", content="sys"),                      # 0 (head)
+        Message(role="user", content="first user"),                 # 1
+        Message(role="assistant", content="", tool_calls=[tc]),     # 2
+        Message(role="tool", content="done", tool_call_id="call_a", name="shell"),  # 3
+        Message(role="user", content="second user"),                # 4
+        Message(role="assistant", content="ok"),                    # 5
+    ]
+
+    # Desired end = 3 would split the (assistant tool_calls, tool) pair
+    # that spans 2 -> 3.  Snap must walk back to the user at index 1.
+    snap = AgentLoop._snap_drop_end_to_turn_boundary(messages, keep_head=1, desired_end=3)
+    assert snap == 1, f"expected snap back to user@1, got {snap}"
+
+    # Desired end = 4 is allowed: it's exactly the next user turn, and
+    # the tool pair at 2-3 is fully contained in the drop range.
+    snap2 = AgentLoop._snap_drop_end_to_turn_boundary(messages, keep_head=1, desired_end=4)
+    assert snap2 == 4, f"expected snap to user@4, got {snap2}"
+
+
+@pytest.mark.requires_spoon_core
+def test_snap_drop_end_stops_on_settled_assistant_turn():
+    """An assistant without tool_calls, not followed by tool, is a safe cut."""
+    from spoon_ai.schema import Message
+    from spoon_bot.agent.loop import AgentLoop
+
+    messages = [
+        Message(role="system", content="sys"),     # 0
+        Message(role="user", content="u1"),        # 1
+        Message(role="assistant", content="a1"),   # 2  (settled)
+        Message(role="user", content="u2"),        # 3
+        Message(role="assistant", content="a2"),   # 4
+    ]
+
+    # Desired end = 3 lands directly on a user turn (preferred).
+    snap = AgentLoop._snap_drop_end_to_turn_boundary(messages, keep_head=1, desired_end=3)
+    assert snap == 3
+
+    # Desired end = 2 lands on a settled assistant whose next message is
+    # ``user``, so it is also a valid cut.
+    snap2 = AgentLoop._snap_drop_end_to_turn_boundary(messages, keep_head=1, desired_end=2)
+    assert snap2 == 2
+
+
+@pytest.mark.requires_spoon_core
+def test_insert_compaction_marker_is_runtime_only():
+    """The marker lands in runtime memory with role=user and references search_history."""
+    from spoon_ai.schema import Message
+    from spoon_bot.agent.loop import AgentLoop
+
+    messages = [Message(role="system", content="sys"), Message(role="user", content="u")]
+    loop = _make_loop(messages)
+    AgentLoop._insert_compaction_marker(loop, messages, dropped=7)
+
+    # Marker is inserted after the head (system) message.
+    assert _roles(messages)[:3] == ["system", "user", "user"]
+    marker = messages[1]
+    content = getattr(marker, "content", "")
+    assert "[history-compacted]" in content
+    assert "7" in content
+    assert "search_history" in content
+
+
+@pytest.mark.requires_spoon_core
+def test_force_compress_drops_segment_aware_and_inserts_marker():
+    """Force-compression must not split tool pairs and must insert the marker."""
+    from spoon_ai.schema import Function, Message, ToolCall
+    from spoon_bot.agent.loop import AgentLoop
+
+    def tool_pair(i: int) -> list:
+        tc = ToolCall(
+            id=f"call_{i}",
+            function=Function(name="shell", arguments="{}"),
+        )
+        return [
+            Message(role="user", content=f"u{i} " + "x" * 400),
+            Message(role="assistant", content="", tool_calls=[tc]),
+            Message(role="tool", content=f"r{i} " + "y" * 400, tool_call_id=f"call_{i}", name="shell"),
+        ]
+
+    messages: list = [Message(role="system", content="sys" + "z" * 400)]
+    for i in range(6):  # 18 tool-turn messages + 1 system = 19 messages
+        messages.extend(tool_pair(i))
+
+    loop = _make_loop(messages, context_window=200)  # force aggressive drops
+    before_len = len(messages)
+
+    dropped_actions = AgentLoop._force_compress_runtime_context(loop)
+
+    # Something was dropped or truncated.
+    assert dropped_actions > 0
+
+    # No orphan: every ``role=tool`` message must be immediately preceded
+    # by an ``assistant`` with tool_calls containing the matching id.
+    for idx, msg in enumerate(messages):
+        if AgentLoop._message_role_value(msg) != "tool":
+            continue
+        assert idx > 0, "tool message at position 0 is invalid"
+        prev = messages[idx - 1]
+        prev_role = AgentLoop._message_role_value(prev)
+        assert prev_role == "assistant", (
+            f"tool@{idx} not preceded by assistant (got {prev_role})"
+        )
+        prev_tc = getattr(prev, "tool_calls", None) or []
+        ids = {getattr(tc, "id", None) for tc in prev_tc}
+        assert getattr(msg, "tool_call_id", None) in ids, (
+            f"tool@{idx} has tool_call_id {getattr(msg, 'tool_call_id', None)} "
+            f"not present in preceding assistant tool_calls {ids}"
+        )
+
+    # If we actually shrunk the list, a compaction marker must exist.
+    if len(messages) < before_len:
+        marker_present = any(
+            getattr(m, "role", None) in ("user", "User")
+            and "[history-compacted]" in (getattr(m, "content", "") or "")
+            for m in messages
+        )
+        assert marker_present, "expected [history-compacted] marker in runtime memory"
+
+
+@pytest.mark.requires_spoon_core
+def test_compress_runtime_context_keeps_tool_pairs_atomic():
+    """Phase-3 drops in ``_compress_runtime_context`` must not orphan tools."""
+    from spoon_ai.schema import Function, Message, ToolCall
+    from spoon_bot.agent.loop import AgentLoop
+
+    def tool_pair(i: int) -> list:
+        tc = ToolCall(
+            id=f"call_{i}",
+            function=Function(name="shell", arguments="{}"),
+        )
+        return [
+            Message(role="user", content=f"u{i} " + "x" * 200),
+            Message(role="assistant", content="", tool_calls=[tc]),
+            Message(role="tool", content=f"r{i} " + "y" * 200, tool_call_id=f"call_{i}", name="shell"),
+        ]
+
+    messages: list = [Message(role="system", content="sys")]
+    for i in range(8):
+        messages.extend(tool_pair(i))
+
+    loop = _make_loop(messages, context_window=400)  # tiny budget -> triggers phase 3
+    AgentLoop._compress_runtime_context(loop)
+
+    for idx, msg in enumerate(messages):
+        if AgentLoop._message_role_value(msg) != "tool":
+            continue
+        assert idx > 0, "tool message at position 0 is invalid"
+        prev = messages[idx - 1]
+        prev_role = AgentLoop._message_role_value(prev)
+        assert prev_role == "assistant", (
+            f"tool@{idx} not preceded by assistant (got {prev_role})"
+        )
+        prev_tc = getattr(prev, "tool_calls", None) or []
+        ids = {getattr(tc, "id", None) for tc in prev_tc}
+        assert getattr(msg, "tool_call_id", None) in ids


### PR DESCRIPTION
## Summary

Adds a **conversation history search** capability (agent tool + WS + REST)
and overhauls runtime context compaction so that **all tool-call inputs /
outputs stay in the persisted session store and remain searchable even
after the LLM context has been compacted**.

Motivation: users were losing access to earlier tool results after the
context window was trimmed, and the agent had no way to recover them.
The old trimming path also destructively mutated the session store and
could split `assistant(tool_calls) -> tool(result)` pairs when cutting
messages — leaving orphan tool messages that providers reject.

## What's in the box

### 1. Search surfaces
- New builtin tool `search_history` (scope=`current` | `session` | `all`),
  registered in `CORE_TOOLS` so every profile gets it.
- New WebSocket method `session.search`.
- New REST routes `GET /v1/sessions/search` and
  `GET /v1/sessions/{key}/search`.
- `SessionStore.search_messages` with concrete implementations on
  file / SQLite / Postgres backends (regex + substring, role / extras
  filters, pagination, role=tool blobs surfaced).
- Assistant tool_calls and tool results are persisted on every turn via
  `_persist_turn_tool_trace`, so the full transcript (including tool
  I/O) survives beyond runtime memory.

### 2. Context compaction — non-destructive + segment-aware
- Persisted session store is now the authoritative, immutable transcript.
  `_trim_context_if_needed` is a deliberate no-op.
- `_compress_runtime_context` / `_force_compress_runtime_context` use
  `_snap_drop_end_to_turn_boundary` to drop only on safe boundaries
  (user turn or fully-settled assistant turn) — tool pairs are atomic.
- `_insert_compaction_marker` writes a **runtime-only** `[history-compacted]`
  system message after a drop, pointing the model at `search_history`.
  The marker never touches the persisted store, so the real transcript
  stays clean.
- `_prepare_request_context` compresses proactively before each LLM call
  (no more waiting for a provider error to trigger recovery).

### 3. Correctness fixes surfaced by E2E
- `SearchHistoryTool` uses a **pull-based session-key resolver**
  (`session_key_resolver`) wired from `AgentLoop`, so it always targets
  the active WS session instead of a stale `"default"` key.
- `_sync_runtime_history_from_session` now rehydrates `tool_call_id`,
  `tool_name`, and `tool_calls` when injecting persisted messages back
  into runtime memory — eliminates the `Dropping tool message with
  missing tool_call_id` warnings observed on session reload.
- WS handler calls `manager.touch(conn_id)` on every inbound frame so
  half-open connections are evicted by the idle sweeper (carried over
  from the earlier WS resilience work).

## Test plan

Ran locally on `feat/conversation-history-search`:

- [x] `pytest tests/test_runtime_compaction.py` — 6 passed (trim no-op,
      segment-aware snap, marker insertion, atomic tool pairs under
      both normal and force compression).
- [x] `pytest tests/test_runtime_message_sequence.py
       tests/test_history_search_e2e.py` — 4 passed (3 pre-existing +
      full-stack REST/WS search integration).
- [x] `python tests/test_cypher_game_ws.py` — exit 0, **10/10 guards**,
      using a **single-line prompt**:
        `Play one full round of the SPOT on-chain game using the
         spot-agent-cypher skill and report the result.`
      Round played: gameId=232, spot=C. Guards include:
        - `play-round.completed`
        - `play-round.tool_call_extras`
        - `ws.search.any-hit` / `ws.search.tool-trace-hits`
        - `rest.search.wallet-hit`
        - `recall.completed`
        - `recall.no-tool-metadata-loss-during-sync`
        - `recall.invoked-search_history`
        - `recall.search_history.session_key-resolved-to-active`
        - `recall.search_history.no-stale-default-session_key`

### Suggested reviewer checks
- [ ] Confirm `_trim_context_if_needed` being a no-op is acceptable in
      callers that previously relied on its return value for metrics
      (all grep'd paths now treat 0 as the no-op case).
- [ ] Confirm `search_history` appearing in `CORE_TOOLS` is fine for
      the minimal tool profile (it only reads from the session store).
- [ ] Verify the new Postgres / SQLite `search_messages` queries on
      your preferred deployment backend.

Made with [Cursor](https://cursor.com)