### PR TITLE
fix: keep workspace watch alive when paths disappear mid-scan

### DIFF
--- a/spoon_bot/gateway/websocket/workspace_watch.py
+++ b/spoon_bot/gateway/websocket/workspace_watch.py
@@ -176,18 +176,35 @@ class WorkspaceWatchService:
         if target.is_file():
             try:
                 relative = target.relative_to(self._workspace_root)
-            except ValueError:
+                snapshot = self._entry_snapshot(target)
+            except (ValueError, FileNotFoundError, OSError):
                 return {}
-            return {self._sandbox_path_for(relative): self._entry_snapshot(target)}
+            return {self._sandbox_path_for(relative): snapshot}
 
         entries: dict[str, dict[str, Any]] = {}
-        iterator = target.rglob("*") if recursive else target.iterdir()
-        for entry in iterator:
+        try:
+            iterator = iter(target.rglob("*") if recursive else target.iterdir())
+        except (FileNotFoundError, OSError):
+            return entries
+
+        while True:
+            try:
+                entry = next(iterator)
+            except StopIteration:
+                break
+            except (FileNotFoundError, OSError):
+                # Highly volatile trees (for example pnpm/node_modules during install)
+                # can lose paths mid-walk. Keep the watch alive and retry next poll.
+                break
+
             try:
                 relative = entry.relative_to(self._workspace_root)
             except ValueError:
                 continue
-            entries[self._sandbox_path_for(relative)] = self._entry_snapshot(entry)
+            try:
+                entries[self._sandbox_path_for(relative)] = self._entry_snapshot(entry)
+            except (FileNotFoundError, OSError):
+                continue
         return entries
 
     @staticmethod

--- a/tests/test_workspace_watch_service.py
+++ b/tests/test_workspace_watch_service.py
@@ -59,3 +59,62 @@ async def test_workspace_watch_service_remove_watch_stops_events(tmp_path: Path)
     await service.close()
 
     assert events == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_watch_service_survives_transient_missing_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    events: list[dict[str, object]] = []
+
+    async def emit_change(payload: dict[str, object]) -> None:
+        events.append(payload)
+
+    service = WorkspaceWatchService(workspace, emit_change, poll_interval=0.05)
+    await service.add_watch("/workspace", recursive=True)
+
+    volatile_file = workspace / "volatile.txt"
+    volatile_file.write_text("volatile", encoding="utf-8")
+
+    original_entry_snapshot = WorkspaceWatchService._entry_snapshot
+    state = {"failed": False}
+
+    def flaky_entry_snapshot(entry: Path) -> dict[str, object]:
+        if entry.name == "volatile.txt" and not state["failed"]:
+            state["failed"] = True
+            if entry.exists():
+                entry.unlink()
+            raise FileNotFoundError(str(entry))
+        return original_entry_snapshot(entry)
+
+    monkeypatch.setattr(
+        WorkspaceWatchService,
+        "_entry_snapshot",
+        staticmethod(flaky_entry_snapshot),
+    )
+
+    for _ in range(10):
+        if state["failed"]:
+            break
+        await asyncio.sleep(0.05)
+
+    stable_file = workspace / "stable.txt"
+    stable_file.write_text("stable", encoding="utf-8")
+
+    for _ in range(20):
+        if any(event.get("path") == "/workspace/stable.txt" for event in events):
+            break
+        await asyncio.sleep(0.05)
+
+    await service.close()
+
+    assert state["failed"] is True
+    assert any(
+        event.get("path") == "/workspace/stable.txt"
+        and event.get("change_type") == "created"
+        for event in events
+    )


### PR DESCRIPTION
## Summary
- keep WorkspaceWatchService alive when files or directories disappear during recursive scans
- skip transient FileNotFoundError/OSError entries instead of killing the watch loop
- add regression coverage for a disappearing path during s.watch polling

## Root cause
Volatile trees such as 
ode_modules/.pnpm can change between directory iteration and stat(). The old code treated that race as fatal, which stopped the per-connection watch task and left s.watch silently dead.

## Testing
- python -m pytest tests/test_workspace_watch_service.py -q

## Not tested
- live /v1/ws flow against an external cypher_api client/runtime
