### PR TITLE
Preserve context across retries and compressed history recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,8 +59,11 @@ OPENROUTER_API_KEY=sk-or-your-openrouter-api-key-here
 #
 # Override the context window size in tokens.
 # If not set, auto-resolved based on the model (default: 128000).
-# Examples: 128000 (128K), 200000 (200K), 1000000 (1M)
-# CONTEXT_WINDOW=128000
+# Examples: 128000 (128K), 400000 (GPT-5.4 operational cap), 1000000 (1M).
+# Preferred env var:
+# SPOON_BOT_CONTEXT_WINDOW=400000
+# Legacy alias (still supported):
+# CONTEXT_WINDOW=400000
 
 # ======= YOLO Mode (optional) =======
 #

--- a/README.md
+++ b/README.md
@@ -514,12 +514,24 @@ Use the `activate_tool` tool with actions `activate` (single or batch) and `list
 
 ## Context Window
 
-spoon-bot automatically resolves the context window based on the selected model. For example, Claude Sonnet 4.5 gets 1M tokens, GPT-5.2 gets 400K, and DeepSeek V3.2 gets 164K. The default for unknown models is 128K.
+spoon-bot automatically resolves the context window based on the selected model. For example, Claude Sonnet 4.5 gets 1M tokens, GPT-5.2 gets 400K, GPT-5.4 is intentionally capped at 400K in spoon-bot, and DeepSeek V3.2 gets 164K. The default for unknown models is 128K.
 
-You can override this via environment variable or code:
+Before a provider call, spoon-bot now proactively compacts runtime context when it nears the configured window. If a provider still rejects the request as too large, spoon-bot compacts once more and retries the same request without dropping the latest user turn.
+
+You can override this via YAML, environment variable, or code:
+
+```yaml
+agent:
+  context_window: 400000
+```
 
 ```bash
 # Override to 256K
