### PR TITLE
Fix streamed content after tool calls

### DIFF
--- a/spoon_bot/agent/loop.py
+++ b/spoon_bot/agent/loop.py
@@ -2117,7 +2117,12 @@ class AgentLoop:
                     or AgentLoop._stream_message_attr(msg, "id", None)
                 if tool_call_id:
                     extras["tool_call_id"] = str(tool_call_id)
-                    extras.update(self._stream_tool_result_metadata_for_trace(tool_call_id))
+                    extras.update(
+                        AgentLoop._stream_tool_result_metadata_for_trace(
+                            self,
+                            tool_call_id,
+                        )
+                    )
                 name = AgentLoop._stream_message_attr(msg, "name", None)
                 if name:
                     extras["name"] = str(name)
@@ -3535,20 +3540,6 @@ class AgentLoop:
             media=media,
             attachments=attachments,
         )
-        _pre_turn_memory_index = self._runtime_memory_snapshot_index()
-
-        direct_clarification = AgentLoop._build_short_request_ambiguity_clarification(
-            self,
-            authoritative_message
-        )
-        if direct_clarification:
-            await self._agent.add_message("user", runtime_message)
-            await self._agent.add_message("assistant", direct_clarification)
-            self._persist_direct_assistant_turn_response(
-                direct_clarification,
-                turn_memory_start_index=_pre_turn_memory_index,
-            )
-            return direct_clarification
 
         original_system_prompt: str | None = None
         original_base_system_prompt: object = _MISSING
@@ -5820,6 +5811,113 @@ class AgentLoop:
                 return final, final[len(prefix):]
 
         return streamed + final, final
+
+    @staticmethod
+    def _normalized_text_with_source_end_offsets(text: str) -> tuple[str, list[int]]:
+        """Normalize whitespace while retaining source end offsets for each char."""
+        normalized_chars: list[str] = []
+        source_end_offsets: list[int] = []
+        in_whitespace = False
+        for index, char in enumerate(text):
+            if char.isspace():
+                if normalized_chars and not in_whitespace:
+                    normalized_chars.append(" ")
+                    source_end_offsets.append(index + 1)
+                    in_whitespace = True
+                continue
+            normalized_chars.append(char)
+            source_end_offsets.append(index + 1)
+            in_whitespace = False
+
+        while normalized_chars and normalized_chars[-1] == " ":
+            normalized_chars.pop()
+            source_end_offsets.pop()
+        return "".join(normalized_chars), source_end_offsets
+
+    @staticmethod
+    def _whitespace_free_text_with_source_end_offsets(text: str) -> tuple[str, list[int]]:
+        """Remove whitespace while retaining source end offsets for each char."""
+        normalized_chars: list[str] = []
+        source_end_offsets: list[int] = []
+        for index, char in enumerate(text):
+            if char.isspace():
+                continue
+            normalized_chars.append(char)
+            source_end_offsets.append(index + 1)
+        return "".join(normalized_chars), source_end_offsets
+
+    @staticmethod
+    def _remove_all_whitespace(text: str | None) -> str:
+        return "".join(str(text or "").split())
+
+    @staticmethod
+    def _looks_like_incomplete_repeated_stream_prefix(
+        incoming_text: str | None,
+        already_emitted_text: str | None,
+    ) -> bool:
+        incoming_normalized = AgentLoop._remove_all_whitespace(incoming_text)
+        emitted_normalized = AgentLoop._remove_all_whitespace(already_emitted_text)
+        return (
+            len(incoming_normalized) >= 12
+            and len(emitted_normalized) >= 24
+            and len(incoming_normalized) < len(emitted_normalized)
+            and emitted_normalized.startswith(incoming_normalized)
+        )
+
+    @staticmethod
+    def _trim_repeated_stream_prefix(
+        incoming_text: str | None,
+        already_emitted_text: str | None,
+    ) -> str:
+        """Remove a repeated prefix that has already been streamed to the user."""
+        incoming = str(incoming_text or "")
+        emitted_normalized = AgentLoop._normalize_comparable_text(already_emitted_text)
+        if not incoming or len(emitted_normalized) < 24:
+            return incoming
+
+        incoming_normalized, incoming_source_ends = (
+            AgentLoop._normalized_text_with_source_end_offsets(incoming)
+        )
+        if not incoming_normalized:
+            return incoming
+
+        matched_len = 0
+        if incoming_normalized.startswith(emitted_normalized):
+            matched_len = len(emitted_normalized)
+        else:
+            min_match_len = 24
+            max_start = max(0, len(emitted_normalized) - 2000)
+            for start in range(max_start, len(emitted_normalized) - min_match_len + 1):
+                suffix = emitted_normalized[start:]
+                if incoming_normalized.startswith(suffix):
+                    matched_len = len(suffix)
+                    break
+
+        if matched_len < 24 or matched_len > len(incoming_source_ends):
+            emitted_compact = AgentLoop._remove_all_whitespace(already_emitted_text)
+            incoming_compact, incoming_compact_source_ends = (
+                AgentLoop._whitespace_free_text_with_source_end_offsets(incoming)
+            )
+            matched_compact_len = 0
+            if incoming_compact.startswith(emitted_compact):
+                matched_compact_len = len(emitted_compact)
+            else:
+                min_match_len = 24
+                max_start = max(0, len(emitted_compact) - 2000)
+                for start in range(max_start, len(emitted_compact) - min_match_len + 1):
+                    suffix = emitted_compact[start:]
+                    if incoming_compact.startswith(suffix):
+                        matched_compact_len = len(suffix)
+                        break
+            if (
+                matched_compact_len < 24
+                or matched_compact_len > len(incoming_compact_source_ends)
+            ):
+                return incoming
+            cut_at = incoming_compact_source_ends[matched_compact_len - 1]
+            return incoming[cut_at:].lstrip()
+        cut_at = incoming_source_ends[matched_len - 1]
+        return incoming[cut_at:].lstrip()
 
     def _looks_like_duplicate_thinking(
         self,
@@ -8110,6 +8208,7 @@ class AgentLoop:
         post_tool_content_events: list[dict[str, Any]] = []
         saw_tool_call = False
         saw_content_after_tool_call = False
+        streamed_content_after_latest_tool_call = False
         pseudo_tool_repair_attempted = False
         stream_completed = False
         stream_cancelled = False
@@ -8118,16 +8217,18 @@ class AgentLoop:
         original_base_system_prompt: object = _MISSING
         tool_output_capture_scope: str | None = None
         capture_manager = None
-        withheld_initial_content = False
         pending_fallback_content_emit = False
         pending_fallback_reason: str | None = None
         pending_fallback_delta = ""
         tool_loop_fallback_active = False
         initial_content_passthrough_started = False
+        post_tool_content_passthrough_started = False
+        emitted_content_text = ""
         stream_error_reason: BaseException | str | None = None
         interrupted_assistant_reply_persisted = False
         execution_ledger: ExecutionLedger | None = None
         ledger_manager = None
+        _pre_turn_memory_index: int | None = None
 
         def _persist_interrupted_stream_reply(reason: str = "task_cancelled") -> None:
             nonlocal interrupted_assistant_reply_persisted
@@ -8163,34 +8264,6 @@ class AgentLoop:
             media=media,
             attachments=attachments,
         )
-        _pre_turn_memory_index = self._runtime_memory_snapshot_index()
-
-        direct_clarification = AgentLoop._build_short_request_ambiguity_clarification(
-            self,
-            authoritative_message
-        )
-        if direct_clarification:
-            await self._agent.add_message("user", runtime_message)
-            await self._agent.add_message("assistant", direct_clarification)
-            full_content = direct_clarification
-            stream_completed = True
-            self._persist_direct_assistant_turn_response(
-                direct_clarification,
-                turn_memory_start_index=_pre_turn_memory_index,
-            )
-            yield {
-                "type": "content",
-                "delta": direct_clarification,
-                "metadata": {"clarification": "short_request_ambiguity"},
-                "source": AgentLoop.get_last_response_source(self),
-            }
-            yield {
-                "type": "done",
-                "delta": "",
-                "metadata": {"content": direct_clarification},
-                "source": AgentLoop.get_last_response_source(self),
-            }
-            return
 
         try:
             capture_manager = capture_tool_outputs()
