### PR TITLE
Add built-in wallet and service exposure tools

### DIFF
--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -105,6 +105,13 @@ from spoon_bot.agent.tools.self_config import (
 )
 from spoon_bot.agent.tools.cron import CronTool
 from spoon_bot.agent.tools.web import WebSearchTool, WebFetchTool
+from spoon_bot.agent.tools.wallet import WalletTool
+from spoon_bot.agent.tools.web3 import (
+    BalanceCheckTool,
+    ContractCallTool,
+    SwapTool,
+    TransferTool,
+)
 from spoon_bot.config import (
     AgentLoopConfig,
     DEFAULT_MAX_STREAM_TOOL_RESULTS_WITHOUT_CONTENT,
@@ -1075,6 +1082,15 @@ class AgentLoop:
         # Web tools
         self.tools.register(WebSearchTool())
         self.tools.register(WebFetchTool())
+
+        # Wallet and Web3 tools are registered but remain inactive under the
+        # default core profile. The agent can load them when a wallet task needs
+        # balance checks, signing, transfers, swaps, or contract calls.
+        self.tools.register(WalletTool())
+        self.tools.register(BalanceCheckTool())
+        self.tools.register(TransferTool())
+        self.tools.register(SwapTool())
+        self.tools.register(ContractCallTool())
 
         logger.debug(f"Registered native tools: {self.tools.list_tools()}")
 

--- a/spoon_bot/agent/tools/registry.py
+++ b/spoon_bot/agent/tools/registry.py
@@ -17,7 +17,7 @@ from spoon_bot.agent.tools.execution_context import bind_tool_invocation, finali
 CORE_TOOLS: frozenset[str] = frozenset({
     "shell", "read_file", "write_file", "edit_file", "list_dir", "grep",
     "self_config", "memory", "activate_tool", "self_upgrade", "cron",
-    "web_search", "web_fetch",
+    "web_search", "web_fetch", "wallet", "balance_check",
 })
 
 AUTOMATION_TOOLS: frozenset[str] = frozenset({

--- a/spoon_bot/agent/tools/wallet.py
+++ b/spoon_bot/agent/tools/wallet.py
@@ -1,0 +1,238 @@
+"""Built-in wallet management and signing tool."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from spoon_bot.agent.tools.base import Tool
+from spoon_bot.wallet import (
+    backup_wallet,
+    create_new_wallet,
+    ensure_wallet_runtime,
+    sign_wallet_message,
+    sign_wallet_transaction,
+    sign_wallet_typed_data,
+    wallet_summary,
+)
+
+
+def _env_enabled(name: str) -> bool:
+    raw = os.environ.get(name, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+class WalletTool(Tool):
+    """Manage the local built-in EVM wallet without shelling out."""
+
+    @property
+    def name(self) -> str:
+        return "wallet"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Manage spoon-bot's built-in local EVM wallet: status, backup, create a new "
+            "wallet with automatic backup, export the private key on explicit request, "
+            "and sign EIP-191 messages, EIP-712 typed data, or prepared transactions."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "status",
+                        "backup",
+                        "create_new",
+                        "export_private_key",
+                        "sign_message",
+                        "sign_typed_data",
+                        "sign_transaction",
+                    ],
+                    "description": "Wallet action to perform.",
+                },
+                "network": {
+                    "type": "string",
+                    "description": "Wallet network for create_new, for example neox or neox_testnet.",
+                },
+                "confirm": {
+                    "type": "boolean",
+                    "description": "Required for create_new and export_private_key.",
+                },
+                "reveal_private_key": {
+                    "type": "boolean",
+                    "description": "When exporting, include the raw private key in the tool result.",
+                },
+                "output_path": {
+                    "type": "string",
+                    "description": "Optional file path to write an exported private key.",
+                },
+                "message": {
+                    "type": "string",
+                    "description": "Plain text message for EIP-191 signing.",
+                },
+                "hexstr": {
+                    "type": "string",
+                    "description": "Hex encoded message for EIP-191 signing.",
+                },
+                "typed_data": {
+                    "type": "object",
+                    "description": "Full EIP-712 typed-data object.",
+                },
+                "domain_data": {
+                    "type": "object",
+                    "description": "EIP-712 domain data when not using typed_data.",
+                },
+                "message_types": {
+                    "type": "object",
+                    "description": "EIP-712 custom type definitions when not using typed_data.",
+                },
+                "message_data": {
+                    "type": "object",
+                    "description": "EIP-712 message data when not using typed_data.",
+                },
+                "transaction": {
+                    "type": "object",
+                    "description": "Prepared EVM transaction object to sign without broadcasting.",
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(
+        self,
+        action: str,
+        network: str | None = None,
+        confirm: bool = False,
+        reveal_private_key: bool = False,
+        output_path: str | None = None,
+        message: str | None = None,
+        hexstr: str | None = None,
+        typed_data: dict[str, Any] | str | None = None,
+        domain_data: dict[str, Any] | str | None = None,
+        message_types: dict[str, Any] | str | None = None,
+        message_data: dict[str, Any] | str | None = None,
+        transaction: dict[str, Any] | str | None = None,
+        **_: Any,
+    ) -> str:
+        try:
+            if action == "status":
+                runtime = ensure_wallet_runtime()
+                summary = wallet_summary(runtime)
+                summary.pop("private_key", None)
+                summary["private_key_available"] = True
+                return json.dumps(summary, ensure_ascii=True)
+
+            if action == "backup":
+                backup_dir = backup_wallet()
+                return json.dumps(
+                    {
+                        "success": True,
+                        "backup_dir": str(backup_dir) if backup_dir else None,
+                        "message": "No wallet files existed to back up" if backup_dir is None else "Wallet backed up",
+                    },
+                    ensure_ascii=True,
+                )
+
+            if action == "create_new":
+                if not confirm:
+                    return (
+                        "Safety check failed: creating a new wallet replaces the active wallet files. "
+                        "Call again with confirm=true; existing wallet files will be backed up first."
+                    )
+                if _env_enabled("SPOON_BOT_DISABLE_WALLET_REPLACE"):
+                    return (
+                        "Safety check failed: wallet replacement is disabled by runtime "
+                        "configuration. Unset SPOON_BOT_DISABLE_WALLET_REPLACE or set it "
+                        "to false, then retry after explicit user confirmation."
+                    )
+                runtime, backup_dir = create_new_wallet(network=network, backup_existing=True)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "address": runtime.address,
+                        "network": runtime.network.key,
+                        "wallet_root": str(runtime.wallet_root),
+                        "backup_dir": str(backup_dir) if backup_dir else None,
+                    },
+                    ensure_ascii=True,
+                )
+
+            if action == "export_private_key":
+                if not confirm:
+                    return (
+                        "Safety check failed: private key export requires confirm=true and should only "
+                        "be used when the user explicitly asks for the secret."
+                    )
+                if _env_enabled("SPOON_BOT_DISABLE_PRIVATE_KEY_EXPORT"):
+                    return (
+                        "Safety check failed: private key export is disabled by runtime "
+                        "configuration. Unset SPOON_BOT_DISABLE_PRIVATE_KEY_EXPORT or set it "
+                        "to false, then retry after explicit user confirmation."
+                    )
+                runtime = ensure_wallet_runtime()
+                payload: dict[str, Any] = {
+                    "success": True,
+                    "address": runtime.address,
+                    "network": runtime.network.key,
+                }
+                if output_path:
+                    output = Path(output_path).expanduser().resolve()
+                    output.parent.mkdir(parents=True, exist_ok=True)
+                    output.write_text(runtime.private_key, encoding="utf-8")
+                    try:
+                        output.chmod(0o600)
+                    except OSError:
+                        pass
+                    payload["output_path"] = str(output)
+                if reveal_private_key:
+                    payload["private_key"] = runtime.private_key
+                if not output_path and not reveal_private_key:
+                    payload["message"] = "Private key export confirmed, but no output_path or reveal_private_key was requested."
+                return json.dumps(payload, ensure_ascii=True)
+
+            if action == "sign_message":
+                result = sign_wallet_message(message=message, hexstr=hexstr)
+                return json.dumps(result, ensure_ascii=True)
+
+            if action == "sign_typed_data":
+                result = sign_wallet_typed_data(
+                    full_message=self._object_or_json(typed_data, "typed_data"),
+                    domain_data=self._object_or_json(domain_data, "domain_data"),
+                    message_types=self._object_or_json(message_types, "message_types"),
+                    message_data=self._object_or_json(message_data, "message_data"),
+                )
+                return json.dumps(result, ensure_ascii=True)
+
+            if action == "sign_transaction":
+                tx = self._object_or_json(transaction, "transaction")
+                if tx is None:
+                    return "Error: transaction is required for sign_transaction"
+                result = sign_wallet_transaction(tx)
+                return json.dumps(result, ensure_ascii=True)
+
+            return f"Error: Unsupported wallet action '{action}'"
+        except Exception as exc:
+            return f"Error: wallet action failed: {exc}"
+
+    @staticmethod
+    def _object_or_json(value: dict[str, Any] | str | None, field_name: str) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{field_name} must be a JSON object") from exc
+            if not isinstance(parsed, dict):
+                raise ValueError(f"{field_name} must be a JSON object")
+            return parsed
+        raise ValueError(f"{field_name} must be a JSON object")

--- a/spoon_bot/agent/tools/web3.py
+++ b/spoon_bot/agent/tools/web3.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
-from spoon_bot.agent.tools.base import Tool
-from spoon_bot.wallet import DEFAULT_WALLET_NETWORK
+from eth_account import Account
 
+from spoon_bot.agent.tools.base import Tool
+from spoon_bot.wallet import DEFAULT_WALLET_NETWORK, ensure_wallet_runtime
 
 SUPPORTED_WEB3_CHAINS = frozenset({
     "ethereum", "polygon", "arbitrum", "optimism", "base",
@@ -30,6 +32,126 @@ NETWORK_SYMBOLS = {
     "neox": "GAS",
     "neox_testnet": "GAS",
 }
+
+
+def _decimal_to_units(amount: str, decimals: int) -> int:
+    try:
+        value = Decimal(str(amount))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"Invalid amount '{amount}'. Must be a valid number.") from exc
+    if value <= 0:
+        raise ValueError("Amount must be greater than 0")
+    units = value * (Decimal(10) ** int(decimals))
+    if units != units.to_integral_value():
+        raise ValueError(f"Amount has more than {decimals} decimal places")
+    return int(units)
+
+
+def _get_env_rpc_url(chain: str, default_rpc_url: str | None = None) -> str | None:
+    chain_env_var = f"{chain.upper()}_RPC_URL"
+    rpc_url = os.environ.get(chain_env_var)
+    if not rpc_url and os.environ.get("WALLET_NETWORK") == chain:
+        rpc_url = os.environ.get("ETH_RPC_URL")
+    if not rpc_url and chain == "ethereum":
+        rpc_url = os.environ.get("RPC_URL") or os.environ.get("ETH_RPC_URL") or default_rpc_url
+    return rpc_url
+
+
+def _get_default_wallet_address() -> str | None:
+    address = os.environ.get("WALLET_ADDRESS")
+    if address:
+        return address
+    try:
+        return ensure_wallet_runtime().address
+    except Exception:
+        return None
+
+
+def _get_signing_private_key() -> str | None:
+    private_key = os.environ.get("PRIVATE_KEY")
+    if private_key:
+        return private_key
+    try:
+        return ensure_wallet_runtime().private_key
+    except Exception:
+        return None
+
+
+def _signed_raw_transaction(signed: Any) -> Any:
+    return getattr(signed, "raw_transaction", None) or getattr(signed, "rawTransaction", None)
+
+
+def _fee_fields(web3: Any) -> dict[str, int]:
+    try:
+        latest = web3.eth.get_block("latest")
+        base_fee = latest.get("baseFeePerGas") if hasattr(latest, "get") else latest["baseFeePerGas"]
+    except Exception:
+        base_fee = None
+
+    if base_fee is not None:
+        try:
+            priority_fee = int(web3.eth.max_priority_fee)
+        except Exception:
+            priority_fee = int(web3.to_wei(Decimal("1.5"), "gwei"))
+        return {
+            "maxPriorityFeePerGas": priority_fee,
+            "maxFeePerGas": int(base_fee) * 2 + priority_fee,
+        }
+
+    return {"gasPrice": int(web3.eth.gas_price)}
+
+
+def _env_enabled(name: str) -> bool:
+    raw = os.environ.get(name, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _live_transfer_disabled_message(operation: str) -> str:
+    return (
+        "SAFETY CHECK FAILED: live blockchain writes are disabled by runtime configuration.\n\n"
+        f"Blocked operation: {operation}\n"
+        "Unset SPOON_BOT_DISABLE_LIVE_TRANSFERS or set it to false, then retry "
+        "after the user explicitly confirms the exact operation."
+    )
+
+
+def _to_hex(web3: Any, value: Any) -> str:
+    return web3.to_hex(value) if hasattr(web3, "to_hex") else value.hex()
+
+
+ERC20_ABI: list[dict[str, Any]] = [
+    {
+        "constant": True,
+        "inputs": [{"name": "owner", "type": "address"}],
+        "name": "balanceOf",
+        "outputs": [{"name": "balance", "type": "uint256"}],
+        "type": "function",
+    },
+    {
+        "constant": True,
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [{"name": "", "type": "uint8"}],
+        "type": "function",
+    },
+    {
+        "constant": True,
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [{"name": "", "type": "string"}],
+        "type": "function",
+    },
+    {
+        "constant": False,
+        "inputs": [
+            {"name": "to", "type": "address"},
+            {"name": "value", "type": "uint256"},
+        ],
+        "name": "transfer",
+        "outputs": [{"name": "", "type": "bool"}],
+        "type": "function",
+    },
+]
 
 
 class BalanceCheckTool(Tool):
@@ -88,18 +210,11 @@ class BalanceCheckTool(Tool):
 
     def _get_rpc_url(self, chain: str) -> str | None:
         """Get RPC URL for the specified chain from environment."""
-        # Check chain-specific env var first
-        chain_env_var = f"{chain.upper()}_RPC_URL"
-        rpc_url = os.environ.get(chain_env_var)
-
-        if not rpc_url and chain == "ethereum":
-            rpc_url = os.environ.get("RPC_URL") or self._default_rpc_url
-
-        return rpc_url
+        return _get_env_rpc_url(chain, self._default_rpc_url)
 
     def _get_default_address(self) -> str | None:
         """Get default wallet address from environment."""
-        return os.environ.get("WALLET_ADDRESS")
+        return _get_default_wallet_address()
 
     async def execute(
         self,
@@ -178,33 +293,9 @@ class BalanceCheckTool(Tool):
             }
 
             if tokens:
-                erc20_abi = [
-                    {
-                        "constant": True,
-                        "inputs": [{"name": "owner", "type": "address"}],
-                        "name": "balanceOf",
-                        "outputs": [{"name": "balance", "type": "uint256"}],
-                        "type": "function",
-                    },
-                    {
-                        "constant": True,
-                        "inputs": [],
-                        "name": "decimals",
-                        "outputs": [{"name": "", "type": "uint8"}],
-                        "type": "function",
-                    },
-                    {
-                        "constant": True,
-                        "inputs": [],
-                        "name": "symbol",
-                        "outputs": [{"name": "", "type": "string"}],
-                        "type": "function",
-                    },
-                ]
-
                 for token in tokens:
                     token_address = web3.to_checksum_address(token)
-                    contract = web3.eth.contract(address=token_address, abi=erc20_abi)
+                    contract = web3.eth.contract(address=token_address, abi=ERC20_ABI)
                     balance = contract.functions.balanceOf(checksum_address).call()
                     try:
                         decimals = contract.functions.decimals().call()
@@ -300,15 +391,11 @@ class TransferTool(Tool):
 
     def _get_rpc_url(self, chain: str) -> str | None:
         """Get RPC URL for the specified chain from environment."""
-        chain_env_var = f"{chain.upper()}_RPC_URL"
-        rpc_url = os.environ.get(chain_env_var)
-        if not rpc_url and chain == "ethereum":
-            rpc_url = os.environ.get("RPC_URL")
-        return rpc_url
+        return _get_env_rpc_url(chain)
 
     def _get_private_key(self) -> str | None:
         """Get private key from environment."""
-        return os.environ.get("PRIVATE_KEY")
+        return _get_signing_private_key()
 
     async def execute(
         self,
@@ -342,7 +429,12 @@ class TransferTool(Tool):
                 f"  Amount: {amount}\n"
                 f"  Token: {token}\n"
                 f"  Chain: {chain}\n\n"
-                "To proceed, call this tool again with confirm=true."
+                "To proceed, call this tool again with confirm=true after the user "
+                "explicitly confirms the exact operation."
+            )
+        if self._require_confirmation and _env_enabled("SPOON_BOT_DISABLE_LIVE_TRANSFERS"):
+            return _live_transfer_disabled_message(
+                f"transfer {amount} {token} on {chain} to {to_address}"
             )
 
         # Validate chain
@@ -352,14 +444,6 @@ class TransferTool(Tool):
         # Validate address format (basic check)
         if not to_address.startswith("0x") or len(to_address) != 42:
             return "Error: Invalid address format. Expected 0x followed by 40 hex characters."
-
-        # Check amount is valid number
-        try:
-            amount_float = float(amount)
-            if amount_float <= 0:
-                return "Error: Amount must be greater than 0"
-        except ValueError:
-            return f"Error: Invalid amount '{amount}'. Must be a valid number."
 
         # Check RPC configuration
         rpc_url = self._get_rpc_url(chain)
@@ -379,17 +463,74 @@ class TransferTool(Tool):
                 "WARNING: Never share your private key. Use a dedicated wallet for bot operations."
             )
 
-        # Stub implementation
-        return (
-            f"[STUB] Transfer would execute:\n"
-            f"  To: {to_address}\n"
-            f"  Amount: {amount}\n"
-            f"  Token: {token}\n"
-            f"  Chain: {chain}\n\n"
-            f"To enable Web3 functionality, install web3.py:\n"
-            f"  pip install web3\n\n"
-            f"This is a stub - no actual transaction was sent."
-        )
+        try:
+            from web3 import Web3
+        except ImportError:
+            return (
+                "Error: Web3 provider not available. Install web3.py to enable blockchain tools.\n"
+                "  pip install web3"
+            )
+
+        try:
+            web3 = Web3(Web3.HTTPProvider(rpc_url))
+            if not web3.is_connected():
+                return "Error: RPC connection failed"
+
+            account = Account.from_key(private_key)
+            sender = web3.to_checksum_address(account.address)
+            recipient = web3.to_checksum_address(to_address)
+            nonce = web3.eth.get_transaction_count(sender)
+            chain_id = int(web3.eth.chain_id)
+            base_tx: dict[str, Any] = {
+                "from": sender,
+                "nonce": nonce,
+                "chainId": chain_id,
+                **_fee_fields(web3),
+            }
+
+            if token == "native":
+                value = _decimal_to_units(amount, 18)
+                tx: dict[str, Any] = {
+                    **base_tx,
+                    "to": recipient,
+                    "value": value,
+                }
+                tx["gas"] = int(web3.eth.estimate_gas(tx))
+                symbol = NETWORK_SYMBOLS.get(chain, "NATIVE")
+            else:
+                token_address = web3.to_checksum_address(token)
+                contract = web3.eth.contract(address=token_address, abi=ERC20_ABI)
+                try:
+                    decimals = int(contract.functions.decimals().call())
+                except Exception:
+                    decimals = 18
+                try:
+                    symbol = str(contract.functions.symbol().call())
+                except Exception:
+                    symbol = "TOKEN"
+                value = _decimal_to_units(amount, decimals)
+                tx = contract.functions.transfer(recipient, value).build_transaction(base_tx)
+                if "gas" not in tx:
+                    tx["gas"] = int(web3.eth.estimate_gas(tx))
+
+            signed = web3.eth.account.sign_transaction(tx, private_key)
+            tx_hash = web3.eth.send_raw_transaction(_signed_raw_transaction(signed))
+            return json.dumps(
+                {
+                    "success": True,
+                    "chain": chain,
+                    "chain_id": chain_id,
+                    "from": sender,
+                    "to": recipient,
+                    "token": token,
+                    "symbol": symbol,
+                    "amount": str(amount),
+                    "tx_hash": _to_hex(web3, tx_hash),
+                },
+                ensure_ascii=True,
+            )
+        except Exception as e:
+            return f"Error: Transfer failed: {e}"
 
 
 class SwapTool(Tool):
@@ -477,15 +618,11 @@ class SwapTool(Tool):
 
     def _get_rpc_url(self, chain: str) -> str | None:
         """Get RPC URL for the specified chain from environment."""
-        chain_env_var = f"{chain.upper()}_RPC_URL"
-        rpc_url = os.environ.get(chain_env_var)
-        if not rpc_url and chain == "ethereum":
-            rpc_url = os.environ.get("RPC_URL")
-        return rpc_url
+        return _get_env_rpc_url(chain)
 
     def _get_private_key(self) -> str | None:
         """Get private key from environment."""
-        return os.environ.get("PRIVATE_KEY")
+        return _get_signing_private_key()
 
     async def execute(
         self,
@@ -663,15 +800,11 @@ class ContractCallTool(Tool):
 
     def _get_rpc_url(self, chain: str) -> str | None:
         """Get RPC URL for the specified chain from environment."""
-        chain_env_var = f"{chain.upper()}_RPC_URL"
-        rpc_url = os.environ.get(chain_env_var)
-        if not rpc_url and chain == "ethereum":
-            rpc_url = os.environ.get("RPC_URL")
-        return rpc_url
+        return _get_env_rpc_url(chain)
 
     def _get_private_key(self) -> str | None:
         """Get private key from environment."""
-        return os.environ.get("PRIVATE_KEY")
+        return _get_signing_private_key()
 
     async def execute(
         self,
@@ -727,7 +860,12 @@ class ContractCallTool(Tool):
                 "  - This will submit a transaction to the blockchain\n"
                 "  - Gas fees will be charged\n"
                 "  - State changes may be irreversible\n\n"
-                "To proceed, call this tool again with confirm=true."
+                "To proceed, call this tool again with confirm=true after the user "
+                "explicitly confirms the exact operation."
+            )
+        if is_write and self._require_confirmation and _env_enabled("SPOON_BOT_DISABLE_LIVE_TRANSFERS"):
+            return _live_transfer_disabled_message(
+                f"contract write {method} on {chain} at {contract_address}"
             )
 
         # Check RPC configuration
@@ -758,17 +896,84 @@ class ContractCallTool(Tool):
             except ValueError:
                 return f"Error: Invalid value '{value}'. Must be a valid number."
 
-        # Stub implementation
-        operation_type = "Write (Transaction)" if is_write else "Read (Call)"
-        return (
-            f"[STUB] Contract {operation_type.lower()} would execute:\n"
-            f"  Contract: {contract_address}\n"
-            f"  Method: {method}\n"
-            f"  Arguments: {args}\n"
-            f"  Chain: {chain}\n"
-            f"  Value: {value or '0'}\n"
-            f"  Operation: {operation_type}\n\n"
-            f"To enable Web3 functionality, install web3.py:\n"
-            f"  pip install web3\n\n"
-            f"This is a stub - no actual contract call was made."
-        )
+        try:
+            from web3 import Web3
+        except ImportError:
+            return (
+                "Error: Web3 provider not available. Install web3.py to enable blockchain tools.\n"
+                "  pip install web3"
+            )
+
+        try:
+            parsed_abi = json.loads(abi) if isinstance(abi, str) and abi.strip() else None
+        except json.JSONDecodeError as exc:
+            return f"Error: Invalid ABI JSON: {exc}"
+        if not parsed_abi:
+            return "Error: ABI is required for contract_call"
+
+        try:
+            web3 = Web3(Web3.HTTPProvider(rpc_url))
+            if not web3.is_connected():
+                return "Error: RPC connection failed"
+
+            checksum_contract = web3.to_checksum_address(contract_address)
+            contract = web3.eth.contract(address=checksum_contract, abi=parsed_abi)
+            function_name = method.split("(", 1)[0].strip()
+            if not function_name:
+                return "Error: Method name is required"
+            try:
+                fn = contract.get_function_by_name(function_name)(*args)
+            except Exception:
+                fn = getattr(contract.functions, function_name)(*args)
+
+            if not is_write:
+                call_result = fn.call()
+                return json.dumps(
+                    {
+                        "success": True,
+                        "operation": "call",
+                        "chain": chain,
+                        "contract": checksum_contract,
+                        "method": function_name,
+                        "result": call_result,
+                    },
+                    ensure_ascii=True,
+                    default=str,
+                )
+
+            private_key = self._get_private_key()
+            if not private_key:
+                return (
+                    "Error: Private key not configured for write operation. "
+                    "Set PRIVATE_KEY environment variable or initialize the built-in wallet."
+                )
+            account = Account.from_key(private_key)
+            sender = web3.to_checksum_address(account.address)
+            tx_value = _decimal_to_units(value, 18) if value else 0
+            tx_params: dict[str, Any] = {
+                "from": sender,
+                "nonce": web3.eth.get_transaction_count(sender),
+                "chainId": int(web3.eth.chain_id),
+                "value": tx_value,
+                **_fee_fields(web3),
+            }
+            tx = fn.build_transaction(tx_params)
+            if "gas" not in tx:
+                tx["gas"] = int(web3.eth.estimate_gas(tx))
+            signed = web3.eth.account.sign_transaction(tx, private_key)
+            tx_hash = web3.eth.send_raw_transaction(_signed_raw_transaction(signed))
+            return json.dumps(
+                {
+                    "success": True,
+                    "operation": "transaction",
+                    "chain": chain,
+                    "chain_id": int(web3.eth.chain_id),
+                    "from": sender,
+                    "contract": checksum_contract,
+                    "method": function_name,
+                    "tx_hash": _to_hex(web3, tx_hash),
+                },
+                ensure_ascii=True,
+            )
+        except Exception as e:
+            return f"Error: Contract call failed: {e}"

--- a/spoon_bot/skills/builtin/service_expose/SKILL.md
+++ b/spoon_bot/skills/builtin/service_expose/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: service_expose
+description: Run user-created frontend or backend services in the background and optionally expose them through a Cloudflare Quick Tunnel.
+version: 1.0.0
+author: XSpoon Team
+tags: [service, frontend, backend, cloudflare, tunnel, background]
+triggers:
+  - type: keyword
+    keywords: [background service, run service, expose service, cloudflare tunnel, trycloudflare, frontend preview, backend preview]
+    priority: 90
+scripts:
+  enabled: true
+  definitions:
+    - name: service_expose
+      description: Start, stop, inspect, log, and Cloudflare-expose local frontend/backend services.
+      type: python
+      file: scripts/service_expose.py
+      timeout: 60
+      input_schema:
+        type: object
+        properties:
+          action:
+            type: string
+            description: "start, tunnel, status, list, logs, stop, or stop_tunnel"
+          name:
+            type: string
+            description: "Stable service name"
+          command:
+            type: string
+            description: "Command to run for action=start"
+          cwd:
+            type: string
+            description: "Working directory for the service command"
+          port:
+            type: integer
+            description: "Local port to expose"
+          host:
+            type: string
+            description: "Local host, default 127.0.0.1"
+          url:
+            type: string
+            description: "Full local URL to expose, for example http://127.0.0.1:3000"
+          start_tunnel:
+            type: boolean
+            description: "Start Cloudflare tunnel after service start"
+          replace:
+            type: boolean
+            description: "Stop and replace an existing process with the same name"
+          tail_chars:
+            type: integer
+            description: "Log tail size"
+        required: [action]
+---
+
+# Service Expose
+
+Use this skill when a user-created frontend or backend needs to keep running after the turn and be reachable through Cloudflare.
+
+Prefer `service_expose` over one-off shell backgrounding for preview services because it persists service metadata, log paths, PIDs, local URLs, and tunnel URLs under `~/.spoon-bot/service-expose`.
+
+## Actions
+
+- `start`: run a service command in the background. Include `name`, `command`, and usually `cwd` plus `port` or `url`.
+- `tunnel`: start a Cloudflare Quick Tunnel for an existing service or an explicit local `url`.
+- `status` / `list`: inspect running services and tunnel URLs.
+- `logs`: return recent service or tunnel logs.
+- `stop` / `stop_tunnel`: stop the background service or only its Cloudflare tunnel.
+
+## Rules
+
+Use `replace=true` only when the user wants to restart/replace the existing named service. Quick Tunnels require `cloudflared` in `PATH` or `CLOUDFLARED_PATH`.
+
+Cloudflare Quick Tunnels are for development previews. For production or stable hostnames, use a named Cloudflare Tunnel outside this quick-preview skill.

--- a/spoon_bot/skills/builtin/service_expose/scripts/service_expose.py
+++ b/spoon_bot/skills/builtin/service_expose/scripts/service_expose.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Run local services in the background and expose them through Cloudflare."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+WINDOWS_DETACHED_PROCESS = 0x00000008
+WINDOWS_CREATE_NEW_PROCESS_GROUP = 0x00000200
+WINDOWS_CREATE_NO_WINDOW = 0x08000000
+TRYCLOUDFLARE_RE = re.compile(r"https://[-a-zA-Z0-9]+\.trycloudflare\.com")
+
+
+def _state_root() -> Path:
+    raw = os.environ.get("SPOON_BOT_SERVICE_EXPOSE_DIR")
+    return Path(raw).expanduser().resolve() if raw else Path.home() / ".spoon-bot" / "service-expose"
+
+
+def _registry_path() -> Path:
+    return _state_root() / "registry.json"
+
+
+def _logs_dir() -> Path:
+    return _state_root() / "logs"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _json_result(payload: dict[str, Any]) -> None:
+    json.dump(payload, sys.stdout, ensure_ascii=True)
+
+
+def _load_params() -> dict[str, Any]:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw or "{}")
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON input: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Input must be a JSON object")
+    return payload
+
+
+def _load_registry() -> dict[str, Any]:
+    path = _registry_path()
+    if not path.exists():
+        return {"services": {}}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"services": {}}
+    if not isinstance(payload, dict):
+        return {"services": {}}
+    payload.setdefault("services", {})
+    return payload
+
+
+def _save_registry(registry: dict[str, Any]) -> None:
+    path = _registry_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(registry, indent=2, ensure_ascii=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _safe_name(name: str | None) -> str:
+    raw = str(name or "").strip()
+    if not raw:
+        raise ValueError("name is required")
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", raw).strip("._-")
+    if not safe:
+        raise ValueError("name must contain at least one letter or digit")
+    return safe[:80]
+
+
+def _pid_alive(pid: int | None) -> bool:
+    if not pid:
+        return False
+    try:
+        if os.name == "nt":
+            import ctypes
+
+            handle = ctypes.windll.kernel32.OpenProcess(0x00100000, False, int(pid))
+            if handle:
+                ctypes.windll.kernel32.CloseHandle(handle)
+                return True
+            return False
+        os.kill(int(pid), 0)
+        return True
+    except Exception:
+        return False
+
+
+def _stop_pid(pid: int | None, *, process_group: bool = True) -> bool:
+    if not _pid_alive(pid):
+        return True
+    if os.name == "nt":
+        result = subprocess.run(
+            ["taskkill", "/PID", str(pid), "/T", "/F"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0 or not _pid_alive(pid)
+
+    assert pid is not None
+    try:
+        if process_group:
+            os.killpg(int(pid), signal.SIGTERM)
+        else:
+            os.kill(int(pid), signal.SIGTERM)
+    except ProcessLookupError:
+        return True
+    except OSError:
+        try:
+            os.kill(int(pid), signal.SIGTERM)
+        except OSError:
+            return False
+    for _ in range(20):
+        if not _pid_alive(pid):
+            return True
+        time.sleep(0.1)
+    try:
+        if process_group:
+            os.killpg(int(pid), signal.SIGKILL)
+        else:
+            os.kill(int(pid), signal.SIGKILL)
+    except OSError:
+        pass
+    return not _pid_alive(pid)
+
+
+def _tail(path: str | None, tail_chars: int = 4000) -> str:
+    if not path:
+        return ""
+    log_path = Path(path)
+    if not log_path.exists():
+        return ""
+    try:
+        with open(log_path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - max(1, int(tail_chars))))
+            return fh.read().decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _spawn_shell(command: str, cwd: Path, log_path: Path) -> int:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    flags = 0
+    kwargs: dict[str, Any] = {
+        "stdin": subprocess.DEVNULL,
+        "cwd": str(cwd),
+        "shell": True,
+        "env": os.environ.copy(),
+    }
+    if os.name == "nt":
+        flags = WINDOWS_DETACHED_PROCESS | WINDOWS_CREATE_NEW_PROCESS_GROUP | WINDOWS_CREATE_NO_WINDOW
+        kwargs["creationflags"] = flags
+    else:
+        kwargs["start_new_session"] = True
+
+    with open(log_path, "ab") as log_fh:
+        kwargs["stdout"] = log_fh
+        kwargs["stderr"] = subprocess.STDOUT
+        proc = subprocess.Popen(command, **kwargs)  # noqa: S602
+    return int(proc.pid)
+
+
+def _spawn_argv(argv: list[str], cwd: Path, log_path: Path) -> int:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    kwargs: dict[str, Any] = {
+        "stdin": subprocess.DEVNULL,
+        "cwd": str(cwd),
+        "env": os.environ.copy(),
+    }
+    if os.name == "nt":
+        kwargs["creationflags"] = (
+            WINDOWS_DETACHED_PROCESS | WINDOWS_CREATE_NEW_PROCESS_GROUP | WINDOWS_CREATE_NO_WINDOW
+        )
+    else:
+        kwargs["start_new_session"] = True
+
+    with open(log_path, "ab") as log_fh:
+        kwargs["stdout"] = log_fh
+        kwargs["stderr"] = subprocess.STDOUT
+        proc = subprocess.Popen(argv, **kwargs)  # noqa: S603
+    return int(proc.pid)
+
+
+def _local_url(params: dict[str, Any], entry: dict[str, Any] | None = None) -> str:
+    url = str(params.get("url") or "").strip()
+    if url:
+        return url
+    if entry and entry.get("local_url"):
+        return str(entry["local_url"])
+    port = params.get("port") if params.get("port") is not None else (entry or {}).get("port")
+    if port is None:
+        raise ValueError("port or url is required for tunnel exposure")
+    host = str(params.get("host") or (entry or {}).get("host") or "127.0.0.1").strip() or "127.0.0.1"
+    scheme = str(params.get("scheme") or (entry or {}).get("scheme") or "http").strip() or "http"
+    return f"{scheme}://{host}:{int(port)}"
+
+
+def _parse_public_url(log_path: Path) -> str | None:
+    text = _tail(str(log_path), 20000)
+    match = TRYCLOUDFLARE_RE.search(text)
+    return match.group(0) if match else None
+
+
+def _start_tunnel_for_entry(
+    name: str,
+    entry: dict[str, Any],
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    cloudflared = os.environ.get("CLOUDFLARED_PATH") or shutil.which("cloudflared")
+    if not cloudflared:
+        return {
+            "success": False,
+            "error": "cloudflared not found. Install cloudflared or set CLOUDFLARED_PATH.",
+        }
+
+    local_url = _local_url(params, entry)
+    tunnel_log = _logs_dir() / f"{name}.cloudflared.log"
+    pid = _spawn_argv([cloudflared, "tunnel", "--url", local_url], Path.cwd(), tunnel_log)
+    public_url = None
+    for _ in range(int(params.get("tunnel_wait_seconds", 25)) * 2):
+        public_url = _parse_public_url(tunnel_log)
+        if public_url:
+            break
+        if not _pid_alive(pid):
+            break
+        time.sleep(0.5)
+
+    tunnel = {
+        "pid": pid,
+        "local_url": local_url,
+        "public_url": public_url,
+        "log_path": str(tunnel_log),
+        "started_at": _now(),
+        "status": "running" if _pid_alive(pid) else "exited",
+    }
+    entry["tunnel"] = tunnel
+    return {"success": public_url is not None, **tunnel}
+
+
+def _refresh_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    service_pid = entry.get("pid")
+    entry["status"] = "running" if _pid_alive(service_pid) else "stopped"
+    tunnel = entry.get("tunnel")
+    if isinstance(tunnel, dict):
+        tunnel["status"] = "running" if _pid_alive(tunnel.get("pid")) else "stopped"
+    return entry
+
+
+def _action_start(params: dict[str, Any]) -> dict[str, Any]:
+    name = _safe_name(params.get("name"))
+    command = str(params.get("command") or "").strip()
+    if not command:
+        raise ValueError("command is required for action=start")
+    cwd = Path(params.get("cwd") or os.getcwd()).expanduser().resolve()
+    if not cwd.is_dir():
+        raise ValueError(f"cwd is not a directory: {cwd}")
+
+    registry = _load_registry()
+    services = registry.setdefault("services", {})
+    existing = services.get(name)
+    if isinstance(existing, dict):
+        _refresh_entry(existing)
+        if existing.get("status") == "running" and not params.get("replace"):
+            return {
+                "success": False,
+                "error": f"Service '{name}' is already running",
+                "service": existing,
+            }
+        if params.get("replace"):
+            _stop_entry(existing, stop_tunnel=True)
+
+    log_path = _logs_dir() / f"{name}.service.log"
+    pid = _spawn_shell(command, cwd, log_path)
+    local_url = None
+    try:
+        local_url = _local_url(params)
+    except ValueError:
+        pass
+
+    entry = {
+        "name": name,
+        "command": command,
+        "cwd": str(cwd),
+        "pid": pid,
+        "status": "running" if _pid_alive(pid) else "exited",
+        "host": str(params.get("host") or "127.0.0.1"),
+        "port": params.get("port"),
+        "scheme": str(params.get("scheme") or "http"),
+        "local_url": local_url,
+        "log_path": str(log_path),
+        "started_at": _now(),
+        "tunnel": None,
+    }
+    if params.get("start_tunnel"):
+        entry["tunnel"] = _start_tunnel_for_entry(name, entry, params)
+    services[name] = entry
+    _save_registry(registry)
+    return {"success": True, "service": _refresh_entry(entry)}
+
+
+def _stop_entry(entry: dict[str, Any], *, stop_tunnel: bool) -> dict[str, Any]:
+    stopped_tunnel = None
+    if stop_tunnel and isinstance(entry.get("tunnel"), dict):
+        tunnel = entry["tunnel"]
+        stopped_tunnel = _stop_pid(tunnel.get("pid"))
+        tunnel["status"] = "stopped" if stopped_tunnel else "stop_failed"
+        tunnel["stopped_at"] = _now()
+    stopped_service = _stop_pid(entry.get("pid"))
+    entry["status"] = "stopped" if stopped_service else "stop_failed"
+    entry["stopped_at"] = _now()
+    return {"service_stopped": stopped_service, "tunnel_stopped": stopped_tunnel}
+
+
+def _action_stop(params: dict[str, Any], *, tunnel_only: bool = False) -> dict[str, Any]:
+    name = _safe_name(params.get("name"))
+    registry = _load_registry()
+    entry = registry.get("services", {}).get(name)
+    if not isinstance(entry, dict):
+        return {"success": False, "error": f"Service '{name}' not found"}
+
+    if tunnel_only:
+        tunnel = entry.get("tunnel")
+        if not isinstance(tunnel, dict):
+            return {"success": False, "error": f"Service '{name}' has no tunnel"}
+        stopped = _stop_pid(tunnel.get("pid"))
+        tunnel["status"] = "stopped" if stopped else "stop_failed"
+        tunnel["stopped_at"] = _now()
+        result = {"tunnel_stopped": stopped}
+    else:
+        result = _stop_entry(entry, stop_tunnel=True)
+    _save_registry(registry)
+    return {"success": bool(all(v is not False for v in result.values())), "service": _refresh_entry(entry), **result}
+
+
+def _action_tunnel(params: dict[str, Any]) -> dict[str, Any]:
+    name = _safe_name(params.get("name"))
+    registry = _load_registry()
+    services = registry.setdefault("services", {})
+    entry = services.get(name)
+    if not isinstance(entry, dict):
+        entry = {
+            "name": name,
+            "command": None,
+            "cwd": str(Path.cwd()),
+            "pid": None,
+            "status": "external",
+            "host": str(params.get("host") or "127.0.0.1"),
+            "port": params.get("port"),
+            "scheme": str(params.get("scheme") or "http"),
+            "local_url": _local_url(params),
+            "log_path": None,
+            "started_at": _now(),
+        }
+        services[name] = entry
+
+    existing_tunnel = entry.get("tunnel")
+    if isinstance(existing_tunnel, dict) and _pid_alive(existing_tunnel.get("pid")):
+        if not params.get("replace"):
+            return {"success": False, "error": f"Tunnel for '{name}' is already running", "service": entry}
+        _stop_pid(existing_tunnel.get("pid"))
+
+    tunnel = _start_tunnel_for_entry(name, entry, params)
+    _save_registry(registry)
+    return {"success": bool(tunnel.get("public_url")), "service": _refresh_entry(entry), "tunnel": tunnel}
+
+
+def _action_status(params: dict[str, Any]) -> dict[str, Any]:
+    registry = _load_registry()
+    services = registry.setdefault("services", {})
+    name = params.get("name")
+    if name:
+        safe = _safe_name(str(name))
+        entry = services.get(safe)
+        if not isinstance(entry, dict):
+            return {"success": False, "error": f"Service '{safe}' not found"}
+        return {"success": True, "service": _refresh_entry(entry)}
+    refreshed = {key: _refresh_entry(value) for key, value in services.items() if isinstance(value, dict)}
+    return {"success": True, "services": refreshed}
+
+
+def _action_logs(params: dict[str, Any]) -> dict[str, Any]:
+    name = _safe_name(params.get("name"))
+    target = str(params.get("target") or "service")
+    tail_chars = int(params.get("tail_chars") or 4000)
+    registry = _load_registry()
+    entry = registry.get("services", {}).get(name)
+    if not isinstance(entry, dict):
+        return {"success": False, "error": f"Service '{name}' not found"}
+
+    result: dict[str, Any] = {"success": True, "name": name}
+    if target in {"service", "all"}:
+        result["service_log"] = _tail(entry.get("log_path"), tail_chars)
+    if target in {"tunnel", "all"}:
+        tunnel = entry.get("tunnel") if isinstance(entry.get("tunnel"), dict) else {}
+        result["tunnel_log"] = _tail(tunnel.get("log_path"), tail_chars)
+    return result
+
+
+def main() -> None:
+    try:
+        params = _load_params()
+        action = str(params.get("action") or "").strip().lower()
+        if action == "start":
+            result = _action_start(params)
+        elif action == "tunnel":
+            result = _action_tunnel(params)
+        elif action in {"status", "list"}:
+            result = _action_status(params)
+        elif action == "logs":
+            result = _action_logs(params)
+        elif action == "stop":
+            result = _action_stop(params)
+        elif action == "stop_tunnel":
+            result = _action_stop(params, tunnel_only=True)
+        else:
+            result = {"success": False, "error": "Unsupported action. Use start, tunnel, status, list, logs, stop, or stop_tunnel."}
+    except Exception as exc:
+        result = {"success": False, "error": str(exc)}
+    _json_result(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/spoon_bot/skills/builtin/wallet/SKILL.md
+++ b/spoon_bot/skills/builtin/wallet/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: wallet
-description: Use when working with spoon-bot's built-in EVM wallet, checking Neo X wallet readiness, or supporting skills that expect the legacy ~/.agent-wallet layout.
+description: Use when working with spoon-bot's built-in EVM wallet, checking balances, transferring EVM assets, signing messages or transactions, rotating/exporting keys, or supporting skills that expect the legacy ~/.agent-wallet layout.
 ---
 
 # Wallet
 
 ## Overview
 
-`wallet` is a built-in spoon-bot skill. The wallet runtime is implemented in Python inside spoon-bot, so this skill is documentation and operating guidance only.
+`wallet` is a built-in spoon-bot skill. The wallet runtime and signing tools are implemented in Python inside spoon-bot, so prefer the native `wallet`, `balance_check`, `transfer`, and `contract_call` tools over ad hoc shell commands.
 
 Do not install or bootstrap an external `openclaw/skills` wallet flow when this built-in skill is present.
 
@@ -16,11 +16,13 @@ Do not install or bootstrap an external `openclaw/skills` wallet flow when this 
 Use this skill when:
 
 - a task needs the agent wallet address, network, or compatibility paths
+- a task needs wallet balance lookup, token transfer, message signing, typed-data signing, or prepared transaction signing
+- a user explicitly asks to export a private key or create a fresh wallet
 - a skill such as `joker-game-agent` expects the legacy `~/.agent-wallet` files
 - the user asks whether a wallet already exists or was auto-created on startup
 - the user wants to confirm which Neo X network is active
 
-Do not use this skill to expose or print the raw private key unless the user explicitly asks for that secret.
+Do not use this skill to expose or print the raw private key unless the user explicitly asks for that secret. Private-key export requires `wallet(action="export_private_key", confirm=true, ...)`.
 
 ## Private Key Safety (CRITICAL)
 
@@ -43,6 +45,8 @@ Skills that need the private key for signing transactions access it through the 
 4. The default network is `neox` (Neo X Mainnet). `neox_testnet` is also supported.
 5. If the operator already provided `WALLET_ADDRESS`, `RPC_URL`, or `ETH_RPC_URL`, treat those values as higher priority than the auto-created defaults.
 6. Do not delete, rotate, or replace wallet files unless the user explicitly requests that action.
+7. `wallet(action="create_new", confirm=true)` creates a new wallet and backs up existing wallet files first.
+8. Real transfers and write contract calls require explicit `confirm=true`.
 
 ## What To Check
 

--- a/spoon_bot/wallet.py
+++ b/spoon_bot/wallet.py
@@ -9,11 +9,14 @@ from __future__ import annotations
 import json
 import os
 import secrets
+import shutil
 from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from eth_account import Account
+from eth_account.messages import encode_defunct
 
 
 @dataclass(frozen=True)
@@ -114,6 +117,15 @@ def _password_file(wallet_root: Path) -> Path:
 
 def _private_key_file(wallet_root: Path) -> Path:
     return wallet_root / "privatekey.tmp"
+
+
+def _wallet_files(wallet_root: Path) -> list[Path]:
+    return [
+        _state_file(wallet_root),
+        _keystore_file(wallet_root),
+        _password_file(wallet_root),
+        _private_key_file(wallet_root),
+    ]
 
 
 def _bool_env(name: str, default: bool) -> bool:
@@ -326,6 +338,148 @@ def ensure_wallet_runtime(workspace: Path | str | None = None) -> WalletRuntime:
     export_wallet_environment(runtime)
     os.environ["SPOON_BOT_WALLET_AUTO_CREATED"] = "1" if auto_created else "0"
     return runtime
+
+
+def backup_wallet(
+    workspace: Path | str | None = None,
+    *,
+    backup_root: Path | str | None = None,
+) -> Path | None:
+    """Copy the current wallet files into a timestamped backup directory.
+
+    Returns ``None`` when no wallet files exist yet.
+    """
+    wallet_root = _wallet_root(workspace)
+    existing_files = [path for path in _wallet_files(wallet_root) if path.exists()]
+    if not existing_files:
+        return None
+
+    root = (
+        Path(backup_root).expanduser().resolve()
+        if backup_root is not None
+        else wallet_root / "backups"
+    )
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    backup_dir = root / stamp
+    suffix = 1
+    while backup_dir.exists():
+        backup_dir = root / f"{stamp}-{suffix}"
+        suffix += 1
+
+    backup_dir.mkdir(parents=True, exist_ok=False)
+    for source in existing_files:
+        shutil.copy2(source, backup_dir / source.name)
+
+    metadata = {
+        "backed_up_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "source": str(wallet_root),
+        "files": [path.name for path in existing_files],
+    }
+    _write_json(backup_dir / "metadata.json", metadata)
+    try:
+        backup_dir.chmod(0o700)
+    except OSError:
+        pass
+    return backup_dir
+
+
+def create_new_wallet(
+    workspace: Path | str | None = None,
+    *,
+    network: str | None = None,
+    backup_existing: bool = True,
+) -> tuple[WalletRuntime, Path | None]:
+    """Create a fresh wallet, backing up existing wallet files first."""
+    wallet_root = _wallet_root(workspace)
+    backup_dir = backup_wallet(workspace) if backup_existing else None
+    runtime = _create_wallet(wallet_root, resolve_wallet_network(network))
+    export_wallet_environment(runtime)
+    os.environ["SPOON_BOT_WALLET_AUTO_CREATED"] = "1"
+    return runtime, backup_dir
+
+
+def _hex(value: Any) -> str:
+    raw = value.hex() if hasattr(value, "hex") else str(value)
+    return raw if raw.startswith("0x") or raw == "" else f"0x{raw}"
+
+
+def _signed_payload(runtime: WalletRuntime, signed: Any) -> dict[str, Any]:
+    return {
+        "address": runtime.address,
+        "signature": _hex(signed.signature),
+        "message_hash": _hex(getattr(signed, "message_hash", "")),
+        "v": int(signed.v),
+        "r": hex(int(signed.r)),
+        "s": hex(int(signed.s)),
+    }
+
+
+def sign_wallet_message(
+    *,
+    message: str | None = None,
+    hexstr: str | None = None,
+    workspace: Path | str | None = None,
+) -> dict[str, Any]:
+    """Sign an EIP-191 compatible text or hex message with the built-in wallet."""
+    supplied = [value is not None and str(value) != "" for value in (message, hexstr)]
+    if sum(supplied) != 1:
+        raise ValueError("Provide exactly one of message or hexstr")
+
+    runtime = ensure_wallet_runtime(workspace)
+    signable = (
+        encode_defunct(hexstr=hexstr)
+        if hexstr is not None
+        else encode_defunct(text=str(message))
+    )
+    signed = Account.sign_message(signable, private_key=runtime.private_key)
+    payload = _signed_payload(runtime, signed)
+    payload["kind"] = "eip191"
+    return payload
+
+
+def sign_wallet_typed_data(
+    *,
+    full_message: dict[str, Any] | None = None,
+    domain_data: dict[str, Any] | None = None,
+    message_types: dict[str, Any] | None = None,
+    message_data: dict[str, Any] | None = None,
+    workspace: Path | str | None = None,
+) -> dict[str, Any]:
+    """Sign EIP-712 typed data with the built-in wallet."""
+    runtime = ensure_wallet_runtime(workspace)
+    if full_message is not None:
+        signed = Account.sign_typed_data(runtime.private_key, full_message=full_message)
+    else:
+        signed = Account.sign_typed_data(
+            runtime.private_key,
+            domain_data=domain_data,
+            message_types=message_types,
+            message_data=message_data,
+        )
+    payload = _signed_payload(runtime, signed)
+    payload["kind"] = "eip712"
+    return payload
+
+
+def sign_wallet_transaction(
+    transaction: dict[str, Any],
+    *,
+    workspace: Path | str | None = None,
+) -> dict[str, Any]:
+    """Sign a prepared EVM transaction without broadcasting it."""
+    if not isinstance(transaction, dict):
+        raise TypeError("transaction must be an object")
+
+    runtime = ensure_wallet_runtime(workspace)
+    tx = dict(transaction)
+    tx.setdefault("from", Account.from_key(runtime.private_key).address)
+    signed = Account.sign_transaction(tx, runtime.private_key)
+    raw_transaction = getattr(signed, "raw_transaction", None) or getattr(signed, "rawTransaction", None)
+    return {
+        "address": runtime.address,
+        "transaction_hash": _hex(signed.hash),
+        "raw_transaction": _hex(raw_transaction),
+    }
 
 
 def wallet_summary(runtime: WalletRuntime) -> dict[str, Any]:

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from spoon_bot.skills.builtin import builtin_skills_root, ensure_builtin_skills
 
 
@@ -11,9 +9,11 @@ def test_ensure_builtin_skills_installs_builtin_skill_set(tmp_path):
     installed = ensure_builtin_skills(workspace)
 
     installed_names = {path.name for path in installed}
-    assert {"wallet", "subagents"}.issubset(installed_names)
+    assert {"wallet", "subagents", "service_expose"}.issubset(installed_names)
     assert (workspace / "skills" / "wallet" / "SKILL.md").exists()
     assert (workspace / "skills" / "subagents" / "SKILL.md").exists()
+    assert (workspace / "skills" / "service_expose" / "SKILL.md").exists()
+    assert (workspace / "skills" / "service_expose" / "scripts" / "service_expose.py").exists()
     assert not (workspace / "skills" / "wallet" / "scripts").exists()
     assert not (workspace / "skills" / "wallet" / "assets").exists()
 
@@ -36,5 +36,7 @@ def test_builtin_skills_root_contains_builtin_skill_set():
     assert root.is_dir()
     assert (root / "wallet" / "SKILL.md").exists()
     assert (root / "subagents" / "SKILL.md").exists()
+    assert (root / "service_expose" / "SKILL.md").exists()
+    assert (root / "service_expose" / "scripts" / "service_expose.py").exists()
     assert not (root / "wallet" / "scripts").exists()
     assert not (root / "wallet" / "assets").exists()

--- a/tests/test_service_expose_skill.py
+++ b/tests/test_service_expose_skill.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+SCRIPT = (
+    PROJECT_ROOT
+    / "spoon_bot"
+    / "skills"
+    / "builtin"
+    / "service_expose"
+    / "scripts"
+    / "service_expose.py"
+)
+
+
+def run_service_script(state_dir: Path, payload: dict) -> dict:
+    env = {"SPOON_BOT_SERVICE_EXPOSE_DIR": str(state_dir)}
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=20,
+        cwd=str(PROJECT_ROOT),
+        env={**dict(os.environ), **env},
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_service_expose_start_status_logs_and_stop(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    command = subprocess.list2cmdline([
+        sys.executable,
+        "-c",
+        "import time; print('service-ready', flush=True); time.sleep(60)",
+    ])
+
+    started = run_service_script(
+        state_dir,
+        {
+            "action": "start",
+            "name": "test-service",
+            "command": command,
+            "cwd": str(PROJECT_ROOT),
+            "port": 18765,
+        },
+    )
+    assert started["success"] is True
+    assert started["service"]["status"] == "running"
+
+    try:
+        status = run_service_script(state_dir, {"action": "status", "name": "test-service"})
+        assert status["success"] is True
+        assert status["service"]["local_url"] == "http://127.0.0.1:18765"
+
+        logs = run_service_script(
+            state_dir,
+            {"action": "logs", "name": "test-service", "tail_chars": 2000},
+        )
+        assert logs["success"] is True
+        assert "service_log" in logs
+    finally:
+        stopped = run_service_script(state_dir, {"action": "stop", "name": "test-service"})
+        assert stopped["success"] is True
+        assert stopped["service"]["status"] == "stopped"
+
+
+def test_service_expose_parses_cloudflare_url_from_tunnel_log(tmp_path: Path) -> None:
+    from importlib.util import module_from_spec, spec_from_file_location
+
+    spec = spec_from_file_location("service_expose_script", SCRIPT)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    log_path = tmp_path / "cloudflared.log"
+    log_path.write_text(
+        "INFO Requesting new quick Tunnel on trycloudflare.com...\n"
+        "INF +--------------------------------------------------------------------------------------------+\n"
+        "INF |  Your quick Tunnel has been created! Visit it at https://sample-demo.trycloudflare.com  |\n",
+        encoding="utf-8",
+    )
+    assert module._parse_public_url(log_path) == "https://sample-demo.trycloudflare.com"

--- a/tests/test_wallet_bootstrap.py
+++ b/tests/test_wallet_bootstrap.py
@@ -223,14 +223,11 @@ def test_web3_tools_default_to_neox(tool_cls, expected_default):
     assert "neox_testnet" in tool_cls.SUPPORTED_CHAINS
 
 
-def test_core_tool_profile_excludes_removed_web3_transaction_tools():
+def test_core_tool_profile_excludes_web3_transaction_tools():
     from spoon_bot.agent.tools.registry import TOOL_PROFILES
 
-    removed_tools = {
-        "balance_check",
-        "transfer",
-        "swap",
-        "contract_call",
-    }
-    assert removed_tools.isdisjoint(TOOL_PROFILES["core"])
+    risky_transaction_tools = {"transfer", "swap", "contract_call"}
+    assert risky_transaction_tools.isdisjoint(TOOL_PROFILES["core"])
+    assert "balance_check" in TOOL_PROFILES["core"]
+    assert "wallet" in TOOL_PROFILES["core"]
     assert "web3" not in TOOL_PROFILES

--- a/tests/test_wallet_tool.py
+++ b/tests/test_wallet_tool.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from spoon_bot.agent.tools.wallet import WalletTool
+from spoon_bot.agent.tools.web3 import ContractCallTool, TransferTool
+from spoon_bot.wallet import ensure_wallet_runtime
+
+
+@pytest.fixture
+def wallet_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("SPOON_BOT_WALLET_PATH", raising=False)
+    for name in (
+        "WALLET_ADDRESS",
+        "PRIVATE_KEY",
+        "WALLET_NETWORK",
+        "WALLET_KEYSTORE_PATH",
+        "WALLET_PASSWORD_FILE",
+        "CHAIN_ID",
+        "AGENT_WALLET_DIR",
+        "SPOON_BOT_WALLET_AUTO_CREATED",
+        "SPOON_BOT_DISABLE_PRIVATE_KEY_EXPORT",
+        "SPOON_BOT_DISABLE_WALLET_REPLACE",
+        "SPOON_BOT_DISABLE_LIVE_TRANSFERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_wallet_tool_status_redacts_private_key(wallet_home):
+    runtime = ensure_wallet_runtime(wallet_home / "workspace")
+    result = await WalletTool().execute(action="status")
+    payload = json.loads(result)
+
+    assert payload["address"] == runtime.address
+    assert payload["private_key_available"] is True
+    assert "private_key" not in payload
+
+
+@pytest.mark.asyncio
+async def test_wallet_tool_create_new_backs_up_existing_wallet(wallet_home):
+    first = ensure_wallet_runtime(wallet_home / "workspace")
+    result = await WalletTool().execute(action="create_new", confirm=True, network="neox_testnet")
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    assert payload["address"] != first.address
+    assert payload["network"] == "neox_testnet"
+    backup_dir = payload["backup_dir"]
+    assert backup_dir
+    assert os.path.exists(os.path.join(backup_dir, "keystore.json"))
+    assert os.path.exists(os.path.join(backup_dir, "pw.txt"))
+    assert os.path.exists(os.path.join(backup_dir, "state.env"))
+
+
+@pytest.mark.asyncio
+async def test_wallet_tool_export_private_key_requires_confirmation(wallet_home, tmp_path):
+    runtime = ensure_wallet_runtime(wallet_home / "workspace")
+
+    denied = await WalletTool().execute(action="export_private_key", reveal_private_key=True)
+    assert "Safety check failed" in denied
+
+    output_path = tmp_path / "exported.key"
+    result = await WalletTool().execute(
+        action="export_private_key",
+        confirm=True,
+        reveal_private_key=True,
+        output_path=str(output_path),
+    )
+    payload = json.loads(result)
+    assert payload["private_key"] == runtime.private_key
+    assert output_path.read_text(encoding="utf-8") == runtime.private_key
+
+
+@pytest.mark.asyncio
+async def test_wallet_create_new_disable_env_blocks_confirm(wallet_home, monkeypatch):
+    ensure_wallet_runtime(wallet_home / "workspace")
+    monkeypatch.setenv("SPOON_BOT_DISABLE_WALLET_REPLACE", "true")
+
+    denied = await WalletTool().execute(action="create_new", confirm=True, network="neox_testnet")
+
+    assert "wallet replacement is disabled by runtime configuration" in denied
+
+
+@pytest.mark.asyncio
+async def test_wallet_export_disable_env_blocks_confirm(wallet_home, monkeypatch):
+    ensure_wallet_runtime(wallet_home / "workspace")
+    monkeypatch.setenv("SPOON_BOT_DISABLE_PRIVATE_KEY_EXPORT", "true")
+
+    denied = await WalletTool().execute(
+        action="export_private_key",
+        confirm=True,
+        reveal_private_key=True,
+    )
+
+    assert "private key export is disabled by runtime configuration" in denied
+
+
+@pytest.mark.asyncio
+async def test_transfer_disable_env_blocks_confirm(wallet_home, monkeypatch):
+    tool = TransferTool()
+    monkeypatch.setenv("SPOON_BOT_DISABLE_LIVE_TRANSFERS", "true")
+
+    denied_without_confirm = await tool.execute(
+        to_address="0x0000000000000000000000000000000000000001",
+        amount="0.1",
+        chain="neox",
+    )
+    assert "Transfer not confirmed" in denied_without_confirm
+
+    denied_with_confirm = await tool.execute(
+        to_address="0x0000000000000000000000000000000000000001",
+        amount="0.1",
+        chain="neox",
+        confirm=True,
+    )
+    assert "live blockchain writes are disabled by runtime configuration" in denied_with_confirm
+    assert "SPOON_BOT_DISABLE_LIVE_TRANSFERS" in denied_with_confirm
+
+
+@pytest.mark.asyncio
+async def test_contract_write_disable_env_blocks_confirm(wallet_home, monkeypatch):
+    tool = ContractCallTool()
+    monkeypatch.setenv("SPOON_BOT_DISABLE_LIVE_TRANSFERS", "true")
+
+    denied = await tool.execute(
+        contract_address="0x0000000000000000000000000000000000000001",
+        method="transfer",
+        args=["0x0000000000000000000000000000000000000002", 1],
+        chain="neox",
+        is_write=True,
+        confirm=True,
+    )
+
+    assert "live blockchain writes are disabled by runtime configuration" in denied
+
+
+@pytest.mark.asyncio
+async def test_wallet_tool_signs_message_and_prepared_transaction(wallet_home):
+    runtime = ensure_wallet_runtime(wallet_home / "workspace")
+    tool = WalletTool()
+
+    signed_message = json.loads(await tool.execute(action="sign_message", message="hello"))
+    assert signed_message["address"] == runtime.address
+    assert signed_message["signature"].startswith("0x")
+    assert signed_message["kind"] == "eip191"
+
+    signed_typed_data = json.loads(
+        await tool.execute(
+            action="sign_typed_data",
+            typed_data={
+                "types": {
+                    "EIP712Domain": [
+                        {"name": "name", "type": "string"},
+                        {"name": "version", "type": "string"},
+                        {"name": "chainId", "type": "uint256"},
+                    ],
+                    "Permit": [
+                        {"name": "owner", "type": "address"},
+                        {"name": "spender", "type": "address"},
+                        {"name": "value", "type": "uint256"},
+                    ],
+                },
+                "primaryType": "Permit",
+                "domain": {"name": "Spoon Test", "version": "1", "chainId": 1},
+                "message": {
+                    "owner": "0x0000000000000000000000000000000000000001",
+                    "spender": "0x0000000000000000000000000000000000000002",
+                    "value": 1,
+                },
+            },
+        )
+    )
+    assert signed_typed_data["address"] == runtime.address
+    assert signed_typed_data["signature"].startswith("0x")
+    assert signed_typed_data["kind"] == "eip712"
+
+    signed_tx = json.loads(
+        await tool.execute(
+            action="sign_transaction",
+            transaction={
+                "to": "0x0000000000000000000000000000000000000001",
+                "value": 0,
+                "nonce": 0,
+                "gas": 21000,
+                "gasPrice": 1,
+                "chainId": 1,
+            },
+        )
+    )
+    assert signed_tx["address"] == runtime.address
+    assert signed_tx["raw_transaction"].startswith("0x")
+    assert signed_tx["transaction_hash"].startswith("0x")


### PR DESCRIPTION
## Summary
- Adds a native built-in wallet tool for status, backup, wallet replacement with backup, private-key export, EIP-191/EIP-712 signing, and prepared transaction signing.
- Extends Web3 tools to use the built-in Neo X wallet for native/ERC20 balance checks, real native/ERC20 transfers, and contract reads/writes with confirmation.
- Adds the built-in `service_expose` skill to keep generated frontend/backend services running in the background and expose them through Cloudflare Quick Tunnels.

## Safety Notes
- `transfer` and contract write calls still require `confirm=true`.
- Live blockchain writes are enabled by default after confirmation; deployments can set `SPOON_BOT_DISABLE_LIVE_TRANSFERS=true` as a runtime kill switch.
- Private-key export and wallet replacement require `confirm=true`, with opt-out disable flags available for deployments.

## Test Plan
- [x] `uv run pytest tests/test_wallet_tool.py tests/test_wallet_bootstrap.py tests/test_service_expose_skill.py tests/test_builtin_skills.py tests/test_skills_scripts.py -q`
- [x] `uv run ruff check spoon_bot/agent/tools/registry.py spoon_bot/wallet.py spoon_bot/agent/tools/wallet.py spoon_bot/agent/tools/web3.py tests/test_wallet_tool.py tests/test_wallet_bootstrap.py tests/test_service_expose_skill.py tests/test_builtin_skills.py`
- [x] WS `/v1/ws` balance prompt called `wallet` + `balance_check` and returned Neo X GAS balance.
- [x] Live Neo X transfer `0.1 GAS` confirmed.
- [x] React Todo service started through `service_expose`; local and Cloudflare URLs returned HTTP 200.