+SPOON_BOT_CONTEXT_WINDOW=256000 spoon-bot agent --model gpt-5.2
+```
+
+```bash
+# Legacy alias
 CONTEXT_WINDOW=256000 spoon-bot agent --model gpt-5.2
 ```
 
@@ -860,7 +872,8 @@ ruff check spoon_bot/
 | `SESSION_STORE_BACKEND` | `file` | Session backend: `file`, `sqlite`, `postgres` |
 | `SESSION_STORE_DB_PATH` | `./workspace/sessions.db` | SQLite database path |
 | `SESSION_STORE_DSN` | — | PostgreSQL connection string |
-| `CONTEXT_WINDOW` | auto | Context window override (tokens) |
+| `SPOON_BOT_CONTEXT_WINDOW` | auto | Context window override (tokens, recommended) |
+| `CONTEXT_WINDOW` | auto | Legacy alias for `SPOON_BOT_CONTEXT_WINDOW` |
 | `GATEWAY_AUTH_REQUIRED` | `false` | Enable gateway authentication |
 | `GATEWAY_API_KEY` | — | Gateway API key |
 | `JWT_SECRET` | — | JWT signing secret |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -39,7 +39,9 @@ agent:
   # shell_max_timeout: 7200    # Max allowed per-command timeout override (2 hours).
                                 # The agent can request longer timeouts up to this cap.
   # max_output: 10000
-  # context_window: 200000
+  # context_window: 400000      # Optional explicit cap in tokens.
+                                 # spoon-bot proactively compacts near this limit.
+                                 # Example: keep GPT-5.4 at 400K for stability.
   # auto_reload: false          # Watch skill paths & config for changes, auto-reload
   # auto_reload_interval: 5     # Poll interval in seconds (1-300)
 

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -123,7 +123,12 @@ from spoon_bot.exceptions import (
     user_friendly_error,
 )
 from spoon_bot.services.git import GitManager
-from spoon_bot.utils.retry import RetryConfig, with_provider_retry, is_retryable
+from spoon_bot.utils.retry import (
+    DEFAULT_RETRY_CONFIG,
+    RetryConfig,
+    is_context_overflow_error,
+    with_provider_retry,
+)
 
 if TYPE_CHECKING:
     from spoon_bot.session.manager import Session
@@ -1342,14 +1347,14 @@ class AgentLoop:
         return injected_count
 
     async def _prepare_request_context(self) -> None:
-        """Prepare request context by injecting session history and, if
-        needed, compacting runtime memory *before* the LLM sees it.
+        """Prepare request context by injecting persisted history into runtime memory.
 
         Persisted history (``self._session.messages``) is the authoritative
-        store and is never trimmed here — see
-        :meth:`_trim_context_if_needed` for the reasoning.  Runtime memory
-        is what goes into the next provider request, so that is the only
-        thing compacted by this method.
+        store and is never trimmed here — see :meth:`_trim_context_if_needed`.
+        Runtime memory is rebuilt from the persisted transcript for the next
+        provider request. If that rebuilt runtime context is already close to
+        the configured ``context_window``, older runtime-only history is
+        compacted before the provider call starts.
         """
         trimmed_count = self._trim_context_if_needed()  # always 0 now
         injected_count = await self._sync_runtime_history_from_session()
@@ -1364,20 +1369,20 @@ class AgentLoop:
             if isinstance(messages_ref, list):
                 repaired = self._normalize_runtime_tool_context(messages_ref)
 
-        # Proactively compact runtime memory before the turn so we don't
-        # have to rely on a provider token-overflow error to trigger
-        # compaction.  ``_compress_runtime_context`` is a no-op when we're
-        # under the 50 % budget.  It preserves tool-pair atomicity and
-        # (if a drop happens) injects a ``[history-compacted]`` marker
-        # message pointing the model at ``search_history``.
         compressed = 0
-        if isinstance(messages_ref, list) and messages_ref:
-            try:
-                compressed = self._compress_runtime_context()
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.debug(f"Proactive runtime compression skipped: {exc}")
-
         runtime_tokens = self._estimate_runtime_tokens()
+        trigger_budget = self._runtime_compaction_trigger_budget()
+        if isinstance(messages_ref, list) and messages_ref and runtime_tokens > trigger_budget:
+            try:
+                compressed = self._compress_runtime_context(
+                    force=True,
+                    budget_tokens=trigger_budget,
+                )
+            except Exception as exc:
+                logger.debug(f"Proactive runtime compaction skipped: {exc}")
+            if runtime_tokens > trigger_budget and compressed == 0:
+                compressed = self._force_compress_runtime_context()
+            runtime_tokens = self._estimate_runtime_tokens()
         session_tokens = self._estimate_token_count()
 
         logger.info(
@@ -1556,6 +1561,38 @@ class AgentLoop:
             return self.context._build_user_content(text_content, media)
         return text_content
 
+    @staticmethod
+    def _session_message_save_kwargs(
+        media: list[str] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Build optional persisted-session metadata for a user turn."""
+        save_kwargs: dict[str, Any] = {}
+        if media:
+            save_kwargs["media"] = list(media)
+        if attachments:
+            save_kwargs["attachments"] = [
+                dict(item) for item in attachments if isinstance(item, dict)
+            ]
+        return save_kwargs
+
+    def _persist_user_turn_to_session(
+        self,
+        message: str,
+        media: list[str] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Persist the current user turn before the model run starts."""
+        try:
+            self._session.add_message(
+                "user",
+                _strip_attachment_context(message, attachments or []),
+                **AgentLoop._session_message_save_kwargs(media, attachments),
+            )
+            self.sessions.save(self._session)
+        except Exception as exc:
+            logger.warning(f"Failed to persist user turn: {exc}")
+
     def _current_tool_owner_key(self, session_key: str | None = None) -> str:
         """Resolve a user-scoped ownership key for background tool jobs."""
         return build_tool_owner_key(
@@ -1580,6 +1617,10 @@ class AgentLoop:
                 (e.g. to drain the output queue for streaming).
             **run_kwargs: Forwarded to ``self._agent.run()``.
         """
+        retry_config = getattr(self, "_retry_config", None)
+        if not isinstance(retry_config, RetryConfig):
+            retry_config = DEFAULT_RETRY_CONFIG
+
         async def _do_run() -> Any:
             with bind_tool_owner(self._current_tool_owner_key()):
                 return await self._agent.run(**run_kwargs)
@@ -1587,7 +1628,7 @@ class AgentLoop:
         def _on_retry(attempt: int, exc: Exception, delay: float) -> None:
             logger.warning(
                 f"[{label}] Provider transient error (attempt {attempt + 1}/"
-                f"{self._retry_config.max_retries + 1}), "
+                f"{retry_config.max_retries + 1}), "
                 f"retrying in {delay:.1f}s: {type(exc).__name__}: {exc}"
             )
             if pre_retry_cleanup:
@@ -1598,9 +1639,94 @@ class AgentLoop:
 
         return await with_provider_retry(
             _do_run,
-            config=self._retry_config,
+            config=retry_config,
             on_retry=_on_retry,
         )
+
+    @staticmethod
+    def _resolve_retry_runner(self) -> Callable[..., Awaitable[Any]]:
+        """Pick the configured retry runner, falling back for MagicMock-based tests."""
+        retry_runner = getattr(self, "_run_agent_with_retry", None)
+        self_type_module = getattr(type(self), "__module__", "")
+        if not self_type_module.startswith("unittest.mock") and isinstance(self, AgentLoop):
+            return retry_runner
+
+        if callable(retry_runner):
+            runner_module = getattr(type(retry_runner), "__module__", "")
+            if not runner_module.startswith("unittest.mock"):
+                return retry_runner
+            if getattr(retry_runner, "side_effect", None) is not None:
+                return retry_runner
+            if getattr(retry_runner, "_mock_wraps", None) is not None:
+                return retry_runner
+
+        async def _fallback(**kwargs: Any) -> Any:
+            return await AgentLoop._run_agent_with_retry(self, **kwargs)
+
+        return _fallback
+
+    def _reset_agent_state_for_retry(self) -> None:
+        """Reset transient runtime state before retrying the same turn."""
+        if hasattr(self._agent, "state") and self._agent.state != AgentState.IDLE:
+            self._agent.state = AgentState.IDLE
+            self._agent.current_step = 0
+        if hasattr(self._agent, "_shutdown_event") and self._agent._shutdown_event.is_set():
+            self._agent._shutdown_event.clear()
+
+    def _compress_runtime_context_for_overflow_retry(self) -> int:
+        """Compress runtime context only after an explicit overflow signal."""
+        compressed = 0
+        try:
+            compressed = self._compress_runtime_context(
+                force=True,
+                budget_tokens=self._runtime_compaction_trigger_budget(),
+            )
+        except Exception as exc:
+            logger.debug(f"Soft runtime compaction failed during overflow recovery: {exc}")
+        if compressed == 0:
+            compressed = self._force_compress_runtime_context()
+        return compressed
+
+    async def _run_agent_with_context_overflow_recovery(
+        self,
+        *,
+        label: str,
+        retry_runner: Callable[..., Awaitable[Any]],
+        pre_overflow_retry_cleanup: Callable[[], Any] | None = None,
+        **run_kwargs: Any,
+    ) -> Any:
+        """Retry once after deliberate runtime compaction on context overflow."""
+        try:
+            return await retry_runner(label=label, **run_kwargs)
+        except Exception as exc:
+            if not is_context_overflow_error(exc):
+                raise
+
+            logger.warning(
+                f"[{label}] Context overflow detected: {type(exc).__name__}: {exc}. "
+                "Compacting older runtime history and retrying once."
+            )
+            if pre_overflow_retry_cleanup:
+                try:
+                    pre_overflow_retry_cleanup()
+                except Exception:
+                    pass
+
+            compressed = self._compress_runtime_context_for_overflow_retry()
+            if compressed <= 0:
+                raise
+
+            self._reset_agent_state_for_retry()
+            return await retry_runner(label=f"{label}:overflow_retry", **run_kwargs)
+
+    def _runtime_compaction_trigger_budget(self) -> int:
+        """Return the runtime token budget that should trigger preflight compaction."""
+        # Keep preflight compaction close to the hard limit so long-running
+        # streaming sessions do not repeatedly pay the full compression cost
+        # on every request. Explicit overflow recovery still handles the final
+        # "too large" edge if a request slips past this soft threshold.
+        safety_margin = max(8_000, int(self.context_window * 0.05))
+        return max(8_000, self.context_window - safety_margin)
 
     async def process(
         self,
@@ -1687,6 +1813,12 @@ class AgentLoop:
         )
         if isinstance(runtime_message, str):
             message = runtime_message
+        AgentLoop._persist_user_turn_to_session(
+            self,
+            message,
+            media=media,
+            attachments=attachments,
+        )
 
         # Snapshot runtime memory length before this turn begins so we can
         # later persist the tool-call trace produced during the turn.
@@ -1701,82 +1833,49 @@ class AgentLoop:
         self._install_anti_loop_tracker(_base_prompt)
         await self._agent.add_message("user", runtime_message)
 
-        # Run agent — two layers of retry:
-        #   1. Provider retry (inner): exponential backoff for transient LLM errors
-        #      (rate limits, timeouts, 5xx) — up to provider_max_retries (default 5).
-        #   2. Context-compression retry (outer): up to 2 attempts with increasingly
-        #      aggressive context trimming for non-transient errors.
-        _max_context_retries = 2
-        retry_requires_runtime_message_check = False
+        retry_runner = AgentLoop._resolve_retry_runner(self)
 
         try:
-            for _attempt in range(_max_context_retries + 1):
-                try:
-                    if (
-                        retry_requires_runtime_message_check
-                        and not self._recent_runtime_has_user_message_content(runtime_message)
-                    ):
-                        await self._agent.add_message("user", runtime_message)
-                    retry_requires_runtime_message_check = False
-                    run_kwargs: dict[str, Any] = {}
-                    if (
-                        effective_reasoning_effort
-                        and self._callable_accepts_kwarg(self._agent.run, "reasoning_effort")
-                    ):
-                        run_kwargs["reasoning_effort"] = effective_reasoning_effort
-                    result = await self._run_agent_with_retry(label="process", **run_kwargs)
+            run_kwargs: dict[str, Any] = {}
+            if (
+                effective_reasoning_effort
+                and self._callable_accepts_kwarg(self._agent.run, "reasoning_effort")
+            ):
+                run_kwargs["reasoning_effort"] = effective_reasoning_effort
+            result = await AgentLoop._run_agent_with_context_overflow_recovery(
+                self,
+                label="process",
+                retry_runner=retry_runner,
+                **run_kwargs,
+            )
 
-                    logger.debug(f"Agent result type: {type(result)}")
-                    if hasattr(result, 'content'):
-                        logger.info(f"Agent result.content (first 300): {str(result.content)[:300]}")
+            logger.debug(f"Agent result type: {type(result)}")
+            if hasattr(result, 'content'):
+                logger.info(f"Agent result.content (first 300): {str(result.content)[:300]}")
 
-                    if hasattr(result, "content") and result.content is not None:
-                        final_content = result.content
-                    elif hasattr(result, "content"):
-                        final_content = str(result) if str(result) != "None" else ""
-                    else:
-                        final_content = str(result)
+            if hasattr(result, "content") and result.content is not None:
+                final_content = result.content
+            elif hasattr(result, "content"):
+                final_content = str(result) if str(result) != "None" else ""
+            else:
+                final_content = str(result)
 
-                    if final_content.strip() in ("No results", ""):
-                        logger.warning(
-                            "Agent returned empty/no-results — attempting to extract "
-                            "content from agent memory"
-                        )
-                        _extracted = self._extract_last_assistant_content()
-                        if _extracted:
-                            final_content = _extracted
+            if final_content.strip() in ("No results", ""):
+                logger.warning(
+                    "Agent returned empty/no-results — attempting to extract "
+                    "content from agent memory"
+                )
+                _extracted = self._extract_last_assistant_content()
+                if _extracted:
+                    final_content = _extracted
 
-                    final_content = self._filter_execution_steps(final_content)
-                    break
-
-                except Exception as e:
-                    import traceback
-                    logger.error(
-                        f"Agent run error (context-retry {_attempt + 1}/{_max_context_retries + 1}): "
-                        f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
-                    )
-
-                    if is_retryable(e):
-                        logger.error("Transient provider error exhausted retry budget — not compressing context")
-                        raise
-
-                    if _attempt < _max_context_retries:
-                        logger.warning("Compressing context and retrying...")
-                        compression_actions = 0
-                        if _attempt == 0:
-                            compression_actions = self._compress_runtime_context()
-                            if compression_actions == 0:
-                                compression_actions += self._force_compress_runtime_context()
-                        else:
-                            compression_actions = self._force_compress_runtime_context()
-                        retry_requires_runtime_message_check = True
-                        if hasattr(self._agent, 'state'):
-                            self._agent.state = AgentState.IDLE
-                            self._agent.current_step = 0
-                        if hasattr(self._agent, '_shutdown_event'):
-                            self._agent._shutdown_event.clear()
-                        continue
-                    raise
+            final_content = self._filter_execution_steps(final_content)
+        except Exception as e:
+            import traceback
+            logger.error(
+                f"Agent run error: {type(e).__name__}: {e}\n{traceback.format_exc()}"
+            )
+            raise
         finally:
             # Always ensure agent is back in IDLE state after processing
             self._restore_agent_think()
@@ -1789,16 +1888,6 @@ class AgentLoop:
 
         # Save to session
         try:
-            save_kwargs: dict[str, Any] = {}
-            if media:
-                save_kwargs["media"] = list(media)
-            if attachments:
-                save_kwargs["attachments"] = [dict(item) for item in attachments if isinstance(item, dict)]
-            self._session.add_message(
-                "user",
-                _strip_attachment_context(message, attachments or []),
-                **save_kwargs,
-            )
             self._persist_turn_tool_trace(_pre_turn_memory_index)
             self._session.add_message("assistant", final_content)
             self.sessions.save(self._session)
@@ -1965,6 +2054,54 @@ class AgentLoop:
         return content
 
     @classmethod
+    def _compact_runtime_message_content(cls, message: Any, max_chars: int) -> Any:
+        """Compact older runtime messages without preserving stale assistant authority."""
+        role = cls._message_role_value(message)
+        content = getattr(message, "content", None)
+
+        if role == "assistant":
+            tool_calls = getattr(message, "tool_calls", None) or []
+            if tool_calls:
+                if not content:
+                    return content
+                return (
+                    "[assistant tool-call turn compacted; exact tool arguments/results "
+                    "are recoverable via search_history]"
+                )
+            if content in (None, ""):
+                return content
+            if isinstance(content, list):
+                return (
+                    "[assistant multimodal reply compacted; earlier analysis may be stale. "
+                    "Prioritize the latest user request and current tool evidence. "
+                    "Use search_history for exact earlier wording.]"
+                )
+            return (
+                "[assistant reply compacted; earlier analysis/conclusions may be stale. "
+                "Prioritize the latest user request and current tool evidence. "
+                "Use search_history for exact earlier wording.]"
+            )
+
+        if role == "tool":
+            compressed = cls._compress_message_content(content, max_chars)
+            if compressed == content:
+                return content
+            if isinstance(compressed, str):
+                tool_name = getattr(message, "name", None) or "tool"
+                return f"[{tool_name} result compacted]\n{compressed}"
+            return compressed
+
+        if role == "user":
+            compressed = cls._compress_message_content(content, max_chars)
+            if compressed == content:
+                return content
+            if isinstance(compressed, str):
+                return f"[earlier user message compacted]\n{compressed}"
+            return compressed
+
+        return cls._compress_message_content(content, max_chars)
+
+    @classmethod
     def _message_content_char_count(cls, content: Any) -> int:
         """Return an approximate character count for text and multimodal payloads."""
         if content is None:
@@ -2025,6 +2162,28 @@ class AgentLoop:
             return False
         text = msg.content if isinstance(msg.content, str) else ''
         return text.startswith('[ORIGINAL USER REQUEST]') or text.startswith('Focus on the user')
+
+    @staticmethod
+    def _is_history_compaction_marker(msg: Any) -> bool:
+        """True when *msg* is the runtime-only history-compacted marker."""
+        role = AgentLoop._message_role_value(msg)
+        if role != "user":
+            return False
+        content = getattr(msg, "content", None)
+        return isinstance(content, str) and content.startswith("[history-compacted]")
+
+    def _latest_real_user_message_index(self, messages: list[Any]) -> int | None:
+        """Return the latest user-authored message that must survive compaction intact."""
+        for index in range(len(messages) - 1, -1, -1):
+            message = messages[index]
+            if self._message_role_value(message) != "user":
+                continue
+            if self._is_next_step_user_msg(message):
+                continue
+            if self._is_history_compaction_marker(message):
+                continue
+            return index
+        return None
 
     def _recent_runtime_has_user_message_content(
         self,
@@ -2334,9 +2493,12 @@ class AgentLoop:
             "[history-compacted] "
             f"{dropped} older message(s) (including any tool-call/result pairs) "
             "were removed from this turn's in-memory context to fit the token "
-            "budget.  The full transcript is preserved on disk — if you need "
-            "an earlier tool result, argument, or user statement, call the "
-            "`search_history` tool (scope='current')."
+            "budget. The persisted session transcript was NOT cleared. The "
+            "latest real user request remains authoritative. Earlier assistant "
+            "analysis/conclusions in compacted history may be tentative or "
+            "stale, so do not treat them as current instructions. If you need "
+            "an exact earlier tool result, argument, image description, or "
+            "user statement, call the `search_history` tool (scope='current')."
         )
         try:
             marker = Message(role=Role.USER, content=marker_text)
@@ -2346,7 +2508,12 @@ class AgentLoop:
         insert_at = 1 if messages else 0
         messages.insert(insert_at, marker)
 
-    def _compress_runtime_context(self) -> int:
+    def _compress_runtime_context(
+        self,
+        *,
+        force: bool = False,
+        budget_tokens: int | None = None,
+    ) -> int:
         """Proactively compress the agent's runtime context.
 
         Strategy (inspired by Openclaw's context engine):
@@ -2354,7 +2521,7 @@ class AgentLoop:
         2. Truncate ALL older message content (tool results, assistant, user).
         3. If still over budget, drop entire old message rounds.
 
-        Trigger: estimated tokens > 50 % of context_window.
+        Trigger: estimated tokens > the active runtime compaction budget.
         """
         if not self._agent or not hasattr(self._agent, 'memory'):
             return 0
@@ -2365,9 +2532,9 @@ class AgentLoop:
             return normalized
 
         estimated = self._estimate_runtime_tokens()
-        budget = int(self.context_window * 0.50)
+        budget = budget_tokens if budget_tokens is not None else self._runtime_compaction_trigger_budget()
 
-        if estimated <= budget:
+        if not force and estimated <= budget:
             return normalized
 
         logger.warning(
@@ -2394,13 +2561,17 @@ class AgentLoop:
         if indices_to_remove:
             logger.info(f"Phase 1: removed {len(indices_to_remove)} old next_step_prompt messages")
 
-        # Phase 2: Truncate content of ALL messages except the first and last 6.
+        protected_user_index = self._latest_real_user_message_index(messages)
+
+        # Phase 2: Compact older messages except the first and last 6.
         keep_tail = min(6, len(messages))
         max_content = 300
         for i in range(1, max(1, len(messages) - keep_tail)):
+            if protected_user_index is not None and i == protected_user_index:
+                continue
             msg = messages[i]
             original_content = getattr(msg, "content", None)
-            compressed_content = self._compress_message_content(original_content, max_content)
+            compressed_content = self._compact_runtime_message_content(msg, max_content)
             if compressed_content != original_content:
                 msg.content = compressed_content
                 compressed += 1
@@ -2418,7 +2589,10 @@ class AgentLoop:
         if estimated > budget and len(messages) > 12:
             keep_head = 1
             keep_tail_drop = min(8, len(messages) - 1)
-            droppable = len(messages) - keep_head - keep_tail_drop
+            tail_start = len(messages) - keep_tail_drop
+            if protected_user_index is not None:
+                tail_start = min(tail_start, protected_user_index)
+            droppable = max(0, tail_start - keep_head)
             if droppable > 4:
                 desired = droppable // 2
                 snap_end = self._snap_drop_end_to_turn_boundary(
@@ -2465,10 +2639,14 @@ class AgentLoop:
         if len(messages) <= 4:
             return compressed
 
-        # Truncate ALL messages to 150 chars
-        for msg in messages:
+        protected_user_index = self._latest_real_user_message_index(messages)
+
+        # Compact older messages aggressively while preserving the latest real user turn.
+        for index, msg in enumerate(messages):
+            if protected_user_index is not None and index == protected_user_index:
+                continue
             original_content = getattr(msg, "content", None)
-            compressed_content = self._compress_message_content(original_content, 150)
+            compressed_content = self._compact_runtime_message_content(msg, 150)
             if compressed_content != original_content:
                 msg.content = compressed_content
                 compressed += 1
@@ -2479,6 +2657,8 @@ class AgentLoop:
             keep_head = 1
             keep_tail = min(6, len(messages) - 1)
             desired_end = len(messages) - keep_tail
+            if protected_user_index is not None:
+                desired_end = min(desired_end, protected_user_index)
             snap_end = self._snap_drop_end_to_turn_boundary(
                 messages, keep_head, desired_end
             )
@@ -2612,7 +2792,6 @@ class AgentLoop:
 
         async def _tracked_think(*args: Any, **kwargs: Any) -> bool:
             _evict_duplicate_tool_results()
-            agent_loop._compress_runtime_context()
 
             desired_next_step_prompt = agent.next_step_prompt or base_prompt
             if call_tracker:
@@ -3047,6 +3226,12 @@ class AgentLoop:
         )
         if isinstance(runtime_message, str):
             message = runtime_message
+        AgentLoop._persist_user_turn_to_session(
+            self,
+            message,
+            media=media,
+            attachments=attachments,
+        )
 
         # Snapshot runtime memory length before the turn so we can persist
         # the tool-call trace produced while streaming.
@@ -3088,6 +3273,7 @@ class AgentLoop:
             async def _run_and_signal() -> None:
                 nonlocal run_result_text
                 try:
+                    retry_runner = AgentLoop._resolve_retry_runner(self)
                     run_kwargs: dict[str, Any] = {}
                     if thinking and self._callable_accepts_kwarg(self._agent.run, "thinking"):
                         run_kwargs["thinking"] = True
@@ -3101,8 +3287,11 @@ class AgentLoop:
                         while not self._agent.output_queue.empty():
                             self._agent.output_queue.get_nowait()
 
-                    result = await self._run_agent_with_retry(
+                    result = await AgentLoop._run_agent_with_context_overflow_recovery(
+                        self,
                         label="stream",
+                        retry_runner=retry_runner,
+                        pre_overflow_retry_cleanup=_drain_queue,
                         pre_retry_cleanup=_drain_queue,
                         **run_kwargs,
                     )
@@ -3436,16 +3625,6 @@ class AgentLoop:
         # Save to session only if we got actual content
         if full_content and stream_completed and not stream_cancelled:
             try:
-                save_kwargs: dict[str, Any] = {}
-                if media:
-                    save_kwargs["media"] = list(media)
-                if attachments:
-                    save_kwargs["attachments"] = [dict(item) for item in attachments if isinstance(item, dict)]
-                self._session.add_message(
-                    "user",
-                    _strip_attachment_context(message, attachments or []),
-                    **save_kwargs,
-                )
                 # Persist intermediate tool-call artifacts generated while
                 # streaming so they remain searchable even after runtime
                 # context compaction.
@@ -3512,6 +3691,12 @@ class AgentLoop:
         )
         if isinstance(runtime_message, str):
             message = runtime_message
+        AgentLoop._persist_user_turn_to_session(
+            self,
+            message,
+            media=media,
+            attachments=attachments,
+        )
 
         # Snapshot runtime memory length *before* adding the new user turn
         # so we can later collect the tool-call trace produced during this
@@ -3519,6 +3704,7 @@ class AgentLoop:
         _pre_turn_memory_index = self._runtime_memory_snapshot_index()
 
         try:
+            retry_runner = AgentLoop._resolve_retry_runner(self)
             _base_prompt = self._select_next_step_prompt(message, thinking=True)
             original_system_prompt, original_base_system_prompt = (
                 AgentLoop._apply_request_context_to_system_prompt(self, message, thinking=True)
@@ -3536,8 +3722,12 @@ class AgentLoop:
                 and self._callable_accepts_kwarg(self._agent.run, "reasoning_effort")
             ):
                 run_kwargs["reasoning_effort"] = effective_reasoning_effort
-            with bind_tool_owner(self._current_tool_owner_key()):
-                result = await self._agent.run(**run_kwargs)
+            result = await AgentLoop._run_agent_with_context_overflow_recovery(
+                self,
+                label="process_with_thinking",
+                retry_runner=retry_runner,
+                **run_kwargs,
+            )
 
             # Extract content and thinking
             if hasattr(result, "content"):
@@ -3571,16 +3761,6 @@ class AgentLoop:
 
         # Save to session
         try:
-            save_kwargs: dict[str, Any] = {}
-            if media:
-                save_kwargs["media"] = list(media)
-            if attachments:
-                save_kwargs["attachments"] = [dict(item) for item in attachments if isinstance(item, dict)]
-            self._session.add_message(
-                "user",
-                _strip_attachment_context(message, attachments or []),
-                **save_kwargs,
-            )
             # Persist intermediate tool-call artifacts (tool results and the
             # assistant messages that called them) so they remain searchable
             # even after runtime context compaction.

--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -337,10 +337,13 @@ class AgentLoop:
     # Minimal per-step prompt. Kept short since it's injected every iteration.
     # The agent builds its own reasoning from the system prompt + memory.
     DEFAULT_NEXT_STEP_PROMPT = (
-        "Continue working on the user's request. "
+        "Continue working on the user's latest request. "
+        "Treat the latest real user request as authoritative, even if earlier history was compacted. "
         "Do NOT repeat previous actions. Do NOT fabricate output. "
         "Make autonomous choices when input is needed. "
-        "When the task is complete, summarize concrete results."
+        "Do NOT summarize prior work unless the user explicitly asked for a summary. "
+        "If the task can be completed now, return the final user-facing answer in the format the user requested and stop. "
+        "If an authoritative request-ending block is present, it is copied verbatim from the newest user message and your final answer must satisfy it exactly."
     )
 
     def __init__(
@@ -642,7 +645,8 @@ class AgentLoop:
             "2. Otherwise, if a skill matches, `read_file` its SKILL.md path, "
             "then execute.\n"
             "3. Run commands from SKILL.md directly via shell. Do NOT write script files.\n"
-            "4. Summarize result when done.\n\n"
+            "4. When done, return the user-facing result in the format the latest user requested. "
+            "Only summarize if the user explicitly asked for a summary.\n\n"
             "### Rules\n"
             "- Do NOT re-read files already in context.\n"
             "- `source .env.local` before commands that need env vars.\n"
@@ -2800,7 +2804,13 @@ class AgentLoop:
                     completed_parts.append(f"  - {key} (x{count})")
                 completed_summary = "\n".join(completed_parts)
 
-                anti_loop = f"\n[DONE]:\n{completed_summary}"
+                anti_loop = (
+                    "\n[ALREADY COMPLETED ACTIONS - do not repeat]:\n"
+                    f"{completed_summary}\n"
+                    "Use this only to avoid repetition. Do not restate this list to the user.\n"
+                    "Continue from the latest unfinished user instruction. "
+                    "If the task is already complete, send the final answer once in the requested format and stop."
+                )
 
                 if read_files:
                     recent = sorted(read_files)[-8:]
@@ -2811,7 +2821,7 @@ class AgentLoop:
                 if repeated_details:
                     anti_loop += (
                         "\n⚠️ STOP REPEATING! You already did these actions. "
-                        "Move to the NEXT step toward the goal."
+                        "Choose the next missing action, or finish immediately if nothing remains."
                     )
 
                 if len(anti_loop) > 1000:
@@ -4199,13 +4209,16 @@ class AgentLoop:
         Injects env vars so they survive short-term memory pruning.
         The anti-loop tracker dynamically appends progress info.
         """
-        _truncated = message[:300] + ("…" if len(message) > 300 else "")
+        _truncated = self._truncate_request_for_prompt(message)
         _ws = self._workspace_posix_path()
         prompt = (
             f"[USER REQUEST]: {_truncated}\n"
             f"[WORKSPACE]: {_ws}/\n\n"
             + self.DEFAULT_NEXT_STEP_PROMPT
         )
+        output_requirements = self._extract_output_contract_for_prompt(message)
+        if output_requirements:
+            prompt += output_requirements
         env_section = self._extract_env_for_prompt()
         if env_section:
             prompt += env_section
@@ -4213,16 +4226,71 @@ class AgentLoop:
 
     def _build_request_context_prompt(self, message: str) -> str:
         """Build the compact request context block used for thinking runs."""
-        _truncated = message[:300] + ("…" if len(message) > 300 else "")
+        _truncated = self._truncate_request_for_prompt(message)
         _ws = self._workspace_posix_path()
         prompt = (
             f"[USER REQUEST]: {_truncated}\n"
             f"[WORKSPACE]: {_ws}/\n"
         )
+        output_requirements = self._extract_output_contract_for_prompt(message)
+        if output_requirements:
+            prompt += output_requirements
         env_section = self._extract_env_for_prompt()
         if env_section:
             prompt += env_section
         return prompt
+
+    @staticmethod
+    def _truncate_request_for_prompt(
+        message: str,
+        *,
+        head_chars: int = 220,
+        tail_chars: int = 180,
+    ) -> str:
+        """Keep both the head and tail of the latest request for prompt scaffolding."""
+        normalized = (message or "").strip()
+        if len(normalized) <= head_chars + tail_chars + 24:
+            return normalized
+        head = normalized[:head_chars].rstrip()
+        tail = normalized[-tail_chars:].lstrip()
+        return (
+            f"{head}\n"
+            "[... middle omitted to save tokens; preserve latest tail instructions ...]\n"
+            f"{tail}"
+        )
+
+    @staticmethod
+    def _extract_output_contract_for_prompt(
+        message: str,
+        *,
+        full_request_chars: int = 420,
+        tail_chars: int = 240,
+    ) -> str:
+        """Preserve the latest request ending without language-specific intent matching.
+
+        We avoid keyword heuristics here. Compression failures often happen
+        because the *tail* of a long request carries the final delivery rule,
+        regardless of language.  For longer requests, surface that tail
+        verbatim so the model can continue execution and finish in the
+        requested format without relying on English/Chinese phrase lists.
+        """
+        normalized = (message or "").strip()
+        if not normalized:
+            return ""
+
+        if len(normalized) <= full_request_chars:
+            return ""
+
+        tail_snippet = normalized[-tail_chars:]
+        return (
+            "\n[AUTHORITATIVE REQUEST ENDING]: "
+            "The block below is copied verbatim from the newest user message. "
+            "It may contain the exact completion contract in any language. "
+            "It overrides earlier assistant guesses, stale summaries, and unrelated context. "
+            "Do not answer a different question. Do not translate it away, soften it, or replace it with a recap. "
+            "Your final answer must satisfy this block exactly.\n"
+            f"[LATEST REQUEST ENDING]: {tail_snippet}\n"
+        )
 
     def _apply_request_context_to_system_prompt(
         self,

--- a/spoon_bot/channels/config.py
+++ b/spoon_bot/channels/config.py
@@ -764,7 +764,7 @@ def load_agent_config(config_path: str | Path | None = None) -> dict[str, Any]:
         "shell_timeout": ["SPOON_BOT_SHELL_TIMEOUT"],
         "shell_max_timeout": ["SPOON_BOT_SHELL_MAX_TIMEOUT"],
         "max_output": ["SPOON_BOT_MAX_OUTPUT"],
-        "context_window": ["CONTEXT_WINDOW"],
+        "context_window": ["SPOON_BOT_CONTEXT_WINDOW", "CONTEXT_WINDOW"],
         "provider_max_retries":        ["SPOON_BOT_PROVIDER_MAX_RETRIES"],
         "provider_retry_base_delay":   ["SPOON_BOT_PROVIDER_RETRY_BASE_DELAY"],
         "provider_retry_max_delay":    ["SPOON_BOT_PROVIDER_RETRY_MAX_DELAY"],

--- a/spoon_bot/config.py
+++ b/spoon_bot/config.py
@@ -53,6 +53,13 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "gpt-5.2-codex":           400_000,
     "gpt-5.2-chat":            128_000,
     "gpt-5.2-pro":             400_000,
+    # OpenAI currently documents GPT-5.4 at 1M input tokens, but spoon-bot
+    # intentionally keeps the operational default at 400K for stability.
+    # Users can still raise/lower this explicitly via context_window.
+    "gpt-5.4":                 400_000,
+    "gpt-5.4-pro":             400_000,
+    "gpt-5.4-mini":            400_000,
+    "gpt-5.4-nano":            400_000,
     "gpt-5.1":                 400_000,
     "gpt-5.1-codex":           400_000,
     "gpt-5.1-codex-mini":      400_000,

--- a/spoon_bot/gateway/server.py
+++ b/spoon_bot/gateway/server.py
@@ -87,10 +87,6 @@ async def _lifespan(app: FastAPI):
         session_store_dsn = os.environ.get("SESSION_STORE_DSN")
         session_store_db_path = os.environ.get("SESSION_STORE_DB_PATH")
 
-        # Context window override (optional)
-        _ctx_env = os.environ.get("CONTEXT_WINDOW")
-        context_window = int(_ctx_env) if _ctx_env else None
-
         # YOLO mode: operate directly in user's path without sandbox
         yolo_mode = (
             agent_cfg.get("yolo_mode")
@@ -110,7 +106,6 @@ async def _lifespan(app: FastAPI):
             session_store_backend=session_store_backend,
             session_store_dsn=session_store_dsn,
             session_store_db_path=session_store_db_path,
-            context_window=context_window,
             yolo_mode=bool(yolo_mode),
         )
         if agent_cfg.get("mcp_config") is not None:

--- a/spoon_bot/utils/retry.py
+++ b/spoon_bot/utils/retry.py
@@ -45,6 +45,7 @@ _TRANSIENT_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"gateway.?timeout", re.IGNORECASE),
     re.compile(r"overloaded", re.IGNORECASE),
     re.compile(r"temporarily", re.IGNORECASE),
+    re.compile(r"an error occurred while processing your request", re.IGNORECASE),
     re.compile(r"ECONNRESET", re.IGNORECASE),
     re.compile(r"ECONNREFUSED", re.IGNORECASE),
 ]
@@ -58,6 +59,43 @@ _NON_RETRYABLE_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"content.*filter", re.IGNORECASE),
     re.compile(r"content.*policy", re.IGNORECASE),
 ]
+
+_CONTEXT_OVERFLOW_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"context.*length.*exceeded", re.IGNORECASE),
+    re.compile(r"maximum.*context", re.IGNORECASE),
+    re.compile(r"context.*overflow", re.IGNORECASE),
+    re.compile(r"prompt.*too long", re.IGNORECASE),
+    re.compile(r"too many input tokens", re.IGNORECASE),
+    re.compile(r"request.*too large", re.IGNORECASE),
+]
+
+_RETRYABLE_EXCEPTION_NAMES: set[str] = {
+    "APIConnectionError",
+    "APITimeoutError",
+    "InternalServerError",
+    "OverloadedError",
+    "RateLimitError",
+    "ResourceExhausted",
+    "ServerError",
+    "ServiceUnavailableError",
+    "TooManyRequestsError",
+    "UnavailableError",
+}
+
+_NON_RETRYABLE_EXCEPTION_NAMES: set[str] = {
+    "AuthenticationError",
+    "BadRequestError",
+    "ContextLengthExceededError",
+    "InvalidRequestError",
+    "NotFoundError",
+    "PermissionDeniedError",
+    "UnauthorizedError",
+    "UnprocessableEntityError",
+}
+
+_CONTEXT_OVERFLOW_EXCEPTION_NAMES: set[str] = {
+    "ContextLengthExceededError",
+}
 
 
 @dataclass
@@ -132,6 +170,9 @@ def is_retryable(exc: Exception) -> bool:
         APIKeyMissingError,
     )
 
+    if is_context_overflow_error(exc):
+        return False
+
     if isinstance(exc, (APIKeyMissingError, ContextOverflowError)):
         return False
 
@@ -156,15 +197,49 @@ def is_retryable(exc: Exception) -> bool:
             return True
 
     err_str = str(exc)
+    exc_name = type(exc).__name__
+    exc_module = (type(exc).__module__ or "").lower()
 
     for pat in _NON_RETRYABLE_PATTERNS:
         if pat.search(err_str):
             return False
 
+    if exc_name in _NON_RETRYABLE_EXCEPTION_NAMES:
+        return False
+
+    if exc_name == "APIError" and exc_module.startswith("openai"):
+        return True
+
+    if exc_name in _RETRYABLE_EXCEPTION_NAMES:
+        return True
+
     for pat in _RATE_LIMIT_PATTERNS:
         if pat.search(err_str):
             return True
     for pat in _TRANSIENT_PATTERNS:
+        if pat.search(err_str):
+            return True
+
+    return False
+
+
+def is_context_overflow_error(exc: Exception) -> bool:
+    """Decide whether *exc* signals a recoverable context-overflow failure."""
+    from spoon_bot.exceptions import ContextOverflowError
+
+    if isinstance(exc, ContextOverflowError):
+        return True
+
+    status = _extract_status_code(exc)
+    if status == 413:
+        return True
+
+    exc_name = type(exc).__name__
+    if exc_name in _CONTEXT_OVERFLOW_EXCEPTION_NAMES:
+        return True
+
+    err_str = str(exc)
+    for pat in _CONTEXT_OVERFLOW_PATTERNS:
         if pat.search(err_str):
             return True
 

--- a/tests/test_config_and_channels.py
+++ b/tests/test_config_and_channels.py
@@ -73,6 +73,41 @@ class TestConfigPriority:
         result = load_agent_config(cfg_path)
         assert result["reasoning_effort"] == "low"
 
+    def test_context_window_loaded_from_yaml_or_env(self, tmp_path, monkeypatch):
+        """context_window should resolve via YAML > env using integer parsing."""
+        cfg_path = self._write_yaml(tmp_path, """\
+            agent:
+              context_window: 400000
+        """)
+        monkeypatch.setenv("SPOON_BOT_CONTEXT_WINDOW", "256000")
+        monkeypatch.setenv("CONTEXT_WINDOW", "128000")
+
+        from spoon_bot.channels.config import load_agent_config
+
+        result = load_agent_config(cfg_path)
+        assert result["context_window"] == 400000
+
+        cfg_path = self._write_yaml(tmp_path, """\
+            agent:
+              provider: openai
+        """)
+        result = load_agent_config(cfg_path)
+        assert result["context_window"] == 256000
+
+    def test_context_window_prefers_namespaced_env_alias(self, tmp_path, monkeypatch):
+        """The SPOON_BOT_ namespaced env should win over the legacy alias."""
+        cfg_path = self._write_yaml(tmp_path, """\
+            agent:
+              provider: openai
+        """)
+        monkeypatch.setenv("SPOON_BOT_CONTEXT_WINDOW", "400000")
+        monkeypatch.setenv("CONTEXT_WINDOW", "256000")
+
+        from spoon_bot.channels.config import load_agent_config
+
+        result = load_agent_config(cfg_path)
+        assert result["context_window"] == 400000
+
     def test_validate_agent_loop_params_accepts_reasoning_effort(self, tmp_path):
         from spoon_bot.config import validate_agent_loop_params
 

--- a/tests/test_provider_retry.py
+++ b/tests/test_provider_retry.py
@@ -8,6 +8,7 @@ import pytest
 
 from spoon_bot.utils.retry import (
     RetryConfig,
+    is_context_overflow_error,
     is_retryable,
     with_provider_retry,
 )
@@ -127,6 +128,62 @@ class TestIsRetryable:
         class FakeError(Exception):
             response = FakeResponse()
         assert is_retryable(FakeError("oops")) is True
+
+    def test_openai_apierror_without_status_is_retryable(self):
+        class FakeOpenAIAPIError(Exception):
+            __module__ = "openai"
+
+        exc = FakeOpenAIAPIError(
+            "An error occurred while processing your request. Please retry your request."
+        )
+        assert is_retryable(exc) is True
+
+    def test_common_sdk_retryable_exception_names_are_retryable(self):
+        class RateLimitError(Exception):
+            pass
+
+        class APIConnectionError(Exception):
+            pass
+
+        class ServiceUnavailableError(Exception):
+            pass
+
+        assert is_retryable(RateLimitError("slow down")) is True
+        assert is_retryable(APIConnectionError("socket reset")) is True
+        assert is_retryable(ServiceUnavailableError("please retry")) is True
+
+    def test_common_sdk_non_retryable_exception_names_are_not_retryable(self):
+        class AuthenticationError(Exception):
+            pass
+
+        class BadRequestError(Exception):
+            pass
+
+        assert is_retryable(AuthenticationError("bad key")) is False
+        assert is_retryable(BadRequestError("invalid request")) is False
+
+
+class TestIsContextOverflowError:
+    def test_context_overflow_exception_is_detected(self):
+        assert is_context_overflow_error(ContextOverflowError(200_000, 128_000)) is True
+
+    def test_context_length_pattern_is_detected(self):
+        assert is_context_overflow_error(Exception("context length exceeded for this model")) is True
+
+    def test_request_too_large_tpm_error_is_treated_as_overflow_not_retryable(self):
+        exc = Exception(
+            "Request too large for gpt-5.4 (for limit gpt-5.4-long-context) "
+            "on tokens per min (TPM): Limit 400000, Requested 860809."
+        )
+
+        assert is_context_overflow_error(exc) is True
+        assert is_retryable(exc) is False
+
+    def test_request_too_large_status_is_detected(self):
+        class FakeError(Exception):
+            status_code = 413
+
+        assert is_context_overflow_error(FakeError("payload too large")) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runtime_compaction.py
+++ b/tests/test_runtime_compaction.py
@@ -18,7 +18,7 @@ so they do not require any LLM / network setup.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -39,6 +39,64 @@ def _roles(messages: list) -> list[str | None]:
     from spoon_bot.agent.loop import AgentLoop
 
     return [AgentLoop._message_role_value(m) for m in messages]
+
+
+def test_resolve_context_window_uses_400k_for_gpt54():
+    from spoon_bot.config import resolve_context_window
+
+    assert resolve_context_window("gpt-5.4") == 400_000
+    assert resolve_context_window("openai/gpt-5.4") == 400_000
+
+
+@pytest.mark.asyncio
+async def test_prepare_request_context_proactively_compacts_near_context_limit():
+    from spoon_bot.agent.loop import AgentLoop
+
+    loop = AgentLoop.__new__(AgentLoop)
+    loop.context_window = 400_000
+    loop.session_key = "ctx-limit"
+    loop._agent = MagicMock()
+    loop._agent.memory = MagicMock()
+    loop._agent.memory.messages = [MagicMock()]
+    loop._trim_context_if_needed = MagicMock(return_value=0)
+    loop._sync_runtime_history_from_session = AsyncMock(return_value=5)
+    loop._normalize_runtime_tool_context = MagicMock(return_value=0)
+    loop._estimate_runtime_tokens = MagicMock(side_effect=[390_000, 280_000])
+    loop._estimate_token_count = MagicMock(return_value=390_000)
+    loop._compress_runtime_context = MagicMock(return_value=3)
+    loop._force_compress_runtime_context = MagicMock(return_value=0)
+
+    await AgentLoop._prepare_request_context(loop)
+
+    loop._compress_runtime_context.assert_called_once_with(
+        force=True,
+        budget_tokens=380_000,
+    )
+    loop._force_compress_runtime_context.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prepare_request_context_skips_proactive_compaction_until_near_limit():
+    from spoon_bot.agent.loop import AgentLoop
+
+    loop = AgentLoop.__new__(AgentLoop)
+    loop.context_window = 400_000
+    loop.session_key = "ctx-not-near-limit"
+    loop._agent = MagicMock()
+    loop._agent.memory = MagicMock()
+    loop._agent.memory.messages = [MagicMock()]
+    loop._trim_context_if_needed = MagicMock(return_value=0)
+    loop._sync_runtime_history_from_session = AsyncMock(return_value=5)
+    loop._normalize_runtime_tool_context = MagicMock(return_value=0)
+    loop._estimate_runtime_tokens = MagicMock(return_value=360_000)
+    loop._estimate_token_count = MagicMock(return_value=360_000)
+    loop._compress_runtime_context = MagicMock(return_value=0)
+    loop._force_compress_runtime_context = MagicMock(return_value=0)
+
+    await AgentLoop._prepare_request_context(loop)
+
+    loop._compress_runtime_context.assert_not_called()
+    loop._force_compress_runtime_context.assert_not_called()
 
 
 @pytest.mark.requires_spoon_core
@@ -122,6 +180,42 @@ def test_insert_compaction_marker_is_runtime_only():
     assert "[history-compacted]" in content
     assert "7" in content
     assert "search_history" in content
+    assert "latest real user request" in content
+    assert "assistant analysis/conclusions" in content
+
+
+@pytest.mark.requires_spoon_core
+def test_compress_runtime_context_neutralizes_old_assistant_conclusions_but_keeps_latest_user_request():
+    from spoon_ai.schema import Message
+    from spoon_bot.agent.loop import AgentLoop
+
+    latest_request = (
+        "Please inspect the repo, follow the latest instruction, and do not stop at a summary. "
+        + "z" * 220
+    )
+    messages = [
+        Message(role="system", content="sys"),
+        Message(role="user", content="Earlier request 1 " + "a" * 400),
+        Message(
+            role="assistant",
+            content="Conclusion: the task is already done, so no more tools are needed. " + "b" * 320,
+        ),
+        Message(role="user", content="Earlier request 2 " + "c" * 400),
+        Message(role="assistant", content="Older analysis " + "d" * 320),
+        Message(role="user", content="Earlier request 3 " + "e" * 400),
+        Message(role="assistant", content="Recent note"),
+        Message(role="user", content=latest_request),
+        Message(role="assistant", content="Working on it."),
+    ]
+
+    loop = _make_loop(messages, context_window=400)
+    compressed = AgentLoop._compress_runtime_context(loop, force=True, budget_tokens=1)
+
+    assert compressed > 0
+    assert messages[1].content.startswith("[earlier user message compacted]")
+    assert messages[2].content.startswith("[assistant reply compacted;")
+    assert "Prioritize the latest user request" in messages[2].content
+    assert messages[7].content == latest_request
 
 
 @pytest.mark.requires_spoon_core

--- a/tests/test_runtime_message_sequence.py
+++ b/tests/test_runtime_message_sequence.py
@@ -156,3 +156,49 @@ async def test_install_anti_loop_tracker_logs_provider_reasoning_summary():
         call.args and call.args[0] == "💭 Agent reasoning: Plan from provider summary"
         for call in log_info.call_args_list
     )
+
+
+@pytest.mark.requires_spoon_core
+@pytest.mark.asyncio
+async def test_install_anti_loop_tracker_uses_non_summary_progress_guard():
+    from spoon_ai.schema import Function, ToolCall
+    from spoon_bot.agent.loop import AgentLoop
+
+    seen_prompts: list[str | None] = []
+    assistant_tool_call = ToolCall(
+        id="call_1",
+        function=Function(name="shell", arguments='{"command":"cat result.txt"}'),
+    )
+
+    async def base_think() -> bool:
+        seen_prompts.append(agent._agent.next_step_prompt)
+        agent._agent.tool_calls = [assistant_tool_call]
+        return True
+
+    agent = AgentLoop.__new__(AgentLoop)
+    agent.workspace = Path("/workspace")
+    agent.provider = "anthropic"
+    agent.model = "claude-sonnet-4.5"
+    agent.base_url = None
+    agent._agent = MagicMock()
+    agent._agent.think = base_think
+    agent._agent._spoon_bot_base_think = base_think
+    agent._agent.next_step_prompt = "prompt"
+    agent._agent.tool_calls = []
+    agent._agent.memory = MagicMock()
+    agent._agent.memory.messages = []
+    agent._agent.last_reasoning_summary = None
+    agent._compress_runtime_context = MagicMock(return_value=0)
+    agent._latest_reasoning_excerpt = None
+    agent._pending_reasoning_chunks = []
+
+    AgentLoop._install_anti_loop_tracker(agent, "prompt")
+    await agent._agent.think()
+    await agent._agent.think()
+
+    assert len(seen_prompts) == 2
+    assert seen_prompts[0] == "prompt"
+    assert seen_prompts[1] is not None
+    assert "[ALREADY COMPLETED ACTIONS - do not repeat]" in seen_prompts[1]
+    assert "[DONE]" not in seen_prompts[1]
+    assert "Do not restate this list to the user." in seen_prompts[1]

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -492,6 +492,14 @@ class _NoChunkRuntimeAgent:
         return type("RunResult", (), {"content": self._final_content})()
 
 
+class _FailingStreamRuntimeAgent(_NoChunkRuntimeAgent):
+    """Runtime agent whose stream run fails before yielding assistant content."""
+
+    async def run(self, *args, **kwargs):
+        self.run_calls.append((args, kwargs))
+        raise RuntimeError("upstream exploded")
+
+
 class _ChunkedRuntimeAgent:
     """Runtime agent that emits real incremental chunks through output_queue."""
 
@@ -544,6 +552,17 @@ class _RetryRuntimeAgent:
         return type("RunResult", (), {"content": self._final_content})()
 
 
+class _OverflowThenSuccessRuntimeAgent(_RetryRuntimeAgent):
+    """Runtime agent that overflows once, then succeeds after compaction."""
+
+    async def run(self, *args, **kwargs):
+        self.run_calls.append((args, kwargs))
+        if self._failures_remaining > 0:
+            self._failures_remaining -= 1
+            raise RuntimeError("context length exceeded for this model")
+        return type("RunResult", (), {"content": self._final_content})()
+
+
 class _ThinkingRuntimeAgent:
     """Runtime agent that supports a thinking kwarg."""
 
@@ -568,6 +587,32 @@ class _ThinkingRuntimeAgent:
 
     async def run(self, *args, **kwargs):
         self.run_calls.append((args, kwargs))
+        return type(
+            "RunResult",
+            (),
+            {"content": self._final_content, "thinking_content": self._thinking_content},
+        )()
+
+
+class _OpenAITransientAPIError(Exception):
+    __module__ = "openai"
+
+
+class _RetryThinkingRuntimeAgent(_ThinkingRuntimeAgent):
+    """Thinking-capable runtime agent that fails once with a retryable API error."""
+
+    def __init__(self, final_content: str, thinking_content: str, failures: int = 1) -> None:
+        super().__init__(final_content, thinking_content)
+        self._failures_remaining = failures
+
+    async def run(self, *args, **kwargs):
+        self.run_calls.append((args, kwargs))
+        if self._failures_remaining > 0:
+            self._failures_remaining -= 1
+            raise _OpenAITransientAPIError(
+                "An error occurred while processing your request. "
+                "You can retry your request, or contact us through our help center."
+            )
         return type(
             "RunResult",
             (),
@@ -622,7 +667,7 @@ class TestAgentLoopCurrentRequestMultimodal:
         assert loop._session.messages[0]["media"] == [str(image_path)]
 
     @pytest.mark.asyncio
-    async def test_process_requeues_multimodal_request_after_retry_compression(self, tmp_dir: Path):
+    async def test_process_does_not_auto_compress_context_on_runtime_failure(self, tmp_dir: Path):
         from spoon_bot.agent.context import ContextBuilder
         from spoon_bot.agent.loop import AgentLoop
 
@@ -658,27 +703,24 @@ class TestAgentLoopCurrentRequestMultimodal:
         loop._compress_runtime_context = MagicMock(side_effect=_compress_runtime_context)
         loop._force_compress_runtime_context = MagicMock(return_value=0)
 
-        response = await AgentLoop.process(
-            loop,
-            message="What text appears in the image?",
-            media=[str(image_path)],
-        )
+        with pytest.raises(RuntimeError, match="transient runtime failure"):
+            await AgentLoop.process(
+                loop,
+                message="What text appears in the image?",
+                media=[str(image_path)],
+            )
 
-        assert response == "recovered reply"
-        assert len(loop._agent.add_message_calls) == 2
+        assert len(loop._agent.add_message_calls) == 1
         _assert_multimodal_user_call(
             loop._agent.add_message_calls[0],
             expected_text="What text appears in the image?",
         )
-        _assert_multimodal_user_call(
-            loop._agent.add_message_calls[1],
-            expected_text="What text appears in the image?",
-        )
-        assert loop._agent.run_calls == [((), {}), ((), {})]
-        loop._compress_runtime_context.assert_called_once()
+        assert loop._agent.run_calls == [((), {})]
+        loop._compress_runtime_context.assert_not_called()
+        loop._force_compress_runtime_context.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_process_does_not_duplicate_request_after_noop_retry_compression(self, tmp_dir: Path):
+    async def test_process_persists_user_turn_before_runtime_failure(self, tmp_dir: Path):
         from spoon_bot.agent.context import ContextBuilder
         from spoon_bot.agent.loop import AgentLoop
 
@@ -710,21 +752,78 @@ class TestAgentLoopCurrentRequestMultimodal:
         loop._compress_runtime_context = MagicMock(return_value=0)
         loop._force_compress_runtime_context = MagicMock(return_value=0)
 
-        response = await AgentLoop.process(
-            loop,
-            message="What text appears in the image?",
-            media=[str(image_path)],
-        )
+        with pytest.raises(RuntimeError, match="transient runtime failure"):
+            await AgentLoop.process(
+                loop,
+                message="What text appears in the image?",
+                media=[str(image_path)],
+            )
 
-        assert response == "recovered reply"
         assert len(loop._agent.add_message_calls) == 1
         _assert_multimodal_user_call(
             loop._agent.add_message_calls[0],
             expected_text="What text appears in the image?",
         )
+        assert loop._agent.run_calls == [((), {})]
+        assert loop._session.messages == [
+            {
+                "role": "user",
+                "content": "What text appears in the image?",
+                "timestamp": loop._session.messages[0]["timestamp"],
+                "media": [str(image_path)],
+            }
+        ]
+        loop.sessions.save.assert_called_once_with(loop._session)
+        loop._compress_runtime_context.assert_not_called()
+        loop._force_compress_runtime_context.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_retries_once_after_context_overflow_compaction(self, tmp_dir: Path):
+        from spoon_bot.agent.context import ContextBuilder
+        from spoon_bot.agent.loop import AgentLoop
+
+        workspace = tmp_dir / "workspace"
+        uploads = workspace / "uploads"
+        uploads.mkdir(parents=True)
+        image_path = uploads / "overflow.png"
+        image_path.write_bytes(b"png")
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop._stop_requested = False
+        loop._initialized = True
+        loop.workspace = workspace
+        loop.context = ContextBuilder(workspace)
+        loop.memory = MagicMock()
+        loop.memory.get_memory_context = MagicMock(return_value=None)
+        loop._agent = _OverflowThenSuccessRuntimeAgent("recovered after compaction")
+        loop.context_window = 400_000
+        loop._session = Session(session_key="overflow_retry")
+        loop.sessions = MagicMock()
+        loop.sessions.save = MagicMock()
+        loop._auto_commit = False
+        loop._git = None
+        loop._prepare_request_context = AsyncMock(return_value=None)
+        loop._pre_inject_matched_skill = lambda message: message
+        loop._build_step_prompt = lambda message: f"prompt::{message}"
+        loop._install_anti_loop_tracker = lambda prompt: None
+        loop._restore_agent_think = lambda: None
+        loop._filter_execution_steps = lambda content: content
+        loop._compress_runtime_context = MagicMock(return_value=2)
+        loop._force_compress_runtime_context = MagicMock(return_value=0)
+
+        response = await AgentLoop.process(
+            loop,
+            message="Keep the image request and continue.",
+            media=[str(image_path)],
+        )
+
+        assert response == "recovered after compaction"
         assert loop._agent.run_calls == [((), {}), ((), {})]
-        loop._compress_runtime_context.assert_called_once()
-        loop._force_compress_runtime_context.assert_called_once()
+        loop._compress_runtime_context.assert_called_once_with(
+            force=True,
+            budget_tokens=380_000,
+        )
+        loop._force_compress_runtime_context.assert_not_called()
 
 
 class TestAgentLoopStreamFallback:
@@ -760,7 +859,8 @@ class TestAgentLoopStreamFallback:
 
         assert loop._session.messages[-1]["role"] == "assistant"
         assert loop._session.messages[-1]["content"] == "fallback from run result"
-        loop.sessions.save.assert_called_once_with(loop._session)
+        assert loop.sessions.save.call_count == 2
+        loop.sessions.save.assert_called_with(loop._session)
 
     @pytest.mark.asyncio
     async def test_stream_preserves_incremental_queue_chunks(self, tmp_dir: Path):
@@ -823,6 +923,38 @@ class TestAgentLoopStreamFallback:
         assert loop._session.messages[0]["content"] == "Please summarize the attachment."
         assert loop._session.messages[0]["attachments"] == attachments
 
+    @pytest.mark.asyncio
+    async def test_stream_persists_user_turn_when_upstream_fails(self, tmp_dir: Path):
+        from spoon_bot.agent.loop import AgentLoop
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop._initialized = True
+        loop._agent = _FailingStreamRuntimeAgent("unused")
+        loop.workspace = tmp_dir
+        loop._session = Session(session_key="stream_error_context")
+        loop.sessions = MagicMock()
+        loop.sessions.save = MagicMock()
+        loop.memory = MagicMock()
+        loop.memory.get_memory_context = MagicMock(return_value=None)
+        loop.context = MagicMock()
+        loop._prepare_request_context = AsyncMock(return_value=None)
+        loop._build_step_prompt = lambda message: f"prompt::{message}"
+        loop._install_anti_loop_tracker = lambda prompt: None
+
+        chunks = []
+        async for chunk in AgentLoop.stream(loop, message="keep this request in history"):
+            chunks.append(chunk)
+
+        assert any(chunk["type"] == "error" for chunk in chunks)
+        assert loop._session.messages == [
+            {
+                "role": "user",
+                "content": "keep this request in history",
+                "timestamp": loop._session.messages[0]["timestamp"],
+            }
+        ]
+        loop.sessions.save.assert_called_once_with(loop._session)
+
 
 class TestContextBuilderMediaPaths:
     def test_build_user_content_resolves_workspace_alias_and_relative_media(self, tmp_dir: Path):
@@ -871,13 +1003,47 @@ class TestAgentLoopRuntimeCompression:
         loop.context_window = 200
         loop._agent = SimpleNamespace(memory=SimpleNamespace(messages=messages))
 
-        compressed = AgentLoop._compress_runtime_context(loop)
+        compressed = AgentLoop._compress_runtime_context(loop, force=True, budget_tokens=100)
 
         assert compressed >= 1
         assert isinstance(messages[1].content, str)
         assert "image attachment(s) omitted during context compression" in messages[1].content
         assert "Please inspect this image carefully." in messages[1].content
         assert "data:image/png;base64," not in messages[1].content
+
+    def test_force_compaction_preserves_latest_real_multimodal_user_request(self):
+        from spoon_bot.agent.loop import AgentLoop
+
+        data_url = "data:image/png;base64," + ("B" * 800)
+        older_multimodal_message = [
+            {"type": "image_url", "image_url": {"url": data_url}},
+            {"type": "text", "text": "Older screenshot."},
+        ]
+        latest_multimodal_message = [
+            {"type": "image_url", "image_url": {"url": data_url}},
+            {"type": "text", "text": "Current request with image must stay intact."},
+        ]
+        messages = [
+            SimpleNamespace(role="system", content="system prompt", tool_calls=None, tool_call_id=None),
+            SimpleNamespace(role="user", content=older_multimodal_message, tool_calls=None, tool_call_id=None),
+            SimpleNamespace(role="assistant", content="assistant 1", tool_calls=None, tool_call_id=None),
+            SimpleNamespace(role="user", content="another request", tool_calls=None, tool_call_id=None),
+            SimpleNamespace(role="assistant", content="assistant 2", tool_calls=None, tool_call_id=None),
+            SimpleNamespace(role="user", content=latest_multimodal_message, tool_calls=None, tool_call_id=None),
+            SimpleNamespace(role="assistant", content="tool summary " * 40, tool_calls=None, tool_call_id=None),
+            SimpleNamespace(role="assistant", content="another summary " * 40, tool_calls=None, tool_call_id=None),
+            SimpleNamespace(role="assistant", content="tail summary " * 40, tool_calls=None, tool_call_id=None),
+        ]
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop.context_window = 200
+        loop._agent = SimpleNamespace(memory=SimpleNamespace(messages=messages))
+
+        compressed = AgentLoop._force_compress_runtime_context(loop)
+
+        assert compressed >= 1
+        assert any(message.content == latest_multimodal_message for message in messages)
+        assert any(message.content != older_multimodal_message for message in messages if getattr(message, "role", None) == "user")
 
 
 class TestAgentLoopThinkingMode:
@@ -938,6 +1104,38 @@ class TestAgentLoopThinkingMode:
         assert response == "answer"
         assert thinking == "reasoning trace"
         assert loop._agent.run_calls == [((), {"thinking": True, "reasoning_effort": "high"})]
+
+    @pytest.mark.asyncio
+    async def test_process_with_thinking_retries_openai_apierror(self, tmp_dir: Path):
+        from spoon_bot.agent.loop import AgentLoop
+        from spoon_bot.utils.retry import RetryConfig
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop._initialized = True
+        loop.workspace = tmp_dir
+        loop.memory = MagicMock()
+        loop.memory.get_memory_context = MagicMock(return_value=None)
+        loop.context = MagicMock()
+        loop._agent = _RetryThinkingRuntimeAgent("answer", "reasoning trace")
+        loop._session = Session(session_key="thinking_retry")
+        loop.sessions = MagicMock()
+        loop.sessions.save = MagicMock()
+        loop._prepare_request_context = AsyncMock(return_value=None)
+        loop._build_step_prompt = lambda message: f"prompt::{message}"
+        loop._install_anti_loop_tracker = lambda prompt: None
+        loop._restore_agent_think = lambda: None
+        loop._auto_commit = False
+        loop._git = None
+        loop._retry_config = RetryConfig(max_retries=1, base_delay=0.01, max_delay=0.01, jitter=0.0)
+
+        response, thinking = await AgentLoop.process_with_thinking(loop, message="Explain the answer.")
+
+        assert response == "answer"
+        assert thinking == "reasoning trace"
+        assert loop._agent.run_calls == [
+            ((), {"thinking": True}),
+            ((), {"thinking": True}),
+        ]
 
 
 # ============================================================================

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -1550,8 +1550,8 @@ class TestAgentLoopStream:
         assert chunks[-1]["metadata"]["content"] == "partial"
 
     @pytest.mark.asyncio
-    async def test_stream_skips_session_save_on_error(self):
-        """stream() should NOT save session when full_content is empty (error before any content)."""
+    async def test_stream_persists_user_turn_on_error_without_assistant(self):
+        """stream() should keep the user turn even when the provider fails immediately."""
         from spoon_bot.agent.loop import AgentLoop
 
         async def mock_stream(message, **kwargs):
@@ -1576,9 +1576,8 @@ class TestAgentLoopStream:
         assert chunks[-1]["type"] == "done"
         assert "error" in chunks[-1]["metadata"]
 
-        # Session should NOT be saved since full_content is empty
-        agent.sessions.save.assert_not_called()
-        agent._session.add_message.assert_not_called()
+        agent._session.add_message.assert_called_once_with("user", "test")
+        agent.sessions.save.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_stream_saves_session_on_success(self):
@@ -1619,7 +1618,7 @@ class TestAgentLoopStream:
         # Verify session was saved
         agent._session.add_message.assert_any_call("user", "test message")
         agent._session.add_message.assert_any_call("assistant", "hello")
-        agent.sessions.save.assert_called_once()
+        assert agent.sessions.save.call_count == 2
 
     @pytest.mark.asyncio
     async def test_stream_close_cancels_background_run_and_skips_session_save(self):
@@ -1669,8 +1668,8 @@ class TestAgentLoopStream:
         await stream.aclose()
         await asyncio.wait_for(run_cancelled.wait(), timeout=1.0)
 
-        agent.sessions.save.assert_not_called()
-        agent._session.add_message.assert_not_called()
+        agent._session.add_message.assert_called_once_with("user", "test message")
+        agent.sessions.save.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_install_anti_loop_tracker_does_not_stack_previous_request_prompt(self):
@@ -1709,6 +1708,7 @@ class TestAgentLoopStream:
         await agent._agent.think()
 
         assert seen_prompts[-1] == "prompt two"
+        agent._compress_runtime_context.assert_not_called()
 
 
 @pytest.mark.requires_spoon_core

--- a/tests/test_streaming_thinking.py
+++ b/tests/test_streaming_thinking.py
@@ -447,6 +447,60 @@ class TestAgentLoopStream:
         assert loop._agent.system_prompt == "base system"
         assert loop._agent._original_system_prompt == "base original"
 
+    def test_build_request_context_prompt_preserves_tail_output_constraints(self):
+        """Compact request scaffolding must keep the latest request ending verbatim."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop.workspace = Path("/workspace")
+        loop._extract_env_for_prompt = MagicMock(return_value="")
+
+        message = (
+            "Inspect the workspace carefully. "
+            + ("middle context " * 30)
+            + "When you are done, reply with exactly: FINAL_OK. Do not summarize."
+        )
+
+        prompt = AgentLoop._build_request_context_prompt(loop, message)
+
+        assert "[... middle omitted to save tokens; preserve latest tail instructions ...]" in prompt
+        assert "reply with exactly: final_ok" in prompt.lower()
+        assert "Do not summarize." in prompt
+        assert "[AUTHORITATIVE REQUEST ENDING]" in prompt
+        assert "[LATEST REQUEST ENDING]:" in prompt
+
+    def test_build_request_context_prompt_skips_extra_tail_block_for_short_requests(self):
+        """Short requests are already preserved whole and do not need an extra tail block."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop.workspace = Path("/workspace")
+        loop._extract_env_for_prompt = MagicMock(return_value="")
+
+        prompt = AgentLoop._build_request_context_prompt(loop, "Return FINAL_OK")
+
+        assert "[AUTHORITATIVE REQUEST ENDING]" not in prompt
+
+    def test_build_request_context_prompt_keeps_non_english_tail_constraints(self):
+        """Long non-English requests should preserve their tail verbatim without keyword matching."""
+        from spoon_bot.agent.loop import AgentLoop
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop.workspace = Path("/workspace")
+        loop._extract_env_for_prompt = MagicMock(return_value="")
+
+        message = (
+            "Revisa el repositorio con cuidado. "
+            + ("contexto intermedio " * 40)
+            + "Al terminar, responde solo con FINAL_OK y no hagas resumen."
+        )
+
+        prompt = AgentLoop._build_request_context_prompt(loop, message)
+
+        assert "[AUTHORITATIVE REQUEST ENDING]" in prompt
+        assert "responde solo con final_ok" in prompt.lower()
+        assert "no hagas resumen" in prompt.lower()
+
     @pytest.mark.asyncio
     async def test_stream_yields_typed_dicts(self):
         """stream() should yield dicts with type, delta, metadata keys."""


### PR DESCRIPTION
## Summary
- persist each user turn before provider execution so manual retries keep the active request
- route thinking mode through the shared provider retry path and recognize more transient SDK errors
- stop background per-step compaction, and only compact older runtime history after an explicit context-overflow failure while preserving the latest real user request, including multimodal prompts
- keep compacted runs anchored to the latest user instruction by preserving the request head/tail and adding an authoritative request-ending block copied verbatim from the newest user message
- turn anti-loop progress tracking into a repetition guard so completed actions do not get echoed back as summary pressure after compression

## Testing
- `python -m pytest tests/test_provider_retry.py tests/test_session_persistence.py tests/test_streaming_thinking.py::TestAgentLoopStream tests/test_streaming_thinking.py::TestAgentLoopProcessWithThinking tests/test_runtime_compaction.py tests/test_runtime_message_sequence.py -q`
- real OpenAI `gpt-5.4` probes with forced runtime compaction for Spanish exact-output and Japanese tool-execution flows