@@ -9341,6 +9414,11 @@ class AgentLoop:
                             if len(raw_tool_calls) > 1:
                                 chunk = dict(chunk)
                                 chunk["tool_calls"] = raw_tool_calls[:1]
+                        if full_content:
+                            full_content = ""
+                        saw_content_after_tool_call = False
+                        streamed_content_after_latest_tool_call = False
+                        post_tool_content_passthrough_started = False
                         saw_tool_call = True
                         stream_tool_call_count += len(chunk["tool_calls"])
                         last_tool_progress_at = time.monotonic()
@@ -9603,12 +9681,43 @@ class AgentLoop:
                                     continue
                                 full_content += delta
                             else:
-                                post_tool_content_buffer += delta
-                                post_tool_content_events.append(event)
-                                continue
+                                if not post_tool_content_passthrough_started:
+                                    post_tool_content_buffer += delta
+                                    post_tool_content_events.append(event)
+                                    pending_content = AgentLoop._strip_leaked_scratchpad_prefix(
+                                        post_tool_content_buffer
+                                    )
+                                    compact_pending = " ".join(pending_content.strip().split())
+                                    if (
+                                        not compact_pending
+                                        or len(compact_pending) < 12
+                                        or AgentLoop._looks_like_internal_scratchpad_text(
+                                            pending_content
+                                        )
+                                        or AgentLoop._looks_like_incomplete_repeated_stream_prefix(
+                                            pending_content,
+                                            emitted_content_text,
+                                        )
+                                    ):
+                                        continue
+                                    delta = pending_content
+                                    post_tool_content_events = []
+                                    post_tool_content_buffer = ""
+                                    post_tool_content_passthrough_started = True
+                                delta = AgentLoop._trim_repeated_stream_prefix(
+                                    delta,
+                                    emitted_content_text,
+                                )
+                                delta = AgentLoop._mask_user_visible_text(delta)
+                                if not delta:
+                                    continue
+                                saw_content_after_tool_call = True
+                                streamed_content_after_latest_tool_call = True
+                                full_content += delta
                             if buffer_stream_content:
                                 continue
                             event["delta"] = delta
+                            emitted_content_text += delta
                         yield _decorate_stream_event(event)
                         if _stop_if_total_timeout():
                             break
@@ -9781,8 +9890,18 @@ class AgentLoop:
                 post_tool_content_events = []
 
             if pre_tool_scratchpad_buffer and not saw_tool_call:
-                full_content += AgentLoop._mask_user_visible_text(pre_tool_scratchpad_buffer)
-                withheld_initial_content = True
+                for buffered_event in pre_tool_scratchpad_events:
+                    buffered_delta = AgentLoop._mask_user_visible_text(
+                        str(buffered_event.get("delta") or "")
+                    )
+                    if not buffered_delta:
+                        continue
+                    full_content += buffered_delta
+                    emitted_content_text += buffered_delta
+                    yield _decorate_stream_event({
+                        **buffered_event,
+                        "delta": buffered_delta,
+                    })
                 pre_tool_scratchpad_events = []
                 pre_tool_scratchpad_buffer = ""
 
@@ -9824,8 +9943,16 @@ class AgentLoop:
                     if not pending_content.strip():
                         pending_content = ""
                 if pending_content.strip():
+                    pending_content = AgentLoop._trim_repeated_stream_prefix(
+                        pending_content,
+                        emitted_content_text,
+                    )
                     pending_content = AgentLoop._mask_user_visible_text(pending_content)
+                    if not pending_content.strip():
+                        pending_content = ""
+                if pending_content.strip():
                     saw_content_after_tool_call = True
+                    streamed_content_after_latest_tool_call = True
                     full_content += pending_content
                     if not buffer_stream_content:
                         yield _decorate_stream_event({
@@ -9833,6 +9960,7 @@ class AgentLoop:
                             "delta": pending_content,
                             "metadata": {"validated": True},
                         })
+                        emitted_content_text += pending_content
 
             if (
                 tool_loop_fallback_active
@@ -10117,6 +10245,7 @@ class AgentLoop:
                 and skill_contract_has_progress(all_tool_result_events)
                 and not latest_tool_event_has_user_summary_marker(all_tool_result_events)
                 and not latest_tool_event_from_skill_continuation(all_tool_result_events)
+                and not streamed_content_after_latest_tool_call
             ):
                 full_content = await AgentLoop._synthesize_final_answer_from_tool_events(
                     self,
@@ -10135,6 +10264,7 @@ class AgentLoop:
                 full_content.strip()
                 and should_run_skill_contract_check(all_tool_result_events)
                 and latest_tool_event_has_user_summary_marker(all_tool_result_events)
+                and not streamed_content_after_latest_tool_call
             ):
                 full_content = await AgentLoop._synthesize_final_answer_from_tool_events(
                     self,
@@ -10262,6 +10392,7 @@ class AgentLoop:
                     bool(request_execution_hints.get("current_session_fact_check_required"))
                     or bool(request_execution_hints.get("session_evidence_synthesis_preferred"))
                 )
+                and not streamed_content_after_latest_tool_call
             ):
                 synthesis_events = self._session_evidence_synthesis_events(
                     all_tool_result_events,
@@ -10285,6 +10416,7 @@ class AgentLoop:
                 all_tool_result_events
                 and should_run_skill_contract_check(all_tool_result_events)
                 and not skill_contract_has_progress(all_tool_result_events)
+                and not streamed_content_after_latest_tool_call
             ):
                 full_content = await AgentLoop._synthesize_final_answer_from_tool_events(
                     self,
@@ -10366,10 +10498,19 @@ class AgentLoop:
                 full_content,
                 turn_memory_start_index=_pre_turn_memory_index,
             )
+            final_content_changed = (
+                self._normalize_comparable_text(final_content)
+                != self._normalize_comparable_text(pre_finalize_full_content)
+            )
             if (
                 (
-                    buffer_stream_content
-                    or withheld_initial_content
+                    (
+                        buffer_stream_content
+                        and (
+                            not emitted_content_text.strip()
+                            or final_content_changed
+                        )
+                    )
                     or pending_fallback_content_emit
                 )
                 and final_content
@@ -10381,18 +10522,24 @@ class AgentLoop:
                     == self._normalize_comparable_text(pre_finalize_full_content)
                 ):
                     emit_delta = pending_fallback_delta or final_content
+                trimmed_emit_delta = AgentLoop._trim_repeated_stream_prefix(
+                    emit_delta,
+                    emitted_content_text,
+                )
+                trimmed_emit_delta = AgentLoop._mask_user_visible_text(trimmed_emit_delta)
+                emit_delta = trimmed_emit_delta
                 emit_metadata = {
                     "buffered": bool(buffer_stream_content),
-                    "withheld_initial_content": bool(withheld_initial_content),
                     "validated": True,
                 }
                 if pending_fallback_reason:
                     emit_metadata["fallback"] = pending_fallback_reason
-                yield _decorate_stream_event({
-                    "type": "content",
-                    "delta": emit_delta,
-                    "metadata": emit_metadata,
-                })
+                if emit_delta.strip():
+                    yield _decorate_stream_event({
+                        "type": "content",
+                        "delta": emit_delta,
+                        "metadata": emit_metadata,
+                    })
             full_content = final_content
 
             # Emit done
@@ -10592,23 +10739,10 @@ class AgentLoop:
             media=media,
             attachments=attachments,
         )
-        _pre_turn_memory_index = self._runtime_memory_snapshot_index()
-
-        direct_clarification = AgentLoop._build_short_request_ambiguity_clarification(
-            self,
-            authoritative_message
-        )
-        if direct_clarification:
-            await self._agent.add_message("user", runtime_message)
-            await self._agent.add_message("assistant", direct_clarification)
-            self._persist_direct_assistant_turn_response(
-                direct_clarification,
-                turn_memory_start_index=_pre_turn_memory_index,
-            )
-            return direct_clarification, ""
 
         execution_ledger: ExecutionLedger | None = None
         ledger_manager = None
+        _pre_turn_memory_index: int | None = None
 
         try:
             retry_runner = AgentLoop._resolve_retry_runner(self)
@@ -11432,201 +11566,6 @@ class AgentLoop:
                 )
         return None
 
-    @staticmethod
-    def _token_identifier_variants(
-        text: str,
-        *,
-        combine_adjacent: bool = True,
-    ) -> set[str]:
-        """Return compact identifier tokens from free text without routing intent."""
-        tokens = [
-            token
-            for token in ordered_request_matching_tokens(str(text or ""))
-            if len(token) >= 3
-        ]
-        variants: set[str] = set(tokens)
-        if not combine_adjacent:
-            return variants
-        for index in range(len(tokens) - 1):
-            left = tokens[index]
-            right = tokens[index + 1]
-            if left.isascii() and right.isascii():
-                variants.add(f"{left}{right}")
-        if len(tokens) >= 3:
-            for index in range(len(tokens) - 2):
-                first = tokens[index]
-                second = tokens[index + 1]
-                third = tokens[index + 2]
-                if first.isascii() and second.isascii() and third.isascii():
-                    variants.add(f"{first}{second}{third}")
-        return variants
-
-    def _recent_skill_ambiguity_candidates(self) -> list[dict[str, Any]]:
-        """Return recent skill-backed workflows as generic clarification candidates."""
-        recent = getattr(self, "_recent_invoked_skill_contexts", [])
-        if not isinstance(recent, list) or len(recent) < 2:
-            return []
-
-        catalog_by_name: dict[str, dict[str, Any]] = {}
-        for item in self._collect_request_skill_candidates():
-            name = str(item.get("name") or "").strip()
-            if name:
-                catalog_by_name[name] = item
-
-        candidates: list[dict[str, Any]] = []
-        seen: set[str] = set()
-        for item in recent:
-            if not isinstance(item, dict):
-                continue
-            name = str(item.get("name") or "").strip()
-            if not name or name in seen:
-                continue
-            seen.add(name)
-            catalog = catalog_by_name.get(name, {})
-            identifier_text = " ".join(
-                str(value or "")
-                for value in (
-                    name,
-                    item.get("location"),
-                    item.get("workspace_relative_path"),
-                    catalog.get("description"),
-                    catalog.get("when_to_use"),
-                )
-                if str(value or "").strip()
-            )
-            candidates.append({
-                "name": name,
-                "location": str(item.get("location") or ""),
-                "tokens": self._token_identifier_variants(identifier_text),
-            })
-        return candidates if len(candidates) >= 2 else []
-
-    def _short_request_ambiguity_candidates(self, message: str) -> list[dict[str, Any]]:
-        """Return recent workflow candidates when a short request selects none.
-
-        This uses only recent skill metadata and request tokens. It does not
-        route by product names, CLI commands, or domain-specific phrases.
-        """
-        text = str(message or "").strip()
-        if not text:
-            return []
-        if len([char for char in text if not char.isspace()]) > 36:
-            return []
-        if len(ordered_request_matching_tokens(text)) > 5:
-            return []
-        if extract_urls_from_text(text):
-            return []
-        if extract_exact_shell_commands_from_request(text):
-            return []
-
-        candidates = self._recent_skill_ambiguity_candidates()
-        if len(candidates) < 2:
-            return []
-
-        request_tokens = self._token_identifier_variants(text, combine_adjacent=False)
-        if not request_tokens:
-            return []
-
-        token_owners: dict[str, set[str]] = {}
-        for candidate in candidates:
-            name = candidate["name"]
-            for token in candidate.get("tokens") or set():
-                token_owners.setdefault(token, set()).add(name)
-
-        if not any(token in token_owners for token in request_tokens):
-            visible_chars = len([char for char in text if not char.isspace()])
-            if visible_chars > 4:
-                return []
-
-        uniquely_selected: set[str] = set()
-        for token in request_tokens:
-            owners = token_owners.get(token)
-            if owners and len(owners) == 1:
-                uniquely_selected.update(owners)
-        if uniquely_selected:
-            return []
-
-        return candidates
-
-    def _format_short_request_ambiguity_context(self, message: str) -> str:
-        """Warn the model when a short request does not select a recent workflow.
-
-        This is deliberately context only. It does not route to a skill, and it
-        does not classify domain terms. The model may still answer read-only
-        questions, but it must not pick one recent state-changing workflow
-        solely from recency.
-        """
-        candidates = self._short_request_ambiguity_candidates(message)
-        if len(candidates) < 2:
-            return ""
-
-        lines = [
-            "[SHORT REQUEST AMBIGUITY BOUNDARY]:",
-            (
-                "The newest request is short and does not uniquely identify one "
-                "of the recent skill-backed workflows below."
-            ),
-            (
-                "If satisfying it would require a state-changing, paid, remote, "
-                "or externally visible action from one of these workflows, ask "
-                "one concise clarification before calling side-effecting tools. "
-                "Do not choose a workflow from recency alone. Read-only status "
-                "questions may still be verified with tools."
-            ),
-            "Recent workflow candidates:",
-        ]
-        for candidate in candidates[:6]:
-            location = str(candidate.get("location") or "").strip()
-            if location:
-                lines.append(f"- {candidate['name']} ({location})")
-            else:
-                lines.append(f"- {candidate['name']}")
-        lines.append("")
-        return "\n".join(lines)
-
-    @staticmethod
-    def _message_prefers_cjk_response(message: str) -> bool:
-        for char in str(message or ""):
-            if "\u3400" <= char <= "\u9fff":
-                return True
-        return False
-
-    def _build_short_request_ambiguity_clarification(self, message: str) -> str:
-        candidates = self._short_request_ambiguity_candidates(message)
-        if len(candidates) < 2:
-            return ""
-        names: list[str] = []
-        seen: set[str] = set()
-        for candidate in candidates[:6]:
-            name = str(candidate.get("name") or "").strip()
-            if not name or name in seen:
-                continue
-            seen.add(name)
-            names.append(name)
-        if len(names) < 2:
-            return ""
-        if self._message_prefers_cjk_response(message):
-            return "我需要先确认要使用哪个 workflow：" + "、".join(names) + "？"
-        return "Which workflow should I use: " + ", ".join(names) + "?"
-
-    def _persist_direct_assistant_turn_response(
-        self,
-        content: str,
-        *,
-        turn_memory_start_index: int,
-    ) -> None:
-        AgentLoop._mark_latest_user_turn_state(self, _TURN_STATE_COMPLETED)
-        try:
-            self._persist_turn_tool_trace(turn_memory_start_index)
-        except Exception:
-            pass
-        self._session.add_message(
-            "assistant",
-            content,
-            **AgentLoop._assistant_session_save_kwargs(content),
-        )
-        AgentLoop._persist_session_if_possible(self)
-
     def _build_request_context_sections(self, message: str) -> str:
         """Build reusable request-derived context without changing user intent."""
         hint_source = self._request_hint_source_text(message)
@@ -11635,7 +11574,6 @@ class AgentLoop:
             _BOUNDED_CONTINUATION_BOUNDARY
             if request_is_bare_continuation(message)
             else "",
-            self._format_short_request_ambiguity_context(message),
             format_explicit_request_urls_context(hint_source),
             format_explicit_request_values_context(hint_source),
             self._format_local_skill_execution_context(hints),

--- a/spoon_bot/agent/session_compact.py
+++ b/spoon_bot/agent/session_compact.py
@@ -266,6 +266,43 @@ def _interrupted_user_evidence_lines(
     return evidence[-max_items:]
 
 
+def _interrupted_turn_evidence_lines(
+    raw_messages: Any,
+    current_message: str,
+    *,
+    max_items: int = 10,
+) -> list[str]:
+    """Keep persisted evidence from aborted turns as historical context."""
+    messages = _messages_before_current(raw_messages, current_message)
+
+    evidence: list[str] = []
+    seen: set[str] = set()
+    include_current_turn = False
+    for message in messages:
+        role = str(message.get("role") or "").lower()
+        if role == "user":
+            state = str(message.get("turn_state") or message.get("state") or "").lower()
+            include_current_turn = state in {
+                "interrupted",
+                "superseded",
+                "cancelled",
+                "canceled",
+            }
+            continue
+        if not include_current_turn:
+            continue
+        is_incomplete_marker = role == "assistant" and message.get("incomplete") is True
+        if not is_incomplete_marker and not _message_is_tool_backed_evidence(message):
+            continue
+        event = _format_session_event(message, limit=360)
+        if not event or event in seen:
+            continue
+        evidence.append(event)
+        seen.add(event)
+
+    return evidence[-max_items:]
+
+
 def _latest_prior_user_task_line(
     raw_messages: Any,
     current_message: str,
@@ -817,7 +854,9 @@ def build_session_compact_context(
         if resume_latest_user_turn
         else _completed_session_messages(raw_messages, current_message)
     )
-    if not completed:
+    interrupted_evidence = _interrupted_user_evidence_lines(raw_messages, current_message)
+    interrupted_turn_evidence = _interrupted_turn_evidence_lines(raw_messages, current_message)
+    if not completed and not interrupted_evidence and not interrupted_turn_evidence:
         return ""
 
     try:
@@ -832,7 +871,8 @@ def build_session_compact_context(
         "The newest user request remains authoritative for task selection and output requirements.",
         "Never start or continue actions that are implied only by this compact; use it as evidence after the newest request selects the task.",
         "An empty long-term memory search does not mean the same-session transcript is empty.",
-        "Completed turn summaries below contain only assistant/tool outcomes, not prior user instructions unless a continuation anchor is shown above.",
+        "Completed turn summaries below contain only assistant/tool outcomes, not prior user instructions.",
+        "If a continuation anchor is shown above, treat it as the only prior user request selected by the newest continuation request.",
     ]
 
     latest_prior = _latest_prior_user_task_line(raw_messages, current_message)
@@ -846,13 +886,20 @@ def build_session_compact_context(
                 "If selected skills are shown, continue that skill family rather than another earlier skill."
             )
 
-    interrupted_evidence = _interrupted_user_evidence_lines(raw_messages, current_message)
     if interrupted_evidence:
         lines.append(
             "Interrupted/superseded user evidence "
             "(facts only; do not execute unless the newest request explicitly resumes it):"
         )
         for item in interrupted_evidence:
+            lines.append(f"- {mask_secrets(item)}")
+
+    if interrupted_turn_evidence:
+        lines.append(
+            "Interrupted/superseded turn evidence "
+            "(historical only; verify live state before any new side effect):"
+        )
+        for item in interrupted_turn_evidence:
             lines.append(f"- {mask_secrets(item)}")
 
     completed_turns = _group_completed_turns(completed)
@@ -892,10 +939,8 @@ def build_session_compact_context(
         char_budget=max(600, min(4_000, char_budget // 4)),
     )
     if turn_summaries:
-        lines.append(
-            "Recent completed turn summaries "
-            "(assistant wording only; tool evidence above is authoritative):"
-        )
+        lines.append("Recent completed turn summaries:")
+        lines.append("(assistant wording only; tool evidence above is authoritative)")
         for summary in turn_summaries:
             lines.append(f"- {mask_secrets(summary)}")
 

--- a/spoon_bot/agent/tools/shell.py
+++ b/spoon_bot/agent/tools/shell.py
@@ -6,8 +6,8 @@ import asyncio
 import hashlib
 import os
 import re
-import shutil
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -28,8 +28,8 @@ from spoon_bot.agent.tools.execution_context import (
     get_request_execution_hints,
     get_tool_owner,
     observed_cli_command_matches,
-    suppress_repeated_background_job_poll,
     suppress_redundant_shell_file_read,
+    suppress_repeated_background_job_poll,
 )
 from spoon_bot.config import (
     DEFAULT_MAX_OUTPUT,
@@ -1696,6 +1696,16 @@ class ShellTool(Tool):
         normalized = str(command or "").replace("\\", "/")
         return "~/.agent-wallet" in normalized or "/.agent-wallet" in normalized
 
+    @staticmethod
+    def _wallet_compat_home(wallet_root: Path) -> Path:
+        base = Path(
+            os.environ.get("SPOON_BOT_WALLET_COMPAT_HOME_ROOT")
+            or os.environ.get("TMPDIR")
+            or "/tmp"
+        ).expanduser()
+        digest = hashlib.sha256(str(wallet_root).encode("utf-8")).hexdigest()[:16]
+        return (base / "spoon-bot-wallet-homes" / digest).resolve(strict=False)
+
     def _align_wallet_home_for_command(
         self,
         env: dict[str, str],
@@ -1747,8 +1757,12 @@ class ShellTool(Tool):
                 wallet_root.mkdir(parents=True, exist_ok=True)
             if not wallet_root.is_dir():
                 return
-            compat_home = wallet_root.parent / f".home-{wallet_root.name}"
+            compat_home = self._wallet_compat_home(wallet_root)
             compat_home.mkdir(parents=True, exist_ok=True)
+            try:
+                compat_home.chmod(0o700)
+            except OSError:
+                pass
             compat_wallet = compat_home / ".agent-wallet"
             if compat_wallet.is_symlink():
                 compat_wallet.unlink()

--- a/spoon_bot/gateway/api/v1/workspace.py
+++ b/spoon_bot/gateway/api/v1/workspace.py
@@ -11,6 +11,10 @@ from pydantic import BaseModel
 from spoon_bot.gateway.app import get_agent
 from spoon_bot.gateway.auth.dependencies import CurrentUser
 from spoon_bot.gateway.models.responses import APIResponse, MetaInfo
+from spoon_bot.gateway.workspace_visibility import (
+    is_workspace_wallet_runtime_path,
+    should_hide_workspace_path,
+)
 
 router = APIRouter()
 
@@ -31,9 +35,12 @@ def _build_tree(
     max_depth: int = 5,
     current_depth: int = 0,
     include_hidden: bool = False,
+    workspace_root: Path | None = None,
 ) -> list[TreeNode]:
     """Recursively build a directory tree, respecting depth and hidden-file filters."""
     if current_depth >= max_depth or not root.is_dir():
+        return []
+    if is_workspace_wallet_runtime_path(root, workspace_root=workspace_root):
         return []
 
     nodes: list[TreeNode] = []
@@ -43,9 +50,11 @@ def _build_tree(
         return []
 
     for entry in entries:
-        if not include_hidden and entry.name.startswith("."):
-            continue
-        if entry.name in ("__pycache__", "node_modules", ".git"):
+        if should_hide_workspace_path(
+            entry,
+            workspace_root=workspace_root,
+            include_hidden=include_hidden,
+        ):
             continue
 
         rel = str(entry.relative_to(root.parent)).replace("\\", "/")
@@ -56,6 +65,7 @@ def _build_tree(
                 max_depth=max_depth,
                 current_depth=current_depth + 1,
                 include_hidden=include_hidden,
+                workspace_root=workspace_root,
             )
             nodes.append(TreeNode(
                 name=entry.name,
@@ -104,7 +114,12 @@ async def get_workspace_tree(
             detail={"code": "PATH_NOT_FOUND", "message": f"Path not found: {path}"},
         )
 
-    tree = _build_tree(target, max_depth=depth, include_hidden=include_hidden)
+    tree = _build_tree(
+        target,
+        max_depth=depth,
+        include_hidden=include_hidden,
+        workspace_root=workspace,
+    )
 
     return APIResponse(
         success=True,

--- a/spoon_bot/gateway/websocket/handler.py
+++ b/spoon_bot/gateway/websocket/handler.py
@@ -899,21 +899,22 @@ class WebSocketHandler:
                                         if isinstance(metadata, dict)
                                         else ""
                                     )
-                                    if not full_content and isinstance(done_content, str) and done_content:
+                                    if isinstance(done_content, str) and done_content:
+                                        if not full_content:
+                                            await manager.send_message(
+                                                self.connection_id,
+                                                WSEvent(event=ServerEvent.AGENT_STREAM_CHUNK.value, data={
+                                                    "task_id": task_id,
+                                                    "request_id": request_id,
+                                                    "session_key": session_key,
+                                                    "type": "content",
+                                                    "delta": done_content,
+                                                    "metadata": {"fallback": "done_metadata_content"},
+                                                    "trace_id": trace_id,
+                                                    "source": source,
+                                                }),
+                                            )
                                         full_content = done_content
-                                        await manager.send_message(
-                                            self.connection_id,
-                                            WSEvent(event=ServerEvent.AGENT_STREAM_CHUNK.value, data={
-                                                "task_id": task_id,
-                                                "request_id": request_id,
-                                                "session_key": session_key,
-                                                "type": "content",
-                                                "delta": done_content,
-                                                "metadata": {"fallback": "done_metadata_content"},
-                                                "trace_id": trace_id,
-                                                "source": source,
-                                            }),
-                                        )
                                     if not str(full_content or "").strip():
                                         full_content = _fallback_empty_agent_response(
                                             had_error=had_error,
@@ -1727,7 +1728,12 @@ class WebSocketHandler:
         if not target.exists():
             raise ValueError(f"Path not found: {sub_path}")
 
-        nodes = _build_tree(target, max_depth=depth, include_hidden=include_hidden)
+        nodes = _build_tree(
+            target,
+            max_depth=depth,
+            include_hidden=include_hidden,
+            workspace_root=workspace,
+        )
         return {"tree": [n.model_dump() for n in nodes]}
 
     async def _handle_fs_list(self, params: dict[str, Any]) -> dict[str, Any]:

--- a/spoon_bot/gateway/websocket/workspace_fs.py
+++ b/spoon_bot/gateway/websocket/workspace_fs.py
@@ -9,6 +9,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, AsyncIterator
 
+from spoon_bot.gateway.workspace_visibility import (
+    is_workspace_wallet_runtime_path,
+    should_hide_workspace_path,
+)
 
 SANDBOX_WORKSPACE_ROOT = "/workspace"
 
@@ -156,7 +160,18 @@ class WorkspaceFSService:
     def _list_sync(self, path: str, *, cursor: str | None, limit: int) -> dict[str, Any]:
         directory, _ = self._resolve_existing_path(path, expect_directory=True)
         effective_limit = max(1, min(int(limit), 1000))
-        entries = [self._build_entry(entry) for entry in directory.iterdir()]
+        if is_workspace_wallet_runtime_path(directory, workspace_root=self._workspace_root):
+            return {"entries": [], "has_more": False}
+
+        entries = [
+            self._build_entry(entry)
+            for entry in directory.iterdir()
+            if not should_hide_workspace_path(
+                entry,
+                workspace_root=self._workspace_root,
+                include_hidden=True,
+            )
+        ]
         entries.sort(key=lambda item: (item["type"] != "dir", item["name"].lower()))
 
         start = 0

--- a/spoon_bot/gateway/websocket/workspace_watch.py
+++ b/spoon_bot/gateway/websocket/workspace_watch.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 
 from loguru import logger
 
+from spoon_bot.gateway.workspace_visibility import is_workspace_wallet_runtime_path
 
 WorkspaceWatchCallback = Callable[[dict[str, Any]], Awaitable[None]]
 SANDBOX_WORKSPACE_ROOT = "/workspace"
@@ -172,6 +173,8 @@ class WorkspaceWatchService:
     def _snapshot_target(self, target: Path, *, recursive: bool) -> dict[str, dict[str, Any]]:
         if not target.exists():
             return {}
+        if is_workspace_wallet_runtime_path(target, workspace_root=self._workspace_root):
+            return {}
 
         if target.is_file():
             try:
@@ -200,6 +203,8 @@ class WorkspaceWatchService:
             try:
                 relative = entry.relative_to(self._workspace_root)
             except ValueError:
+                continue
+            if is_workspace_wallet_runtime_path(entry, workspace_root=self._workspace_root):
                 continue
             try:
                 entries[self._sandbox_path_for(relative)] = self._entry_snapshot(entry)

--- a/spoon_bot/gateway/workspace_visibility.py
+++ b/spoon_bot/gateway/workspace_visibility.py
@@ -1,0 +1,63 @@
+"""Shared visibility policy for workspace file listings."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+SYSTEM_ENTRY_NAMES = frozenset({"__pycache__", "node_modules", ".git"})
+_DEFAULT_WALLET_ROOT_NAME = ".agent-wallet"
+_WALLET_ENV_VARS = ("SPOON_BOT_WALLET_PATH", "AGENT_WALLET_DIR")
+
+
+def configured_wallet_runtime_names() -> set[str]:
+    """Return wallet runtime directory names that should stay out of file views."""
+    names = {
+        _DEFAULT_WALLET_ROOT_NAME,
+        f".home-{_DEFAULT_WALLET_ROOT_NAME}",
+        ".home-agent-wallet",
+    }
+    for env_name in _WALLET_ENV_VARS:
+        raw = os.environ.get(env_name, "").strip()
+        if not raw:
+            continue
+        wallet_name = Path(raw).expanduser().name
+        if not wallet_name:
+            continue
+        names.add(wallet_name)
+        names.add(f".home-{wallet_name}")
+    return names
+
+
+def is_workspace_wallet_runtime_path(
+    path: Path,
+    *,
+    workspace_root: Path | None = None,
+) -> bool:
+    """Return whether *path* is the wallet runtime or one of its descendants."""
+    try:
+        candidate = path.resolve(strict=False)
+        if workspace_root is not None:
+            relative = candidate.relative_to(workspace_root.resolve(strict=False))
+            parts = relative.parts or (candidate.name,)
+        else:
+            parts = candidate.parts
+    except (OSError, RuntimeError, ValueError):
+        parts = path.parts
+
+    runtime_names = configured_wallet_runtime_names()
+    return any(part in runtime_names for part in parts)
+
+
+def should_hide_workspace_path(
+    path: Path,
+    *,
+    workspace_root: Path | None = None,
+    include_hidden: bool = False,
+) -> bool:
+    """Return whether *path* should be omitted from user-visible workspace views."""
+    if is_workspace_wallet_runtime_path(path, workspace_root=workspace_root):
+        return True
+    if path.name in SYSTEM_ENTRY_NAMES:
+        return True
+    return not include_hidden and path.name.startswith(".")

--- a/tests/test_gateway_ws_bugs.py
+++ b/tests/test_gateway_ws_bugs.py
@@ -52,6 +52,7 @@ from spoon_bot.gateway.websocket.handler import (
     _CONCURRENT_REQUEST_LIMIT,
     _resolve_workspace_file,
 )
+from spoon_bot.runtime.session_registry import SessionRuntimeRegistry
 
 
 # ---------------------------------------------------------------------------
@@ -59,7 +60,7 @@ from spoon_bot.gateway.websocket.handler import (
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_agent():
+def _make_mock_agent(session_key: str = "default", sessions=None):
     """Create a mock agent that behaves enough for gateway tests."""
     agent = AsyncMock()
     agent.model = "test-model"
@@ -68,22 +69,25 @@ def _make_mock_agent():
     agent.tools.list_tools.return_value = ["web_search"]
     agent.tools.__len__ = lambda self: 1
     agent.skills = []
-    agent.session_key = "default"
+    agent.session_key = session_key
 
     # Session manager mock
-    session = MagicMock()
-    session.session_key = "default"
-    session.messages = []
-    def _session_add_message(role, content, **kwargs):
-        session.messages.append({"role": role, "content": content, **kwargs})
-    session.add_message = MagicMock(side_effect=_session_add_message)
-    session.clear = MagicMock()
+    if sessions is None:
+        session = MagicMock()
+        session.session_key = session_key
+        session.messages = []
+        def _session_add_message(role, content, **kwargs):
+            session.messages.append({"role": role, "content": content, **kwargs})
+        session.add_message = MagicMock(side_effect=_session_add_message)
+        session.clear = MagicMock()
 
-    sessions = MagicMock()
-    sessions.list_sessions.return_value = [session]
-    sessions.get.return_value = session
-    sessions.get_or_create.return_value = session
-    sessions.save = MagicMock()
+        sessions = MagicMock()
+        sessions.list_sessions.return_value = [session]
+        sessions.get.return_value = session
+        sessions.get_or_create.return_value = session
+        sessions.save = MagicMock()
+    else:
+        session = sessions.get_or_create(session_key)
 
     agent.sessions = sessions
     agent._session = session
@@ -99,7 +103,26 @@ def _make_mock_agent():
         yield {"type": "done", "delta": "", "metadata": {}}
 
     agent.stream = _fake_stream
+    agent.build_creation_kwargs = MagicMock(return_value={})
     return agent
+
+
+def _install_mock_session_registry(agent):
+    async def _factory(**kwargs):
+        clone = _make_mock_agent(
+            kwargs.get("session_key", "default"),
+            sessions=kwargs.get("session_manager"),
+        )
+        clone.process = agent.process
+        clone.process_with_thinking = agent.process_with_thinking
+        clone.stream = agent.stream
+        return clone
+
+    app_module._session_runtime_registry = SessionRuntimeRegistry(
+        agent,
+        agent_factory=_factory,
+        creation_kwargs={"test": True},
+    )
 
 
 def _auth_headers(
@@ -150,6 +173,7 @@ def app(config):
     application = create_app(config)
     agent = _make_mock_agent()
     set_agent(agent)
+    _install_mock_session_registry(agent)
 
     # Initialize ConnectionManager (normally done in lifespan)
     app_module._connection_manager = ConnectionManager()
@@ -165,6 +189,7 @@ def app_auth(auth_config):
     application = create_app(auth_config)
     agent = _make_mock_agent()
     set_agent(agent)
+    _install_mock_session_registry(agent)
 
     # Initialize ConnectionManager
     app_module._connection_manager = ConnectionManager()
@@ -316,20 +341,20 @@ class TestSessionSwitchValidation:
             resp = ws.receive_json()
             assert resp["type"] == "error"
 
-    def test_valid_string_session_key_accepted(self, client):
-        """session.switch with valid string session_key succeeds."""
+    def test_default_string_session_key_accepted(self, client):
+        """session.switch with valid default session_key succeeds."""
         with client.websocket_connect("/v1/ws") as ws:
             ws.receive_json()
             ws.send_json({
                 "type": "request",
                 "id": "sw4",
                 "method": "session.switch",
-                "params": {"session_key": "my-session"},
+                "params": {"session_key": "default"},
             })
             resp = ws.receive_json()
             assert resp["type"] == "response"
             assert resp["result"]["switched"] is True
-            assert resp["result"]["session_key"] == "my-session"
+            assert resp["result"]["session_key"] == "default"
 
 
 # ===================================================================
@@ -535,8 +560,8 @@ class TestJWTSessionValidation:
 class TestWSSessionBinding:
     """#11: WS chat.send should bind runtime session to requested session_key."""
 
-    def test_chat_switches_agent_session(self, client):
-        """chat.send with session_key should call _switch_agent_session."""
+    def test_chat_uses_default_agent_session(self, client):
+        """chat.send with default session_key should keep the runtime session bound."""
         with client.websocket_connect("/v1/ws") as ws:
             ws.receive_json()  # connection.established
 
@@ -546,7 +571,7 @@ class TestWSSessionBinding:
                 "method": "chat.send",
                 "params": {
                     "message": "hello",
-                    "session_key": "custom-session",
+                    "session_key": "default",
                     "stream": False,
                 },
             })
@@ -562,7 +587,7 @@ class TestWSSessionBinding:
             # The response should echo the session_key
             response = next((m for m in msgs if m.get("type") == "response"), None)
             assert response is not None
-            assert response["result"]["session_key"] == "custom-session"
+            assert response["result"]["session_key"] == "default"
 
 
 # ===================================================================
@@ -992,7 +1017,10 @@ class TestRESTSessionRouting:
         agent = app_module._agent
         assert agent is not None
 
+        created_keys: list[str] = []
+
         def _session_factory(key: str):
+            created_keys.append(key)
             session = MagicMock()
             session.session_key = key
             session.messages = []
@@ -1007,7 +1035,9 @@ class TestRESTSessionRouting:
             headers=_auth_headers("routing-user", session_key="token-session"),
         )
         assert resp.status_code == 200
-        assert agent.session_key == "explicit-session"
+        assert "explicit-session" in created_keys
+        assert "token-session" not in created_keys
+        assert agent.session_key == "default"
 
 
 class TestRESTConcurrency:
@@ -1018,6 +1048,7 @@ class TestRESTConcurrency:
         """Concurrent /chat requests should not produce non-IDLE 500 errors."""
         agent = _make_mock_agent()
         set_agent(agent)
+        _install_mock_session_registry(agent)
 
         busy = False
 
@@ -1601,6 +1632,53 @@ class TestWSStreamingContent:
             ]
             assert len(done_events) >= 1
             assert done_events[0]["data"]["content"] == "fallback done content"
+
+    def test_stream_done_metadata_replaces_accumulated_content(self, client):
+        """done.metadata.content is the authoritative final response body."""
+        agent = app_module._agent
+        assert agent is not None
+
+        async def _stream_with_final_metadata(**kwargs):
+            yield {"type": "content", "delta": "starting task", "metadata": {}}
+            yield {"type": "content", "delta": " continuing", "metadata": {}}
+            yield {
+                "type": "done",
+                "delta": "",
+                "metadata": {"content": "final concise result"},
+            }
+
+        agent.stream = _stream_with_final_metadata
+
+        with client.websocket_connect("/v1/ws") as ws:
+            ws.receive_json()  # connection.established
+
+            ws.send_json({
+                "type": "request",
+                "id": "stream_done_final_metadata",
+                "method": "chat.send",
+                "params": {
+                    "message": "hello stream",
+                    "stream": True,
+                },
+            })
+
+            events = []
+            for _ in range(20):
+                msg = ws.receive_json()
+                events.append(msg)
+                if msg.get("type") == "response":
+                    break
+
+            response = next((e for e in events if e.get("type") == "response"), None)
+            assert response is not None
+            assert response["result"]["content"] == "final concise result"
+
+            done_events = [
+                e for e in events
+                if e.get("type") == "event" and e.get("event") == "agent.stream.done"
+            ]
+            assert len(done_events) >= 1
+            assert done_events[0]["data"]["content"] == "final concise result"
 
     def test_stream_complete_event_keeps_full_response(self, client):
         """agent.complete should carry the full response body, not a preview slice."""

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -764,11 +764,11 @@ class _FailingToolTraceRuntimeAgent(_PromptCapturingRuntimeAgent):
                 content="",
                 tool_calls=[
                     {
-                        "id": "call_joker",
+                        "id": "call_task",
                         "type": "function",
                         "function": {
                             "name": "shell",
-                            "arguments": '{"cmd": "node skills/joker-game-agent/cli/index.js challenge-answer"}',
+                            "arguments": '{"cmd": "python scripts/task_runner.py verify"}',
                         },
                     }
                 ],
@@ -779,11 +779,11 @@ class _FailingToolTraceRuntimeAgent(_PromptCapturingRuntimeAgent):
                 role="tool",
                 content=(
                     "Observed output of cmd shell execution: "
-                    "job_id=sh_2398786724 command=node skills/joker-game-agent/cli/index.js "
-                    "challenge-answer status=running"
+                    "job_id=sh_2398786724 command=python scripts/task_runner.py "
+                    "verify status=running"
                 ),
                 name="shell",
-                tool_call_id="call_joker",
+                tool_call_id="call_task",
             )
         )
         raise RuntimeError("openrouter network error")
@@ -809,6 +809,119 @@ class _ChunkedRuntimeAgent:
             await self.output_queue.put({"content": chunk})
             await asyncio.sleep(0)
         return type("RunResult", (), {"content": "".join(self._chunks)})()
+
+
+class _ToolThenChunkedRuntimeAgent:
+    """Runtime agent that emits a tool event sequence before final content chunks."""
+
+    def __init__(self, chunks: list[str]) -> None:
+        self.task_done = asyncio.Event()
+        self.output_queue: asyncio.Queue = asyncio.Queue()
+        self.state = "IDLE"
+        self._chunks = chunks
+        self.add_message_calls: list[tuple[str, Any, dict]] = []
+        self.run_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def add_message(self, role: str, content: Any, **kwargs) -> None:
+        self.add_message_calls.append((role, content, kwargs))
+
+    async def run(self, *args, **kwargs):
+        self.run_calls.append((args, kwargs))
+        await self.output_queue.put({
+            "tool_calls": [
+                {
+                    "id": "call_search",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": '{"query":"spoon bot"}',
+                    },
+                }
+            ],
+        })
+        for chunk in self._chunks:
+            await self.output_queue.put({"type": "content", "delta": chunk})
+            await asyncio.sleep(0)
+        return type("RunResult", (), {"content": "".join(self._chunks)})()
+
+
+class _InterleavedToolContentRuntimeAgent:
+    """Runtime agent that emits progress text between tool calls."""
+
+    def __init__(self, content_segments: list[str]) -> None:
+        self.task_done = asyncio.Event()
+        self.output_queue: asyncio.Queue = asyncio.Queue()
+        self.state = "IDLE"
+        self._content_segments = content_segments
+        self.add_message_calls: list[tuple[str, Any, dict]] = []
+        self.run_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def add_message(self, role: str, content: Any, **kwargs) -> None:
+        self.add_message_calls.append((role, content, kwargs))
+
+    async def run(self, *args, **kwargs):
+        self.run_calls.append((args, kwargs))
+        for index, segment in enumerate(self._content_segments):
+            await self.output_queue.put({
+                "tool_calls": [
+                    {
+                        "id": f"call_{index}",
+                        "type": "function",
+                        "function": {
+                            "name": "shell",
+                            "arguments": f'{{"command":"step {index}"}}',
+                        },
+                    }
+                ],
+            })
+            await self.output_queue.put({"type": "content", "delta": segment})
+            await asyncio.sleep(0)
+        return type("RunResult", (), {"content": "".join(self._content_segments)})()
+
+
+class _SkillSummaryThenContentRuntimeAgent:
+    """Runtime agent that emits terminal skill evidence followed by final text."""
+
+    def __init__(self, final_summary: str) -> None:
+        self.task_done = asyncio.Event()
+        self.output_queue: asyncio.Queue = asyncio.Queue()
+        self.state = "IDLE"
+        self._final_summary = final_summary
+        self.add_message_calls: list[tuple[str, Any, dict]] = []
+        self.run_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def add_message(self, role: str, content: Any, **kwargs) -> None:
+        self.add_message_calls.append((role, content, kwargs))
+
+    async def run(self, *args, **kwargs):
+        self.run_calls.append((args, kwargs))
+        command = "python -c 'print(\"done\")'"
+        await self.output_queue.put({
+            "tool_calls": [
+                {
+                    "id": "call_task",
+                    "type": "function",
+                    "function": {
+                        "name": "shell",
+                        "arguments": json.dumps({"command": command}),
+                    },
+                }
+            ],
+        })
+        await self.output_queue.put({
+            "type": "tool_result",
+            "name": "shell",
+            "delta": (
+                "Read it aloud: TASK_RESULT task=318 status=CONFIRMED"
+            ),
+            "metadata": {
+                "name": "shell",
+                "arguments": json.dumps({"command": command}),
+            },
+        })
+        await self.output_queue.put({"type": "content", "delta": self._final_summary})
+        await asyncio.sleep(0)
+        return type("RunResult", (), {"content": self._final_summary})()
 
 
 class _RetryRuntimeAgent:
@@ -1208,6 +1321,187 @@ class TestAgentLoopStreamFallback:
         assert loop._session.messages[-1]["content"] == "Hello"
 
     @pytest.mark.asyncio
+    async def test_stream_preserves_post_tool_content_chunks(self, tmp_dir: Path):
+        from spoon_bot.agent.loop import AgentLoop
+
+        answer_chunks = ["Final answer ", "visible over websocket."]
+        loop = AgentLoop.__new__(AgentLoop)
+        loop._initialized = True
+        loop._agent = _ToolThenChunkedRuntimeAgent(answer_chunks)
+        loop.workspace = tmp_dir
+        loop._session = Session(session_key="stream_post_tool_content")
+        loop.sessions = MagicMock()
+        loop.sessions.save = MagicMock()
+        loop.memory = MagicMock()
+        loop.memory.get_memory_context = MagicMock(return_value=None)
+        loop.context = MagicMock()
+        loop._prepare_request_context = AsyncMock(return_value=None)
+        loop._build_step_prompt = lambda message: f"prompt::{message}"
+        loop._install_anti_loop_tracker = lambda prompt: None
+        loop._evaluate_task_completion_verdict = AsyncMock(
+            return_value={"status": "complete", "reason": "", "next_focus": ""}
+        )
+
+        chunks = []
+        async for chunk in AgentLoop.stream(loop, message="search then answer"):
+            chunks.append(chunk)
+
+        content_chunks = [c for c in chunks if c["type"] == "content"]
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+        tool_call_index = next(i for i, c in enumerate(chunks) if c["type"] == "tool_call")
+        first_content_index = next(i for i, c in enumerate(chunks) if c["type"] == "content")
+        done_index = next(i for i, c in enumerate(chunks) if c["type"] == "done")
+
+        assert [c["delta"] for c in content_chunks] == answer_chunks
+        assert tool_call_index < first_content_index < done_index
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["metadata"]["content"] == "".join(answer_chunks)
+        assert loop._session.messages[-1]["content"] == "".join(answer_chunks)
+
+    @pytest.mark.asyncio
+    async def test_stream_done_uses_only_latest_post_tool_content_segment(self, tmp_dir: Path):
+        from spoon_bot.agent.loop import AgentLoop
+
+        segments = [
+            "Checking current status.",
+            "Status is healthy; continuing task.",
+            "No follow-up action is currently available.",
+        ]
+        loop = AgentLoop.__new__(AgentLoop)
+        loop._initialized = True
+        loop._agent = _InterleavedToolContentRuntimeAgent(segments)
+        loop.workspace = tmp_dir
+        loop._session = Session(session_key="stream_post_tool_final_segment")
+        loop.sessions = MagicMock()
+        loop.sessions.save = MagicMock()
+        loop.memory = MagicMock()
+        loop.memory.get_memory_context = MagicMock(return_value=None)
+        loop.context = MagicMock()
+        loop._prepare_request_context = AsyncMock(return_value=None)
+        loop._build_step_prompt = lambda message: f"prompt::{message}"
+        loop._install_anti_loop_tracker = lambda prompt: None
+        loop._evaluate_task_completion_verdict = AsyncMock(
+            return_value={"status": "complete", "reason": "", "next_focus": ""}
+        )
+
+        chunks = []
+        async for chunk in AgentLoop.stream(loop, message="run the task"):
+            chunks.append(chunk)
+
+        content_chunks = [c for c in chunks if c["type"] == "content"]
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+
+        assert [c["delta"] for c in content_chunks] == segments
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["metadata"]["content"] == segments[-1]
+        assert loop._session.messages[-1]["content"] == segments[-1]
+
+    @pytest.mark.asyncio
+    async def test_stream_trims_repeated_progress_prefix_from_final_content(self, tmp_dir: Path):
+        from spoon_bot.agent.loop import AgentLoop
+
+        first_progress = "好的，开始处理这个请求，并先检查当前状态。"
+        second_progress = "前置检查完成，继续执行下一步。"
+        final_answer = "目前没有可执行的后续任务。所有必要检查都已经完成。"
+        repeated_final_chunk = (
+            "好的，开始处理这个请求，并先检查当前状态。 "
+            "前置检查完成，继续执行下一步。 "
+            + final_answer
+        )
+        loop = AgentLoop.__new__(AgentLoop)
+        loop._initialized = True
+        loop._agent = _InterleavedToolContentRuntimeAgent([
+            first_progress,
+            second_progress,
+            repeated_final_chunk,
+        ])
+        loop.workspace = tmp_dir
+        loop._session = Session(session_key="stream_post_tool_repeated_final")
+        loop.sessions = MagicMock()
+        loop.sessions.save = MagicMock()
+        loop.memory = MagicMock()
+        loop.memory.get_memory_context = MagicMock(return_value=None)
+        loop.context = MagicMock()
+        loop._prepare_request_context = AsyncMock(return_value=None)
+        loop._build_step_prompt = lambda message: f"prompt::{message}"
+        loop._install_anti_loop_tracker = lambda prompt: None
+        loop._evaluate_task_completion_verdict = AsyncMock(
+            return_value={"status": "complete", "reason": "", "next_focus": ""}
+        )
+
+        chunks = []
+        async for chunk in AgentLoop.stream(loop, message="执行这个任务"):
+            chunks.append(chunk)
+
+        content_chunks = [c for c in chunks if c["type"] == "content"]
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+
+        assert [c["delta"] for c in content_chunks] == [
+            first_progress,
+            second_progress,
+            final_answer,
+        ]
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["metadata"]["content"] == final_answer
+        assert loop._session.messages[-1]["content"] == final_answer
+
+    @pytest.mark.asyncio
+    async def test_stream_does_not_resummarize_after_terminal_skill_content(
+        self,
+        tmp_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from spoon_bot.agent.loop import AgentLoop
+
+        final_summary = (
+            "任务 318 已结束！来看看结果：\n\n"
+            "| 项目 | 详情 |\n"
+            "|---|---|\n"
+            "| **执行项** | check |\n"
+            "| **结果** | 已确认 |"
+        )
+        synthesized_duplicate = (
+            "这次任务已经完成，以下是结果：编号 318，"
+            "最终状态为已确认。"
+        )
+        synthesize = AsyncMock(return_value=synthesized_duplicate)
+        monkeypatch.setattr(
+            AgentLoop,
+            "_synthesize_final_answer_from_tool_events",
+            synthesize,
+        )
+
+        loop = AgentLoop.__new__(AgentLoop)
+        loop._initialized = True
+        loop._agent = _SkillSummaryThenContentRuntimeAgent(final_summary)
+        loop.workspace = tmp_dir
+        loop._session = Session(session_key="stream_terminal_skill_summary")
+        loop.sessions = MagicMock()
+        loop.sessions.save = MagicMock()
+        loop.memory = MagicMock()
+        loop.memory.get_memory_context = MagicMock(return_value=None)
+        loop.context = MagicMock()
+        loop._prepare_request_context = AsyncMock(return_value=None)
+        loop._build_step_prompt = lambda message: f"prompt::{message}"
+        loop._install_anti_loop_tracker = lambda prompt: None
+        loop._evaluate_task_completion_verdict = AsyncMock(
+            return_value={"status": "complete", "reason": "", "next_focus": ""}
+        )
+
+        chunks = []
+        async for chunk in AgentLoop.stream(loop, message="执行这个任务"):
+            chunks.append(chunk)
+
+        content_chunks = [c for c in chunks if c["type"] == "content"]
+        done_chunks = [c for c in chunks if c["type"] == "done"]
+
+        assert [c["delta"] for c in content_chunks] == [final_summary]
+        synthesize.assert_not_called()
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["metadata"]["content"] == final_summary
+        assert loop._session.messages[-1]["content"] == final_summary
+
+    @pytest.mark.asyncio
     async def test_stream_persists_original_user_text_instead_of_attachment_prose(self, tmp_dir: Path):
         from spoon_bot.agent.loop import AgentLoop, _ensure_attachment_context
 
@@ -1288,21 +1582,21 @@ class TestAgentLoopStreamFallback:
         loop._install_anti_loop_tracker = lambda prompt: None
 
         chunks = []
-        async for chunk in AgentLoop.stream(loop, message="run the joker-game-agent challenge"):
+        async for chunk in AgentLoop.stream(loop, message="run the task challenge"):
             chunks.append(chunk)
 
         assert any(chunk["type"] == "error" for chunk in chunks)
         roles = [message["role"] for message in loop._session.messages]
         assert roles == ["user", "assistant", "tool", "assistant"]
         assert loop._session.messages[0]["turn_state"] == "interrupted"
-        assert loop._session.messages[1]["tool_calls"][0]["id"] == "call_joker"
-        assert "joker-game-agent" in loop._session.messages[2]["content"]
+        assert loop._session.messages[1]["tool_calls"][0]["id"] == "call_task"
+        assert "task_runner.py" in loop._session.messages[2]["content"]
         assert loop._session.messages[3]["incomplete"] is True
 
-        recall = AgentLoop._build_session_recall_context(loop, "joker-game-agent 这个呀")
+        recall = AgentLoop._build_session_recall_context(loop, "继续刚才那个任务")
 
         assert "Current Session Compact" in recall
-        assert "joker-game-agent" in recall
+        assert "task_runner.py" in recall
         assert "Previous request did not complete" in recall
 
 

--- a/tests/test_workspace_wallet_visibility.py
+++ b/tests/test_workspace_wallet_visibility.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from spoon_bot.agent.tools.shell import ShellTool
+from spoon_bot.gateway.api.v1.workspace import _build_tree
+from spoon_bot.gateway.websocket.workspace_fs import WorkspaceFSService
+from spoon_bot.gateway.websocket.workspace_watch import WorkspaceWatchService
+
+
+def _make_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "state.env").write_text("APP_DIR=/old\n", encoding="utf-8")
+
+
+def test_workspace_tree_hides_wallet_runtime_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "src").mkdir()
+    (workspace / ".env").write_text("VISIBLE=true\n", encoding="utf-8")
+    _make_dir(workspace / ".agent-wallet")
+    _make_dir(workspace / ".home-.agent-wallet" / ".agent-wallet")
+    _make_dir(workspace / "runtime-wallet")
+    _make_dir(workspace / ".home-runtime-wallet" / ".agent-wallet")
+    monkeypatch.setenv("SPOON_BOT_WALLET_PATH", str(workspace / "runtime-wallet"))
+
+    nodes = _build_tree(
+        workspace,
+        include_hidden=True,
+        workspace_root=workspace,
+    )
+
+    names = {node.name for node in nodes}
+    assert {"src", ".env"} <= names
+    assert ".agent-wallet" not in names
+    assert ".home-.agent-wallet" not in names
+    assert "runtime-wallet" not in names
+    assert ".home-runtime-wallet" not in names
+
+
+@pytest.mark.asyncio
+async def test_workspace_fs_list_hides_wallet_runtime_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "notes.txt").write_text("ok", encoding="utf-8")
+    (workspace / ".env").write_text("VISIBLE=true\n", encoding="utf-8")
+    _make_dir(workspace / ".agent-wallet")
+    _make_dir(workspace / ".home-.agent-wallet" / ".agent-wallet")
+    _make_dir(workspace / "runtime-wallet")
+    monkeypatch.setenv("SPOON_BOT_WALLET_PATH", str(workspace / "runtime-wallet"))
+
+    service = WorkspaceFSService(workspace)
+    listing = await service.list("/workspace")
+
+    names = {entry["name"] for entry in listing["entries"]}
+    assert {"notes.txt", ".env"} <= names
+    assert ".agent-wallet" not in names
+    assert ".home-.agent-wallet" not in names
+    assert "runtime-wallet" not in names
+
+    hidden_listing = await service.list("/workspace/.home-.agent-wallet")
+    assert hidden_listing == {"entries": [], "has_more": False}
+
+
+def test_workspace_watch_snapshot_hides_wallet_runtime_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "visible.txt").write_text("ok", encoding="utf-8")
+    _make_dir(workspace / ".agent-wallet")
+    _make_dir(workspace / ".home-.agent-wallet" / ".agent-wallet")
+    _make_dir(workspace / "runtime-wallet")
+    monkeypatch.setenv("SPOON_BOT_WALLET_PATH", str(workspace / "runtime-wallet"))
+
+    async def emit_change(_: dict[str, object]) -> None:
+        return None
+
+    service = WorkspaceWatchService(workspace, emit_change)
+    snapshot = service._snapshot_target(workspace, recursive=True)
+
+    assert "/workspace/visible.txt" in snapshot
+    assert not any("agent-wallet" in path for path in snapshot)
+    assert not any("runtime-wallet" in path for path in snapshot)
+
+
+def test_shell_wallet_compat_home_stays_outside_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    wallet = workspace / ".agent-wallet"
+    _make_dir(wallet)
+    runtime_home_root = tmp_path / "runtime-home"
+    monkeypatch.setenv("SPOON_BOT_WALLET_COMPAT_HOME_ROOT", str(runtime_home_root))
+
+    env: dict[str, str] = {}
+    tool = ShellTool(working_dir=str(workspace))
+    tool._align_wallet_home_for_command(
+        env,
+        "cat ~/.agent-wallet/state.env",
+        str(workspace),
+    )
+
+    compat_home = Path(env["HOME"])
+    assert runtime_home_root in compat_home.parents
+    assert workspace not in compat_home.parents
+    assert env["SPOON_BOT_WALLET_PATH"] == str(compat_home / ".agent-wallet")
+    assert env["AGENT_WALLET_DIR"] == str(compat_home / ".agent-wallet")
+    assert not (workspace / ".home-.agent-wallet").exists()


### PR DESCRIPTION
## Summary
- stream visible post-tool content chunks instead of holding them until finalization
- preserve short initial content chunks in original chunk order
- avoid duplicate final content emission when finalization does not change text
- keep interleaved tool-progress text out of the final `done.metadata.content` so the final answer does not repeat earlier progress text
- trim repeated progress prefixes from later content chunks when the model itself restates already-streamed progress

## Tests
- uv run --extra dev --extra gateway pytest tests/test_session_persistence.py::TestAgentLoopStreamFallback::test_stream_preserves_post_tool_content_chunks tests/test_session_persistence.py::TestAgentLoopStreamFallback::test_stream_done_uses_only_latest_post_tool_content_segment tests/test_session_persistence.py::TestAgentLoopStreamFallback::test_stream_trims_repeated_progress_prefix_from_final_content tests/test_gateway_ws_bugs.py::TestWSStreamingContent -q
- git diff --check